### PR TITLE
fix: read current audio device id when creating each player

### DIFF
--- a/src/SendspinClient/App.xaml.cs
+++ b/src/SendspinClient/App.xaml.cs
@@ -279,7 +279,8 @@ public partial class App : Application
         services.AddTransient<IAudioPlayer>(sp =>
         {
             var logger = sp.GetRequiredService<ILogger<WasapiAudioPlayer>>();
-            return new WasapiAudioPlayer(logger, audioDeviceId, syncStrategy, resamplerType);
+            var currentDeviceId = _configuration!.GetValue<string?>("Audio:DeviceId");
+            return new WasapiAudioPlayer(logger, currentDeviceId, syncStrategy, resamplerType);
         });
 
         // Audio pipeline - orchestrates decoder, buffer, and player


### PR DESCRIPTION
## Summary
- The DI registration for `IAudioPlayer` (`App.xaml.cs`) closure-captured `audioDeviceId` from settings at app startup.
- When playback pauses in Music Assistant, the SDK sends `stream/end` and `AudioPipeline.StopAsync` disposes the player completely (`_player = null`). On resume, `AudioPipeline.StartAsync` calls `_playerFactory()` to create a new player. The factory used the stale closure value, ignoring any device change the user made after startup.
- Fix: read `Audio:DeviceId` from `IConfiguration` each time the factory runs, so the new player picks up the user's most recent selection (the user-settings file is loaded with `reloadOnChange: true`).

## Closes
Closes #24

## Test plan
- [ ] Launch with a non-default device saved → audio plays on that device
- [ ] Mid-playback, switch to "default" then back to a specific device → audio follows
- [ ] Pause via Music Assistant → resume → audio stays on the most recently selected device, not whatever was saved at startup
- [ ] Pause via WindowsSpin tray → resume → same
- [ ] Restart the app → most recent selection persists (no regression in saved-device flow)