### PR TITLE
fix: drain audio buffer while muted to allow resume after unmute

### DIFF
--- a/src/SendspinClient.Services/Audio/AudioSampleProviderAdapter.cs
+++ b/src/SendspinClient.Services/Audio/AudioSampleProviderAdapter.cs
@@ -69,21 +69,17 @@ internal sealed class AudioSampleProviderAdapter : ISampleProvider
     /// <returns>Number of samples written.</returns>
     public int Read(float[] buffer, int offset, int count)
     {
-        if (IsMuted)
-        {
-            // Fill with silence when muted
-            Array.Fill(buffer, 0f, offset, count);
-            return count;
-        }
-
         var samplesRead = _source.Read(buffer, offset, count);
 
-        // Apply volume if not at full (avoid unnecessary multiply operations)
+        if (IsMuted)
+        {
+            Array.Fill(buffer, 0f, offset, samplesRead);
+            return samplesRead;
+        }
+
         var volume = Volume;
         if (volume < 0.999f)
         {
-            // Power curve for perceived loudness (matches CLI reference implementation)
-            // amplitude = volume^1.5 provides natural-sounding volume control
             var amplitude = (float)Math.Pow(volume, 1.5);
 
             var span = buffer.AsSpan(offset, samplesRead);


### PR DESCRIPTION
## Summary
- The `IsMuted` fast-path in `AudioSampleProviderAdapter.Read` returned silence without calling `_source.Read`, starving the SDK's `TimedAudioBuffer` of consumer pulls. While muted, the buffer filled, sync tracking froze, and on unmute the sync error exceeded the 500ms re-anchor threshold so audio could not resume.
- Fix: always pull from the upstream source, then overwrite with silence if muted. Matches the Python CLI reference (`sendspin/audio.py::_apply_volume`).

## Closes
Closes #25

## Test plan
- [x] Connect to Music Assistant, start playing
- [x] Mute via Music Assistant UI; wait 10-15s; unmute -> audio resumes immediately
- [x] Mute via WindowsSpin tray; wait 10-15s; unmute -> audio resumes immediately
- [x] Volume slider still works smoothly through 0-100%
- [x] Sync error in Stats for Nerds stays small across the mute window