### PR TITLE
NativeAOT support

### DIFF
--- a/src/Sendspin.SDK/Audio/Codecs/OpusDecoder.cs
+++ b/src/Sendspin.SDK/Audio/Codecs/OpusDecoder.cs
@@ -38,7 +38,7 @@ public sealed class OpusDecoder : IAudioDecoder
         Format = format;
 
         // Create Concentus decoder using the factory (preferred over deprecated constructor)
-        _decoder = OpusCodecFactory.CreateDecoder(format.SampleRate, format.Channels);
+        _decoder = new Concentus.Structs.OpusDecoder(format.SampleRate, format.Channels);
 
         // Opus max frame is 120ms, but typically 20ms (960 samples at 48kHz per channel)
         // Allocate for worst case: 120ms * sampleRate / 1000 * channels

--- a/src/Sendspin.SDK/Protocol/MessageSerializerContext.cs
+++ b/src/Sendspin.SDK/Protocol/MessageSerializerContext.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sendspin.SDK.Protocol.Messages;
+
+namespace Sendspin.SDK.Protocol;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    Converters = new[] { typeof(SnakeCaseEnumConverter), typeof(OptionalJsonConverterFactory) })]
+[JsonSerializable(typeof(ClientHelloMessage))]
+[JsonSerializable(typeof(ClientGoodbyeMessage))]
+[JsonSerializable(typeof(ClientTimeMessage))]
+[JsonSerializable(typeof(ClientCommandMessage))]
+[JsonSerializable(typeof(ClientStateMessage))]
+[JsonSerializable(typeof(ClientSyncOffsetMessage))]
+[JsonSerializable(typeof(ClientSyncOffsetAckMessage))]
+[JsonSerializable(typeof(StreamRequestFormatMessage))]
+[JsonSerializable(typeof(ServerHelloMessage))]
+[JsonSerializable(typeof(ServerTimeMessage))]
+[JsonSerializable(typeof(StreamStartMessage))]
+[JsonSerializable(typeof(StreamEndMessage))]
+[JsonSerializable(typeof(StreamClearMessage))]
+[JsonSerializable(typeof(GroupUpdateMessage))]
+[JsonSerializable(typeof(ServerCommandMessage))]
+[JsonSerializable(typeof(ServerStateMessage))]
+internal partial class MessageSerializerContext : JsonSerializerContext
+{
+}
+
+internal sealed class SnakeCaseEnumConverter : JsonStringEnumConverter
+{
+    public SnakeCaseEnumConverter()
+        : base(JsonNamingPolicy.SnakeCaseLower)
+    {
+    }
+}

--- a/src/Sendspin.SDK/Protocol/OptionalJsonConverter.cs
+++ b/src/Sendspin.SDK/Protocol/OptionalJsonConverter.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Sendspin.SDK.Protocol;
 
@@ -55,7 +56,9 @@ internal sealed class OptionalJsonConverter<T> : JsonConverter<Optional<T>>
         }
 
         // Field is present with a value
-        var value = JsonSerializer.Deserialize<T>(ref reader, options);
+        // Use JsonTypeInfo to avoid RequiresUnreferencedCode warning (AOT-friendly)
+        var typeInfo = (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
+        var value = JsonSerializer.Deserialize(ref reader, typeInfo);
         return Optional<T>.Present(value);
     }
 

--- a/src/Sendspin.SDK/PublishTrimming.xml
+++ b/src/Sendspin.SDK/PublishTrimming.xml
@@ -1,0 +1,23 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <!-- Preserve all of Concentus (Opus decoder library) -->
+    <Assembly Name="Concentus" Dynamic="Required All" />
+    
+    <!-- Preserve Sendspin.SDK types that might be accessed dynamically -->
+    <Assembly Name="Sendspin.SDK" Dynamic="Required All" />
+    
+    <!-- Preserve Concentus factory and decoder types explicitly -->
+    <Type Name="Concentus.OpusCodecFactory" Dynamic="Required All" />
+    <Type Name="Concentus.Structs.OpusDecoder" Dynamic="Required All" />
+    <Type Name="Concentus.IOpusDecoder" Dynamic="Required All" />
+    
+    <!-- Preserve audio codec types -->
+    <Type Name="Sendspin.SDK.Audio.Codecs.OpusDecoder" Dynamic="Required All" />
+    <Type Name="Sendspin.SDK.Audio.Codecs.FlacDecoder" Dynamic="Required All" />
+    <Type Name="Sendspin.SDK.Audio.Codecs.PcmDecoder" Dynamic="Required All" />
+    
+    <!-- Preserve protocol message types for JSON serialization -->
+    <Namespace Name="Sendspin.SDK.Protocol.Messages" Dynamic="Required All" />
+    <Namespace Name="Sendspin.SDK.Models" Dynamic="Required All" />
+  </Application>
+</Directives>

--- a/src/Sendspin.SDK/Sendspin.SDK.csproj
+++ b/src/Sendspin.SDK/Sendspin.SDK.csproj
@@ -554,7 +554,7 @@ New Features:
 - Default convergence timeout reduced from 5000ms to 1000ms
 
 Migration Guide:
-- If you implement IClockSynchronizer, add: bool HasMinimalSync => MeasurementCount >= 2;
+- If you implement IClockSynchronizer, add: bool HasMinimalSync =&gt; MeasurementCount &gt;= 2;
 - If you only use KalmanClockSynchronizer (most users), no changes needed
 
 v2.2.1:
@@ -620,9 +620,31 @@ New Features:
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+    <IsTrimmable>True</IsTrimmable>
+    <IsAotCompatible>True</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0|AnyCPU'">
+    <IsTrimmable>True</IsTrimmable>
+    <IsAotCompatible>True</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+    <IsTrimmable>True</IsTrimmable>
+    <IsAotCompatible>True</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0|AnyCPU'">
+    <IsTrimmable>True</IsTrimmable>
+    <IsAotCompatible>True</IsAotCompatible>
+    <TrimMode>partial</TrimMode>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Core dependencies - all cross-platform -->
-    <PackageReference Include="Fleck" Version="1.2.0" />
     <PackageReference Include="Concentus" Version="2.2.2" />
     <PackageReference Include="Zeroconf" Version="3.7.16" />
     <PackageReference Include="Makaretu.Dns.Multicast" Version="0.27.0" />
@@ -633,6 +655,16 @@ New Features:
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    
+    <!-- Add trimming descriptor for AOT support -->
+    <TrimmerRootDescriptor Include="PublishTrimming.xml" />
+    
+    <!-- Preserve these assemblies completely (prevent trimming) -->
+    <TrimmerRootAssembly Include="Concentus" />
+    <TrimmerRootAssembly Include="Sendspin.SDK" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Fleck\src\Fleck\Fleck.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently sendspin client does a few things that prevent use in NativeAOT published apps. I'm not currently at the point where I've got audio out working once AOT compiled.

I would like to emphasis that this is not a big deal, and is just something I've been tinkering with. AOT is cool, but its not the be-all-end-all.


## 1. System.Text.Json dynamic things. This is a pain in the butt but overall minor

Manually adding JsonSerializable attribute to a JsonSerializerContext fixes the majority of it.
ie 
```csharp
[JsonSerializable(typeof(ClientStateMessage))]  
[JsonSerializable(typeof(ClientSyncOffsetMessage))]  
[JsonSerializable(typeof(ClientSyncOffsetAckMessage))]  
[JsonSerializable(typeof(StreamRequestFormatMessage))]
```

## 2. Use of Fleck
The project uses Fleck which isn't compatible with AOT. With Flecks last code push 5 years ago, and so many outstanding PRs, I think its abandoned so unlikely to be updated. The good news it just needs minimal modification
*`net8.0` as a target 
* `<IsAotCompatible>true</IsAotCompatible><IsTrimmable>true</IsTrimmable>` in the csproj
* `return !OperatingSystem.IsWindows();` on ln10 of FleckRuntime.cs

changes at https://github.com/thewoodknight/Fleck/tree/upgrade-to-NET10

## 3. Trimming
I'm unsure whether the correct package trimming values would solve all of these problems and not need any code changes at all.

The following what I needed to get audio to the "playback" stage - that is, not complaining about libraries missing, along with the changes above. Audio still doesn't work, but it stopped complaining that the libraries were missing.

These go in the published client executable project (WateryTart.Platform.Windows for me)

```xml
  <ItemGroup>
    <TrimmerRootDescriptor Include="PublishTrimming.xml" />
    <TrimmerRootAssembly Include="Concentus" />
    <TrimmerRootAssembly Include="Sendspin.SDK" />
  </ItemGroup>
```

```xml
<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
  <Application>
    <!-- Preserve all of Concentus (Opus decoder library) -->
    <Assembly Name="Concentus" Dynamic="Required All" />
    
    <!-- Preserve Sendspin.SDK types that might be accessed dynamically -->
    <Assembly Name="Sendspin.SDK" Dynamic="Required All" />
    
    <!-- Preserve Concentus factory and decoder types explicitly -->
    <Type Name="Concentus.OpusCodecFactory" Dynamic="Required All" />
    <Type Name="Concentus.Structs.OpusDecoder" Dynamic="Required All" />
    <Type Name="Concentus.IOpusDecoder" Dynamic="Required All" />
    
    <!-- Preserve audio codec types -->
    <Type Name="Sendspin.SDK.Audio.Codecs.OpusDecoder" Dynamic="Required All" />
    <Type Name="Sendspin.SDK.Audio.Codecs.FlacDecoder" Dynamic="Required All" />
    <Type Name="Sendspin.SDK.Audio.Codecs.PcmDecoder" Dynamic="Required All" />
    
    <!-- Preserve protocol message types for JSON serialization -->
    <Namespace Name="Sendspin.SDK.Protocol.Messages" Dynamic="Required All" />
    <Namespace Name="Sendspin.SDK.Models" Dynamic="Required All" />
  </Application>
</Directives>
```

## 4. NAudio
Elephant in the room, NAudio.**Wasapi** and its COM interop which seems to be problematic.
There isn't [explicit support, but it does seem possible](https://github.com/naudio/NAudio/discussions/1103). Claude suggested using WinRT, or P/Invoke directly (the latter seems like a bad time to me).

NAudio.DirectSound doesn't work on AOT either ```_wasapiOut = (NAudio.CoreAudioApi.AudioClientShareMode.Shared, latency: 50);``` becomes
```_wasapiOut = new NAudio.Wave.DirectSoundOut();``` + the type change, but that was all that was needed without AOT though.