### PR TITLE
feat: aiosendspin protocol compliance

### DIFF
--- a/src/Sendspin.SDK/Client/ISendSpinClient.cs
+++ b/src/Sendspin.SDK/Client/ISendSpinClient.cs
@@ -75,7 +75,8 @@ public interface ISendspinClient : IAsyncDisposable
     /// </summary>
     /// <param name="volume">Current volume level (0-100).</param>
     /// <param name="muted">Current mute state.</param>
-    Task SendPlayerStateAsync(int volume, bool muted);
+    /// <param name="staticDelayMs">Static delay in milliseconds for group sync calibration.</param>
+    Task SendPlayerStateAsync(int volume, bool muted, double staticDelayMs = 0.0);
 
     /// <summary>
     /// Clears the audio buffer, causing the pipeline to restart buffering.
@@ -106,6 +107,12 @@ public interface ISendspinClient : IAsyncDisposable
     /// Event raised when artwork is received.
     /// </summary>
     event EventHandler<byte[]>? ArtworkReceived;
+
+    /// <summary>
+    /// Event raised when artwork is cleared (empty artwork binary message).
+    /// The server sends an empty payload to signal "no artwork available".
+    /// </summary>
+    event EventHandler? ArtworkCleared;
 
     /// <summary>
     /// Event raised when the clock synchronizer first converges to a stable estimate.

--- a/src/Sendspin.SDK/Client/SendSpinClient.cs
+++ b/src/Sendspin.SDK/Client/SendSpinClient.cs
@@ -83,6 +83,7 @@ public sealed class SendspinClientService : ISendspinClient
     public event EventHandler<GroupState>? GroupStateChanged;
     public event EventHandler<PlayerState>? PlayerStateChanged;
     public event EventHandler<byte[]>? ArtworkReceived;
+    public event EventHandler? ArtworkCleared;
     public event EventHandler<ClockSyncStatus>? ClockSyncConverged;
     public event EventHandler<SyncOffsetEventArgs>? SyncOffsetApplied;
 
@@ -288,12 +289,13 @@ public sealed class SendspinClientService : ISendspinClient
     }
 
     /// <inheritdoc/>
-    public async Task SendPlayerStateAsync(int volume, bool muted)
+    public async Task SendPlayerStateAsync(int volume, bool muted, double staticDelayMs = 0.0)
     {
         var clampedVolume = Math.Clamp(volume, 0, 100);
-        var stateMessage = ClientStateMessage.CreateSynchronized(clampedVolume, muted);
+        var stateMessage = ClientStateMessage.CreateSynchronized(clampedVolume, muted, staticDelayMs);
 
-        _logger.LogDebug("Sending player state: Volume={Volume}, Muted={Muted}", clampedVolume, muted);
+        _logger.LogDebug("Sending player state: Volume={Volume}, Muted={Muted}, StaticDelay={StaticDelay}ms",
+            clampedVolume, muted, staticDelayMs);
         await _connection.SendMessageAsync(stateMessage);
     }
 
@@ -443,7 +445,8 @@ public sealed class SendspinClientService : ISendspinClient
             // Send the current player state (initialized from capabilities)
             var stateMessage = ClientStateMessage.CreateSynchronized(
                 volume: _playerState.Volume,
-                muted: _playerState.Muted);
+                muted: _playerState.Muted,
+                staticDelayMs: _clockSynchronizer.StaticDelayMs);
             var stateJson = MessageSerializer.Serialize(stateMessage);
             _logger.LogInformation("Sending initial client/state:\n{Json}", stateJson);
             await _connection.SendMessageAsync(stateMessage);
@@ -849,7 +852,7 @@ public sealed class SendspinClientService : ISendspinClient
     /// </summary>
     private async Task SendPlayerStateAckAsync()
     {
-        await SendPlayerStateAsync(_playerState.Volume, _playerState.Muted);
+        await SendPlayerStateAsync(_playerState.Volume, _playerState.Muted, _clockSynchronizer.StaticDelayMs);
     }
 
     /// <summary>
@@ -1030,8 +1033,16 @@ public sealed class SendspinClientService : ISendspinClient
                 var artwork = BinaryMessageParser.ParseArtworkChunk(data.Span);
                 if (artwork is not null)
                 {
-                    _logger.LogDebug("Artwork received: {Length} bytes", artwork.ImageData.Length);
-                    ArtworkReceived?.Invoke(this, artwork.ImageData);
+                    if (artwork.ImageData.Length == 0)
+                    {
+                        _logger.LogDebug("Artwork cleared (empty payload)");
+                        ArtworkCleared?.Invoke(this, EventArgs.Empty);
+                    }
+                    else
+                    {
+                        _logger.LogDebug("Artwork received: {Length} bytes", artwork.ImageData.Length);
+                        ArtworkReceived?.Invoke(this, artwork.ImageData);
+                    }
                 }
                 break;
 

--- a/src/Sendspin.SDK/Client/SendSpinHostService.cs
+++ b/src/Sendspin.SDK/Client/SendSpinHostService.cs
@@ -94,6 +94,11 @@ public sealed class SendspinHostService : IAsyncDisposable
     public event EventHandler<byte[]>? ArtworkReceived;
 
     /// <summary>
+    /// Raised when artwork is cleared (empty artwork binary message from server).
+    /// </summary>
+    public event EventHandler? ArtworkCleared;
+
+    /// <summary>
     /// Raised when the last-played server ID changes.
     /// Consumers should persist this value so it survives app restarts.
     /// </summary>
@@ -308,6 +313,7 @@ public sealed class SendspinHostService : IAsyncDisposable
             };
             client.PlayerStateChanged += (s, p) => PlayerStateChanged?.Invoke(this, p);
             client.ArtworkReceived += (s, data) => ArtworkReceived?.Invoke(this, data);
+            client.ArtworkCleared += (s, e) => ArtworkCleared?.Invoke(this, EventArgs.Empty);
 
             // Start the connection (begins receive loop)
             await connection.StartAsync();
@@ -669,7 +675,11 @@ public sealed class SendspinHostService : IAsyncDisposable
     /// <summary>
     /// Sends the current player state (volume, muted) to a specific server or all connected servers.
     /// </summary>
-    public async Task SendPlayerStateAsync(int volume, bool muted, string? serverId = null)
+    /// <param name="volume">Current volume level (0-100).</param>
+    /// <param name="muted">Current mute state.</param>
+    /// <param name="staticDelayMs">Static delay in milliseconds for group sync calibration.</param>
+    /// <param name="serverId">Target server ID, or null for all servers.</param>
+    public async Task SendPlayerStateAsync(int volume, bool muted, double staticDelayMs = 0.0, string? serverId = null)
     {
         List<SendspinClientService> clients;
         lock (_connectionsLock)
@@ -693,7 +703,7 @@ public sealed class SendspinHostService : IAsyncDisposable
 
         foreach (var client in clients)
         {
-            await client.SendPlayerStateAsync(volume, muted);
+            await client.SendPlayerStateAsync(volume, muted, staticDelayMs);
         }
     }
 

--- a/src/Sendspin.SDK/Protocol/Messages/ClientStateMessage.cs
+++ b/src/Sendspin.SDK/Protocol/Messages/ClientStateMessage.cs
@@ -19,7 +19,10 @@ public sealed class ClientStateMessage : IMessageWithPayload<ClientStatePayload>
     /// Creates a synchronized state message with player volume/mute.
     /// This should be sent immediately after receiving server/hello.
     /// </summary>
-    public static ClientStateMessage CreateSynchronized(int volume = 100, bool muted = false)
+    /// <param name="volume">Player volume (0-100).</param>
+    /// <param name="muted">Whether the player is muted.</param>
+    /// <param name="staticDelayMs">Static delay in milliseconds for group sync calibration.</param>
+    public static ClientStateMessage CreateSynchronized(int volume = 100, bool muted = false, double staticDelayMs = 0.0)
     {
         return new ClientStateMessage
         {
@@ -29,7 +32,8 @@ public sealed class ClientStateMessage : IMessageWithPayload<ClientStatePayload>
                 Player = new PlayerStatePayload
                 {
                     Volume = volume,
-                    Muted = muted
+                    Muted = muted,
+                    StaticDelayMs = staticDelayMs
                 }
             }
         };
@@ -115,4 +119,13 @@ public sealed class PlayerStatePayload
     [JsonPropertyName("error")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Error { get; init; }
+
+    /// <summary>
+    /// Static delay in milliseconds configured for this player.
+    /// Used by the server during GroupSync calibration to compensate for
+    /// device audio output latency across the group.
+    /// </summary>
+    [JsonPropertyName("static_delay_ms")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public double StaticDelayMs { get; init; }
 }

--- a/src/Sendspin.SDK/Sendspin.SDK.csproj
+++ b/src/Sendspin.SDK/Sendspin.SDK.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>Sendspin.SDK</PackageId>
-    <Version>7.0.0</Version>
+    <Version>7.1.0</Version>
     <Authors>Sendspin Contributors</Authors>
     <Company>Sendspin</Company>
     <Product>Sendspin SDK</Product>
@@ -20,6 +20,21 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+v7.1.0 - Protocol Compliance (aiosendspin audit):
+
+New Features:
+- PlayerStatePayload.StaticDelayMs: Reports configured static delay to server
+  for GroupSync calibration. Server uses this to compensate for device output
+  latency when calculating group-wide sync offsets.
+- ISendspinClient.ArtworkCleared event: Raised when server sends empty artwork
+  binary payload (type 8-11, 0-byte data) to signal "no artwork available".
+  Previously, empty payloads were passed through as empty byte arrays.
+- SendPlayerStateAsync now accepts optional staticDelayMs parameter (default 0.0)
+- SendspinHostService.ArtworkCleared event: Forwarded from child clients
+
+Bug Fixes:
+- Empty artwork binary messages no longer treated as valid image data
+
 v7.0.0 - NativeAOT Support:
 
 BREAKING CHANGES:

--- a/src/SendspinClient/Configuration/AudioFormatBuilder.cs
+++ b/src/SendspinClient/Configuration/AudioFormatBuilder.cs
@@ -32,10 +32,11 @@ public static class AudioFormatBuilder
         var formats = new List<AudioFormat>();
         var sampleRate = capabilities.NativeSampleRate;
 
-        // WASAPI MixFormat reports 32 for 32-bit float (Windows Audio Engine internal format).
-        // Cap at 24-bit since that's the max standard hi-res PCM bit depth.
-        // When WASAPI reports 32-bit, the device can handle any format via Windows resampling.
-        var bitDepth = Math.Min(capabilities.NativeBitDepth, 24);
+        // Use the device's native bit depth as-is. WASAPI MixFormat reports 32 for devices
+        // using 32-bit float internally, but the server sends 32-bit signed integer PCM.
+        // This works because NAudio's WasapiOut handles the conversion internally, and the
+        // SDK's PcmDecoder already reads 32-bit via ReadInt32LittleEndian.
+        var bitDepth = capabilities.NativeBitDepth;
 
         // Preferred codec first at native resolution
         if (preferredCodec == "flac")

--- a/src/SendspinClient/SendspinClient.csproj
+++ b/src/SendspinClient/SendspinClient.csproj
@@ -10,7 +10,7 @@
     <ApplicationIcon>Resources\Icons\sendspinTray.ico</ApplicationIcon>
 
     <!-- Version info - set via -p:Version= during CI builds -->
-    <Version>1.11.0</Version>
+    <Version>1.12.0</Version>
     <!--
       AssemblyVersion/FileVersion must be purely numeric (major.minor.build.revision).
       For prerelease versions like "0.0.0-dev.xxx", we need separate numeric versions.

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -468,6 +468,7 @@ public partial class MainViewModel : ViewModelBase
         _hostService.GroupStateChanged += OnGroupStateChanged;
         _hostService.PlayerStateChanged += OnPlayerStateChanged;
         _hostService.ArtworkReceived += OnArtworkReceived;
+        _hostService.ArtworkCleared += OnArtworkCleared;
         _hostService.LastPlayedServerIdChanged += OnLastPlayedServerIdChanged;
 
         // Subscribe to server discovery events (client-initiated mode - primary)
@@ -691,17 +692,19 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private async Task SendPlayerStateToActiveClientAsync(int volume, bool muted)
     {
+        var staticDelay = SettingsStaticDelayMs;
+
         // Prefer manual client (discovery/manual connection mode)
         if (_manualClient?.ConnectionState == ConnectionState.Connected)
         {
             _logger.LogDebug("Sending player state via manual client: Volume={Volume}, Muted={Muted}", volume, muted);
-            await _manualClient.SendPlayerStateAsync(volume, muted);
+            await _manualClient.SendPlayerStateAsync(volume, muted, staticDelay);
         }
         // Fall back to host service (server-initiated connection mode)
         else if (ConnectedServers.Count > 0)
         {
             _logger.LogDebug("Sending player state via host service: Volume={Volume}, Muted={Muted}", volume, muted);
-            await _hostService.SendPlayerStateAsync(volume, muted);
+            await _hostService.SendPlayerStateAsync(volume, muted, staticDelay);
         }
         else
         {
@@ -729,6 +732,7 @@ public partial class MainViewModel : ViewModelBase
         _manualClient.GroupStateChanged += OnManualClientGroupStateChanged;
         _manualClient.PlayerStateChanged += OnManualClientPlayerStateChanged;
         _manualClient.ArtworkReceived += OnManualClientArtworkReceived;
+        _manualClient.ArtworkCleared += OnArtworkCleared;
     }
 
     /// <summary>
@@ -852,6 +856,7 @@ public partial class MainViewModel : ViewModelBase
             _manualClient.GroupStateChanged -= OnManualClientGroupStateChanged;
             _manualClient.PlayerStateChanged -= OnManualClientPlayerStateChanged;
             _manualClient.ArtworkReceived -= OnManualClientArtworkReceived;
+            _manualClient.ArtworkCleared -= OnArtworkCleared;
 
             try
             {
@@ -1194,6 +1199,15 @@ public partial class MainViewModel : ViewModelBase
         {
             AlbumArtwork = imageData;
             _logger.LogDebug("Artwork received: {Length} bytes", imageData.Length);
+        });
+    }
+
+    private void OnArtworkCleared(object? sender, EventArgs e)
+    {
+        App.Current.Dispatcher.Invoke(() =>
+        {
+            AlbumArtwork = null;
+            _logger.LogDebug("Artwork cleared (no artwork available)");
         });
     }
 


### PR DESCRIPTION
## Summary
- **Send `static_delay_ms` in `client/state` messages** — Server uses this for GroupSync calibration to compensate for device audio output latency across the group
- **Clear artwork on empty binary payload** — Server sends empty artwork message (type 8-11, 0-byte data) to signal "no artwork"; previously showed stale artwork
- **Advertise 32-bit PCM in supported formats** — Remove 24-bit cap so WASAPI devices report native 32-bit depth; SDK's PcmDecoder and NAudio already handle it
- **SDK version bumped to 7.1.0** (minor, backward-compatible additions)
- **App version bumped to 1.12.0**

Matches protocol gaps identified in SendspinDroid PR #44 audit against aiosendspin server source.

## Test plan
- [ ] Connect to a server, verify `static_delay_ms` appears in client/state JSON in server logs
- [ ] Play a track with artwork, switch to one without — album art should clear to placeholder
- [ ] Check client hello logs for 32-bit bit depth in supported_formats (device-dependent)
- [ ] Verify build succeeds with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)