### PR TITLE
fix: enable touch scrolling on settings and welcome pages

### DIFF
--- a/src/SendspinClient/Resources/Styles/Controls.xaml
+++ b/src/SendspinClient/Resources/Styles/Controls.xaml
@@ -354,6 +354,7 @@
     <!-- Dark ScrollViewer Style -->
     <Style x:Key="DarkScrollViewer" TargetType="ScrollViewer">
         <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="PanningMode" Value="VerticalOnly"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ScrollViewer">


### PR DESCRIPTION
## Summary

Adds `PanningMode="VerticalOnly"` to the `DarkScrollViewer` style, enabling touch scrolling on the settings page and welcome/server list view.

WPF `ScrollViewer` defaults to `PanningMode="None"`, which silently ignores touch input. This one-line fix enables inertial touch panning with native Windows physics.

Closes #3

## Test plan
- [x] Touch scroll settings page on a touchscreen display
- [x] Touch scroll welcome/server list view
- [x] Verify mouse wheel scrolling still works
- [x] Verify Remote Desktop touch input works (Android RDP client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)