### PR TITLE
feat: protocol compliance, sync improvements, and FLAC fixes

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -349,7 +349,7 @@ Settings are stored in two locations:
 
 ### Audio Buffer Configuration
 - `Buffer.TargetMs`: Target buffer depth before starting playback (default: 250ms)
-- `Buffer.CapacityMs`: Maximum buffer capacity (default: 8000ms)
+- `Buffer.CapacityMs`: Maximum buffer capacity (default: 30000ms / 30s — sized to absorb server's initial burst)
 
 ### Clock Sync Configuration
 - `ClockSync.WaitForConvergence`: Wait for Kalman filter to converge before playback (default: true)

--- a/src/Sendspin.SDK/Audio/AudioDecoderFactory.cs
+++ b/src/Sendspin.SDK/Audio/AudioDecoderFactory.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Sendspin.SDK.Audio.Codecs;
 using Sendspin.SDK.Models;
 
@@ -12,6 +14,17 @@ namespace Sendspin.SDK.Audio;
 /// </summary>
 public sealed class AudioDecoderFactory : IAudioDecoderFactory
 {
+    private readonly ILoggerFactory _loggerFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioDecoderFactory"/> class.
+    /// </summary>
+    /// <param name="loggerFactory">Optional logger factory for decoder diagnostics.</param>
+    public AudioDecoderFactory(ILoggerFactory? loggerFactory = null)
+    {
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+    }
+
     /// <inheritdoc/>
     public IAudioDecoder Create(AudioFormat format)
     {
@@ -21,7 +34,7 @@ public sealed class AudioDecoderFactory : IAudioDecoderFactory
         {
             AudioCodecs.Opus => new OpusDecoder(format),
             AudioCodecs.Pcm => new PcmDecoder(format),
-            AudioCodecs.Flac => new FlacDecoder(format),
+            AudioCodecs.Flac => new FlacDecoder(format, _loggerFactory.CreateLogger<FlacDecoder>()),
             _ => throw new NotSupportedException($"Unsupported audio codec: {format.Codec}"),
         };
     }

--- a/src/Sendspin.SDK/Audio/AudioPipeline.cs
+++ b/src/Sendspin.SDK/Audio/AudioPipeline.cs
@@ -273,6 +273,14 @@ public sealed class AudioPipeline : IAudioPipeline
     }
 
     /// <inheritdoc/>
+    public void NotifyReconnect()
+    {
+        _buffer?.NotifyReconnect();
+        _player?.NotifyReconnect();
+        _logger.LogInformation("[Correction] Pipeline notified of reconnect, stabilization period active");
+    }
+
+    /// <inheritdoc/>
     public void Clear(long? newTargetTimestamp = null)
     {
         _buffer?.Clear();

--- a/src/Sendspin.SDK/Audio/Codecs/FlacDecoder.cs
+++ b/src/Sendspin.SDK/Audio/Codecs/FlacDecoder.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Sendspin.SDK.Audio.Codecs.ThirdParty;
 using Sendspin.SDK.Models;
 
@@ -38,35 +40,51 @@ public sealed class FlacDecoder : IAudioDecoder
     /// </summary>
     private const int HeaderSize = 42;
 
-    private readonly byte[] _syntheticHeader;
-    private readonly float _sampleScaleFactor;
+    private readonly ILogger _logger;
+    private readonly byte[] _header;
+    private float _sampleScaleFactor;
+    private bool _scaleFactorCalibrated;
     private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FlacDecoder"/> class.
     /// </summary>
     /// <param name="format">Audio format configuration.</param>
+    /// <param name="logger">Optional logger for diagnostic output.</param>
     /// <exception cref="ArgumentException">Thrown when format is not FLAC.</exception>
-    public FlacDecoder(AudioFormat format)
+    public FlacDecoder(AudioFormat format, ILogger<FlacDecoder>? logger = null)
     {
         if (!string.Equals(format.Codec, AudioCodecs.Flac, StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException($"Expected FLAC format, got {format.Codec}", nameof(format));
         }
 
+        _logger = logger ?? NullLogger<FlacDecoder>.Instance;
         Format = format;
         var bitsPerSample = format.BitDepth ?? 16;
 
         // Calculate scale factor for converting to float [-1.0, 1.0]
-        _sampleScaleFactor = 1.0f / (1 << (bitsPerSample - 1));
+        // Use 1L to avoid integer overflow at 32-bit (1 << 31 overflows int, but not long)
+        _sampleScaleFactor = 1.0f / (1L << (bitsPerSample - 1));
 
         // FLAC typically uses 4096 sample blocks, but can go up to 65535
         // We use 8192 as a reasonable max for streaming
         const int maxBlockSize = 8192;
         MaxSamplesPerFrame = maxBlockSize * format.Channels;
 
-        // Build synthetic FLAC header once
-        _syntheticHeader = BuildSyntheticHeader(format, maxBlockSize);
+        // Use server-provided codec_header (real STREAMINFO) when available,
+        // fall back to synthetic header otherwise
+        if (format.CodecHeader is { } codecHeaderBase64)
+        {
+            _header = Convert.FromBase64String(codecHeaderBase64);
+            _logger.LogDebug("FLAC decoder using server codec_header ({Bytes} bytes, {BitDepth}-bit)",
+                _header.Length, bitsPerSample);
+        }
+        else
+        {
+            _header = BuildSyntheticHeader(format, maxBlockSize);
+            _logger.LogDebug("FLAC decoder using synthetic header ({BitDepth}-bit)", bitsPerSample);
+        }
     }
 
     /// <inheritdoc/>
@@ -85,10 +103,10 @@ public sealed class FlacDecoder : IAudioDecoder
             return 0;
         }
 
-        // Create a stream containing synthetic header + FLAC frame data
-        var streamData = new byte[_syntheticHeader.Length + encodedData.Length];
-        _syntheticHeader.CopyTo(streamData, 0);
-        encodedData.CopyTo(streamData.AsSpan(_syntheticHeader.Length));
+        // Create a stream containing header + FLAC frame data
+        var streamData = new byte[_header.Length + encodedData.Length];
+        _header.CopyTo(streamData, 0);
+        encodedData.CopyTo(streamData.AsSpan(_header.Length));
 
         using var stream = new MemoryStream(streamData, writable: false);
 
@@ -101,6 +119,23 @@ public sealed class FlacDecoder : IAudioDecoder
         try
         {
             using var flacDecoder = new ThirdParty.FlacDecoder(stream, options);
+
+            // Calibrate scale factor from actual FLAC STREAMINFO bit depth.
+            // The stream/start message may report a different bit depth (e.g., 32 from PyAV's s32
+            // container) than the actual FLAC encoding (e.g., 24-bit precision).
+            if (!_scaleFactorCalibrated)
+            {
+                var actualBits = flacDecoder.BitsPerSample;
+                _sampleScaleFactor = 1.0f / (1L << (actualBits - 1));
+                _scaleFactorCalibrated = true;
+
+                if (actualBits != (Format.BitDepth ?? 16))
+                {
+                    _logger.LogWarning(
+                        "FLAC actual bit depth ({ActualBits}) differs from stream/start ({ReportedBits}), using actual",
+                        actualBits, Format.BitDepth ?? 16);
+                }
+            }
 
             // Decode frame(s)
             int totalSamplesWritten = 0;
@@ -128,10 +163,10 @@ public sealed class FlacDecoder : IAudioDecoder
 
             return totalSamplesWritten;
         }
-        catch (InvalidDataException)
+        catch (Exception ex) when (ex is InvalidDataException or NotSupportedException)
         {
-            // Frame decode error - return 0 samples
-            // This can happen with corrupted network data
+            _logger.LogWarning(ex, "FLAC frame decode failed ({BitDepth}-bit, {DataLen} bytes encoded)",
+                Format.BitDepth ?? 16, encodedData.Length);
             return 0;
         }
     }

--- a/src/Sendspin.SDK/Audio/Codecs/FlacDecoder.cs
+++ b/src/Sendspin.SDK/Audio/Codecs/FlacDecoder.cs
@@ -134,6 +134,7 @@ public sealed class FlacDecoder : IAudioDecoder
                     _logger.LogWarning(
                         "FLAC actual bit depth ({ActualBits}) differs from stream/start ({ReportedBits}), using actual",
                         actualBits, Format.BitDepth ?? 16);
+                    Format.BitDepth = actualBits;
                 }
             }
 

--- a/src/Sendspin.SDK/Audio/IAudioPipeline.cs
+++ b/src/Sendspin.SDK/Audio/IAudioPipeline.cs
@@ -84,6 +84,17 @@ public interface IAudioPipeline : IAsyncDisposable
     Task StopAsync();
 
     /// <summary>
+    /// Notifies the pipeline that a WebSocket reconnect occurred.
+    /// Suppresses sync corrections during the reconnect stabilization period.
+    /// </summary>
+    /// <remarks>
+    /// Call this after the clock synchronizer is reset on reconnect. The buffer
+    /// and player correction systems will suppress corrections until the Kalman
+    /// filter has had time to re-converge (~2 seconds by default).
+    /// </remarks>
+    void NotifyReconnect();
+
+    /// <summary>
     /// Clears the buffer (for seek).
     /// Called when stream/clear is received.
     /// </summary>

--- a/src/Sendspin.SDK/Audio/IAudioPlayer.cs
+++ b/src/Sendspin.SDK/Audio/IAudioPlayer.cs
@@ -94,6 +94,16 @@ public interface IAudioPlayer : IAsyncDisposable
     long? GetAudioClockMicroseconds() => null;
 
     /// <summary>
+    /// Notifies the player that a WebSocket reconnect occurred.
+    /// Implementations should forward this to their sync correction provider.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation is a no-op. Override in platform-specific players
+    /// that use <see cref="ISyncCorrectionProvider"/> for external sync correction.
+    /// </remarks>
+    void NotifyReconnect() { }
+
+    /// <summary>
     /// Initializes the audio output with the specified format.
     /// </summary>
     /// <param name="format">Audio format to use.</param>

--- a/src/Sendspin.SDK/Audio/ISyncCorrectionProvider.cs
+++ b/src/Sendspin.SDK/Audio/ISyncCorrectionProvider.cs
@@ -97,4 +97,20 @@ public interface ISyncCorrectionProvider
     /// stale correction decisions from affecting new playback.
     /// </remarks>
     void Reset();
+
+    /// <summary>
+    /// Notifies the provider that a WebSocket reconnect occurred.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// After a reconnect, the clock synchronizer is reset and needs time to re-converge.
+    /// During this stabilization period, sync error measurements are unreliable.
+    /// Implementations should suppress corrections until the stabilization period elapses.
+    /// </para>
+    /// <para>
+    /// The stabilization duration is configured via
+    /// <see cref="SyncCorrectionOptions.ReconnectStabilizationMicroseconds"/>.
+    /// </para>
+    /// </remarks>
+    void NotifyReconnect() { }
 }

--- a/src/Sendspin.SDK/Audio/ITimedAudioBuffer.cs
+++ b/src/Sendspin.SDK/Audio/ITimedAudioBuffer.cs
@@ -195,6 +195,23 @@ public interface ITimedAudioBuffer : IDisposable
     void NotifyExternalCorrection(int samplesDropped, int samplesInserted);
 
     /// <summary>
+    /// Notifies the buffer that a WebSocket reconnect occurred.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// After reconnect, the clock synchronizer is reset and sync error measurements
+    /// become unreliable. This method resets the smoothed sync error (EMA) and
+    /// suppresses internal sync corrections during the reconnect stabilization period
+    /// configured in <see cref="SyncCorrectionOptions.ReconnectStabilizationMicroseconds"/>.
+    /// </para>
+    /// <para>
+    /// The re-anchor threshold is NOT suppressed — catastrophic drift (&gt;500ms)
+    /// is still handled even during stabilization.
+    /// </para>
+    /// </remarks>
+    void NotifyReconnect();
+
+    /// <summary>
     /// Clears all buffered audio (for seek/stream clear).
     /// </summary>
     void Clear();

--- a/src/Sendspin.SDK/Audio/SyncCorrectionCalculator.cs
+++ b/src/Sendspin.SDK/Audio/SyncCorrectionCalculator.cs
@@ -45,6 +45,10 @@ public sealed class SyncCorrectionCalculator : ISyncCorrectionProvider
     private long _totalSamplesProcessed;
     private bool _inStartupGracePeriod = true;
 
+    // Reconnect stabilization tracking (separate from startup grace to avoid interference)
+    private bool _inReconnectStabilization;
+    private long _reconnectSamplesProcessed;
+
     /// <inheritdoc/>
     public SyncCorrectionMode CurrentMode
     {
@@ -134,6 +138,47 @@ public sealed class SyncCorrectionCalculator : ISyncCorrectionProvider
             _targetPlaybackRate = 1.0;
             _totalSamplesProcessed = 0;
             _inStartupGracePeriod = true;
+            _inReconnectStabilization = false;
+            _reconnectSamplesProcessed = 0;
+        }
+
+        if (changed)
+        {
+            CorrectionChanged?.Invoke(this);
+        }
+    }
+
+    /// <summary>
+    /// Notifies the provider that a WebSocket reconnect occurred.
+    /// Suppresses corrections during the reconnect stabilization period.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// After reconnect, the Kalman clock synchronizer is reset and needs ~2 seconds
+    /// to re-converge. During this window, sync error measurements are unreliable.
+    /// This method sets a stabilization flag that causes <see cref="UpdateFromSyncError"/>
+    /// to return neutral corrections until the period elapses.
+    /// </para>
+    /// <para>
+    /// Multiple rapid reconnects restart the stabilization window each time.
+    /// </para>
+    /// </remarks>
+    public void NotifyReconnect()
+    {
+        bool changed;
+        lock (_lock)
+        {
+            changed = _currentMode != SyncCorrectionMode.None
+                || _dropEveryNFrames != 0
+                || _insertEveryNFrames != 0
+                || Math.Abs(_targetPlaybackRate - 1.0) > 0.0001;
+
+            _inReconnectStabilization = true;
+            _reconnectSamplesProcessed = 0;
+            _currentMode = SyncCorrectionMode.None;
+            _dropEveryNFrames = 0;
+            _insertEveryNFrames = 0;
+            _targetPlaybackRate = 1.0;
         }
 
         if (changed)
@@ -144,7 +189,7 @@ public sealed class SyncCorrectionCalculator : ISyncCorrectionProvider
 
     /// <summary>
     /// Notifies the calculator that samples were processed.
-    /// Call this after applying corrections to track startup grace period.
+    /// Call this after applying corrections to track startup grace period and reconnect stabilization.
     /// </summary>
     /// <param name="samplesProcessed">Number of samples processed.</param>
     public void NotifySamplesProcessed(int samplesProcessed)
@@ -161,6 +206,18 @@ public sealed class SyncCorrectionCalculator : ISyncCorrectionProvider
                 if (elapsedMicroseconds >= _options.StartupGracePeriodMicroseconds)
                 {
                     _inStartupGracePeriod = false;
+                }
+            }
+
+            // Check if we've exited the reconnect stabilization period
+            if (_inReconnectStabilization)
+            {
+                _reconnectSamplesProcessed += samplesProcessed;
+                var microsecondsPerSample = 1_000_000.0 / (_sampleRate * _channels);
+                var elapsedMicroseconds = (long)(_reconnectSamplesProcessed * microsecondsPerSample);
+                if (elapsedMicroseconds >= _options.ReconnectStabilizationMicroseconds)
+                {
+                    _inReconnectStabilization = false;
                 }
             }
         }
@@ -180,6 +237,17 @@ public sealed class SyncCorrectionCalculator : ISyncCorrectionProvider
 
         // During startup grace period, don't apply corrections
         if (_inStartupGracePeriod)
+        {
+            _currentMode = SyncCorrectionMode.None;
+            _targetPlaybackRate = 1.0;
+            _dropEveryNFrames = 0;
+            _insertEveryNFrames = 0;
+            return HasChanged(previousMode, previousDrop, previousInsert, previousRate);
+        }
+
+        // During reconnect stabilization, don't apply corrections
+        // (Kalman filter is re-converging, sync error measurements are unreliable)
+        if (_inReconnectStabilization)
         {
             _currentMode = SyncCorrectionMode.None;
             _targetPlaybackRate = 1.0;

--- a/src/Sendspin.SDK/Audio/SyncCorrectionOptions.cs
+++ b/src/Sendspin.SDK/Audio/SyncCorrectionOptions.cs
@@ -135,6 +135,23 @@ public sealed class SyncCorrectionOptions
     public long ReanchorThresholdMicroseconds { get; set; } = 500_000;
 
     /// <summary>
+    /// Gets or sets the minimum time between re-anchors (microseconds).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Prevents rapid repeated re-anchors when the clock synchronizer has persistent error
+    /// (e.g., during reconnect re-convergence or network instability). Without a cooldown,
+    /// re-anchors can trigger every ~750ms (500ms grace + 250ms rebuffer), causing audio stuttering.
+    /// </para>
+    /// <para>
+    /// This value matches the Android client's <c>REANCHOR_COOLDOWN_US</c> and the Python CLI's
+    /// <c>_REANCHOR_COOLDOWN_US</c>.
+    /// Default: 5000000 (5 seconds).
+    /// </para>
+    /// </remarks>
+    public long ReanchorCooldownMicroseconds { get; set; } = 5_000_000;
+
+    /// <summary>
     /// Gets or sets the startup grace period (microseconds).
     /// </summary>
     /// <remarks>
@@ -259,6 +276,13 @@ public sealed class SyncCorrectionOptions
                 nameof(ReanchorThresholdMicroseconds));
         }
 
+        if (ReanchorCooldownMicroseconds < 0)
+        {
+            throw new ArgumentException(
+                "ReanchorCooldownMicroseconds must be non-negative.",
+                nameof(ReanchorCooldownMicroseconds));
+        }
+
         if (StartupGracePeriodMicroseconds < 0)
         {
             throw new ArgumentException(
@@ -293,6 +317,7 @@ public sealed class SyncCorrectionOptions
         CorrectionTargetSeconds = CorrectionTargetSeconds,
         ResamplingThresholdMicroseconds = ResamplingThresholdMicroseconds,
         ReanchorThresholdMicroseconds = ReanchorThresholdMicroseconds,
+        ReanchorCooldownMicroseconds = ReanchorCooldownMicroseconds,
         StartupGracePeriodMicroseconds = StartupGracePeriodMicroseconds,
         ScheduledStartGraceWindowMicroseconds = ScheduledStartGraceWindowMicroseconds,
         ReconnectStabilizationMicroseconds = ReconnectStabilizationMicroseconds,

--- a/src/Sendspin.SDK/Audio/SyncCorrectionOptions.cs
+++ b/src/Sendspin.SDK/Audio/SyncCorrectionOptions.cs
@@ -146,6 +146,27 @@ public sealed class SyncCorrectionOptions
     public long StartupGracePeriodMicroseconds { get; set; } = 500_000;
 
     /// <summary>
+    /// Gets or sets the reconnect stabilization period (microseconds).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// After a WebSocket reconnect, the clock synchronizer is reset and needs time to
+    /// re-converge. During this window, sync error measurements are unreliable because
+    /// they are based on a freshly-reset Kalman filter with high uncertainty.
+    /// </para>
+    /// <para>
+    /// Without suppression, the sync correction system reacts to these inaccurate
+    /// measurements, causing erratic drop/insert or resampling corrections that produce
+    /// audible artifacts.
+    /// </para>
+    /// <para>
+    /// This value matches the Android client's <c>RECONNECT_STABILIZATION_US</c>.
+    /// Default: 2000000 (2 seconds).
+    /// </para>
+    /// </remarks>
+    public long ReconnectStabilizationMicroseconds { get; set; } = 2_000_000;
+
+    /// <summary>
     /// Gets or sets the grace window for scheduled start (microseconds).
     /// </summary>
     /// <remarks>
@@ -251,6 +272,13 @@ public sealed class SyncCorrectionOptions
                 "ScheduledStartGraceWindowMicroseconds must be non-negative.",
                 nameof(ScheduledStartGraceWindowMicroseconds));
         }
+
+        if (ReconnectStabilizationMicroseconds < 0)
+        {
+            throw new ArgumentException(
+                "ReconnectStabilizationMicroseconds must be non-negative.",
+                nameof(ReconnectStabilizationMicroseconds));
+        }
     }
 
     /// <summary>
@@ -267,6 +295,7 @@ public sealed class SyncCorrectionOptions
         ReanchorThresholdMicroseconds = ReanchorThresholdMicroseconds,
         StartupGracePeriodMicroseconds = StartupGracePeriodMicroseconds,
         ScheduledStartGraceWindowMicroseconds = ScheduledStartGraceWindowMicroseconds,
+        ReconnectStabilizationMicroseconds = ReconnectStabilizationMicroseconds,
         BypassDeadband = BypassDeadband,
     };
 

--- a/src/Sendspin.SDK/Audio/TimedAudioBuffer.cs
+++ b/src/Sendspin.SDK/Audio/TimedAudioBuffer.cs
@@ -102,6 +102,10 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
     // At ~10ms audio callbacks, this is ~100ms to stabilize after a change.
     private const double SyncErrorSmoothingAlpha = 0.1;
 
+    // Reconnect stabilization: suppress corrections while Kalman filter re-converges
+    private bool _inReconnectStabilization;
+    private long _reconnectStabilizationStartOutput;
+
     private bool _disposed;
 
     /// <inheritdoc/>
@@ -584,6 +588,30 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
     }
 
     /// <inheritdoc/>
+    public void NotifyReconnect()
+    {
+        lock (_lock)
+        {
+            // Reset EMA to prevent stale pre-disconnect values from polluting correction decisions
+            // At α=0.1, the EMA takes ~100ms to reach 63% of a step change — without resetting,
+            // old values would linger even after the stabilization period ends
+            _smoothedSyncErrorMicroseconds = 0;
+
+            _inReconnectStabilization = true;
+            _reconnectStabilizationStartOutput = _samplesOutputSinceStart;
+
+            // Reset internal correction state to neutral
+            _dropEveryNFrames = 0;
+            _insertEveryNFrames = 0;
+            _framesSinceLastCorrection = 0;
+            SetTargetPlaybackRate(1.0);
+
+            _logger.LogInformation("[Correction] Reconnect stabilization started (suppressing corrections for {DurationMs}ms)",
+                _syncOptions.ReconnectStabilizationMicroseconds / 1000);
+        }
+    }
+
+    /// <inheritdoc/>
     public void Clear()
     {
         lock (_lock)
@@ -617,6 +645,9 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
             _lastOutputFrame = null;
             TargetPlaybackRate = 1.0;
             // Note: Don't reset _samplesDroppedForSync/_samplesInsertedForSync - these are cumulative stats
+
+            // Reset reconnect stabilization state
+            _inReconnectStabilization = false;
 
             // Reset correction mode transition tracking (avoids stale logging after clear)
             _previousCorrectionMode = SyncCorrectionMode.None;
@@ -947,6 +978,25 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
             _dropEveryNFrames = 0;
             _insertEveryNFrames = 0;
             return;
+        }
+
+        // Skip correction during reconnect stabilization (Kalman filter re-converging)
+        if (_inReconnectStabilization)
+        {
+            var samplesSinceReconnect = _samplesOutputSinceStart - _reconnectStabilizationStartOutput;
+            var elapsedSinceReconnect = (long)(samplesSinceReconnect * _microsecondsPerSample);
+            if (elapsedSinceReconnect >= _syncOptions.ReconnectStabilizationMicroseconds)
+            {
+                _inReconnectStabilization = false;
+                _logger.LogInformation("[Correction] Reconnect stabilization ended, resuming corrections");
+            }
+            else
+            {
+                SetTargetPlaybackRate(1.0);
+                _dropEveryNFrames = 0;
+                _insertEveryNFrames = 0;
+                return;
+            }
         }
 
         // Use smoothed error for correction decisions (filters measurement jitter)

--- a/src/Sendspin.SDK/Audio/TimedAudioBuffer.cs
+++ b/src/Sendspin.SDK/Audio/TimedAudioBuffer.cs
@@ -194,7 +194,7 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
     /// </summary>
     /// <param name="format">Audio format for samples.</param>
     /// <param name="clockSync">Clock synchronizer for timestamp conversion.</param>
-    /// <param name="bufferCapacityMs">Maximum buffer capacity in milliseconds (default 500ms).</param>
+    /// <param name="bufferCapacityMs">Maximum buffer capacity in milliseconds. Should be large enough to absorb the server's initial burst (typically 30s).</param>
     /// <param name="syncOptions">Optional sync correction options. Uses <see cref="SyncCorrectionOptions.Default"/> if not provided.</param>
     /// <param name="logger">Optional logger for diagnostics (uses NullLogger if not provided).</param>
     public TimedAudioBuffer(

--- a/src/Sendspin.SDK/Audio/TimedAudioBuffer.cs
+++ b/src/Sendspin.SDK/Audio/TimedAudioBuffer.cs
@@ -62,6 +62,8 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
     private long _samplesDroppedForSync;  // Total samples dropped for sync correction
     private long _samplesInsertedForSync; // Total samples inserted for sync correction
     private bool _needsReanchor;          // Flag to trigger re-anchoring
+    private long _lastReanchorTimeMicroseconds; // Local time of last reanchor (persists across Clear)
+    private long _lastReanchorCooldownLogTime;  // Rate-limit cooldown suppression logging
     private int _reanchorEventPending;    // 0 = not pending, 1 = pending (for thread-safe event coalescing)
     private float[]? _lastOutputFrame;    // Last output frame for smooth drop/insert (Python CLI approach)
 
@@ -403,7 +405,18 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
                 if (elapsedSinceStart >= _syncOptions.StartupGracePeriodMicroseconds
                     && Math.Abs(_currentSyncErrorMicroseconds) > _syncOptions.ReanchorThresholdMicroseconds)
                 {
-                    _needsReanchor = true;
+                    if (currentLocalTime - _lastReanchorTimeMicroseconds >= _syncOptions.ReanchorCooldownMicroseconds)
+                    {
+                        _lastReanchorTimeMicroseconds = currentLocalTime;
+                        _needsReanchor = true;
+                    }
+                    else if (currentLocalTime - _lastReanchorCooldownLogTime >= UnderrunLogIntervalMicroseconds)
+                    {
+                        _lastReanchorCooldownLogTime = currentLocalTime;
+                        _logger.LogWarning(
+                            "[Correction] Reanchor suppressed by cooldown ({CooldownMs}ms remaining)",
+                            (_syncOptions.ReanchorCooldownMicroseconds - (currentLocalTime - _lastReanchorTimeMicroseconds)) / 1000);
+                    }
                 }
             }
 
@@ -521,7 +534,18 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
                 if (elapsedSinceStart >= _syncOptions.StartupGracePeriodMicroseconds
                     && Math.Abs(_currentSyncErrorMicroseconds) > _syncOptions.ReanchorThresholdMicroseconds)
                 {
-                    _needsReanchor = true;
+                    if (currentLocalTime - _lastReanchorTimeMicroseconds >= _syncOptions.ReanchorCooldownMicroseconds)
+                    {
+                        _lastReanchorTimeMicroseconds = currentLocalTime;
+                        _needsReanchor = true;
+                    }
+                    else if (currentLocalTime - _lastReanchorCooldownLogTime >= UnderrunLogIntervalMicroseconds)
+                    {
+                        _lastReanchorCooldownLogTime = currentLocalTime;
+                        _logger.LogWarning(
+                            "[Correction] Reanchor suppressed by cooldown ({CooldownMs}ms remaining)",
+                            (_syncOptions.ReanchorCooldownMicroseconds - (currentLocalTime - _lastReanchorTimeMicroseconds)) / 1000);
+                    }
                 }
             }
 
@@ -645,6 +669,8 @@ public sealed class TimedAudioBuffer : ITimedAudioBuffer
             _lastOutputFrame = null;
             TargetPlaybackRate = 1.0;
             // Note: Don't reset _samplesDroppedForSync/_samplesInsertedForSync - these are cumulative stats
+            // Note: Don't reset _lastReanchorTimeMicroseconds - reanchor itself calls Clear(),
+            // so resetting the cooldown here would defeat its purpose (matches Android/Python CLI)
 
             // Reset reconnect stabilization state
             _inReconnectStabilization = false;

--- a/src/Sendspin.SDK/Client/SendSpinClient.cs
+++ b/src/Sendspin.SDK/Client/SendSpinClient.cs
@@ -910,6 +910,13 @@ public sealed class SendspinClientService : ISendspinClient
             return;
         }
 
+        // stream/start with no "player" key is artwork-only — skip pipeline start
+        if (message.Format is null)
+        {
+            _logger.LogDebug("Stream start is artwork-only (no player key), skipping pipeline start");
+            return;
+        }
+
         _logger.LogInformation("Stream starting: {Format}", message.Format);
 
         // Clear any stale chunks from previous streams

--- a/src/Sendspin.SDK/Client/SendSpinClient.cs
+++ b/src/Sendspin.SDK/Client/SendSpinClient.cs
@@ -423,6 +423,12 @@ public sealed class SendspinClientService : ISendspinClient
         // Reset clock synchronizer for new connection
         _clockSynchronizer.Reset();
 
+        // Notify audio pipeline of reconnect to suppress sync corrections
+        // while the Kalman filter re-converges (~2 seconds).
+        // Safe to call even on initial connection: _audioPipeline is null before first stream/start,
+        // and NotifyReconnect on null buffer/player is a no-op.
+        _audioPipeline?.NotifyReconnect();
+
         // Send initial client state (required by protocol after server/hello)
         // This tells the server we're synchronized and ready
         SendInitialClientStateAsync().SafeFireAndForget(_logger);

--- a/src/Sendspin.SDK/Protocol/Messages/StreamStartMessage.cs
+++ b/src/Sendspin.SDK/Protocol/Messages/StreamStartMessage.cs
@@ -23,7 +23,7 @@ public sealed class StreamStartMessage : IMessageWithPayload<StreamStartPayload>
 
     // Convenience accessor
     [JsonIgnore]
-    public AudioFormat Format => Payload.Format;
+    public AudioFormat? Format => Payload.Format;
 }
 
 /// <summary>
@@ -34,7 +34,8 @@ public sealed class StreamStartPayload
     /// <summary>
     /// Gets or sets the audio format for the incoming stream.
     /// The "player" object contains codec, channels, sample_rate, bit_depth, and codec_header.
+    /// Null when the stream/start only carries artwork info (no player key).
     /// </summary>
     [JsonPropertyName("player")]
-    public AudioFormat Format { get; set; } = new();
+    public AudioFormat? Format { get; set; }
 }

--- a/src/Sendspin.SDK/Sendspin.SDK.csproj
+++ b/src/Sendspin.SDK/Sendspin.SDK.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>Sendspin.SDK</PackageId>
-    <Version>7.1.1</Version>
+    <Version>7.2.0</Version>
     <Authors>Sendspin Contributors</Authors>
     <Company>Sendspin</Company>
     <Product>Sendspin SDK</Product>
@@ -20,6 +20,31 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+v7.2.0 - Reconnect Stabilization:
+
+New Features:
+- Reconnect stabilization period: Suppresses sync corrections for 2 seconds after
+  WebSocket reconnect while the Kalman clock synchronizer re-converges. Prevents
+  audible artifacts (erratic drop/insert/resampling) caused by unreliable sync error
+  measurements from a freshly-reset Kalman filter. Matches Android client behavior.
+- SyncCorrectionOptions.ReconnectStabilizationMicroseconds: Configurable duration
+  (default: 2,000,000 = 2 seconds)
+- ISyncCorrectionProvider.NotifyReconnect(): Default interface method for reconnect notification
+- IAudioPlayer.NotifyReconnect(): Default interface method for player reconnect notification
+- IAudioPipeline.NotifyReconnect(): Pipeline-level reconnect notification
+- ITimedAudioBuffer.NotifyReconnect(): Buffer-level reconnect notification
+
+BREAKING (minor):
+- ITimedAudioBuffer: Added NotifyReconnect() method (no default implementation).
+  If you implement ITimedAudioBuffer directly (not using TimedAudioBuffer), add this method.
+  Most consumers are unaffected as TimedAudioBuffer is the only known implementation.
+
+Implementation Notes:
+- Both Read() (deprecated) and ReadRaw() correction paths are covered
+- Re-anchor threshold is NOT suppressed during stabilization (catastrophic drift still handled)
+- EMA smoothed sync error is reset on reconnect to prevent stale values from lingering
+- Multiple rapid reconnects restart the stabilization window each time
+
 v7.1.1 - Documentation:
 - Added NativeAOT support section to README with PublishAot usage and guidance
 - Added v7.0.0 migration guide for SendspinListener.ServerConnected breaking change

--- a/src/SendspinClient.Services/Audio/WasapiAudioPlayer.cs
+++ b/src/SendspinClient.Services/Audio/WasapiAudioPlayer.cs
@@ -181,6 +181,15 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
         _diagnosticRecorder = diagnosticRecorder;
     }
 
+    /// <summary>
+    /// Notifies the player that a WebSocket reconnect occurred.
+    /// Forwards to the sync correction provider to suppress corrections during Kalman re-convergence.
+    /// </summary>
+    public void NotifyReconnect()
+    {
+        _correctionProvider?.NotifyReconnect();
+    }
+
     /// <inheritdoc/>
     public Task InitializeAsync(AudioFormat format, CancellationToken cancellationToken = default)
     {

--- a/src/SendspinClient/App.xaml.cs
+++ b/src/SendspinClient/App.xaml.cs
@@ -284,9 +284,12 @@ public partial class App : Application
             var decoderFactory = sp.GetRequiredService<IAudioDecoderFactory>();
             var clockSync = sp.GetRequiredService<IClockSynchronizer>();
 
-            // Read buffer configuration (matching JS client's faster startup)
+            // Read buffer configuration
+            // Capacity must hold the full server burst without overflowing.
+            // We advertise 32MB BufferCapacity (compressed bytes) — for FLAC with ~4:1
+            // compression, that decodes to 30+ seconds of audio. Default 30s matches this.
             var bufferTargetMs = _configuration!.GetValue<double>("Audio:Buffer:TargetMs", 250);
-            var bufferCapacityMs = _configuration!.GetValue<int>("Audio:Buffer:CapacityMs", 8000);
+            var bufferCapacityMs = _configuration!.GetValue<int>("Audio:Buffer:CapacityMs", 30000);
 
             // Read clock sync wait configuration
             var waitForConvergence = _configuration!.GetValue<bool>("Audio:ClockSync:WaitForConvergence", true);

--- a/src/SendspinClient/appsettings.json
+++ b/src/SendspinClient/appsettings.json
@@ -18,7 +18,7 @@
     "StaticDelayMs": 200,
     "Buffer": {
       "TargetMs": 250,
-      "CapacityMs": 8000
+      "CapacityMs": 30000
     },
     "ClockSync": {
       "ForgetFactor": 1.001,


### PR DESCRIPTION
## Summary
- **Reconnect stabilization**: Suppress sync corrections for 2s after reconnect while Kalman filter re-converges
- **Reanchor cooldown**: 5s minimum between re-anchors, matching Android/Python CLI behavior
- **FLAC 32-bit fix**: Use actual STREAMINFO bit depth instead of stream/start header (fixes silence on 32-bit FLAC)
- **AudioFormat.BitDepth update**: Propagate actual decoded bit depth from FLAC STREAMINFO to audio format
- **Buffer capacity**: Increase from 8s to 30s to prevent overruns on track start
- **Artwork-only stream/start**: Skip pipeline start when stream/start has no player key

## Test plan
- [x] Verify audio plays correctly with FLAC streams (16-bit and 32-bit)
- [x] Test track changes don't cause silence
- [x] Test reconnect behavior — sync should stabilize within ~2s
- [x] Verify no re-anchor loops on track change

🤖 Generated with [Claude Code](https://claude.com/claude-code)