### PR TITLE
fix: surface manual-connect errors and accept http:// URLs

### DIFF
--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -275,7 +275,7 @@
                     <Expander Header="Advanced: Connect by URL"
                               Style="{StaticResource CollapsibleSectionStyle}">
                         <StackPanel>
-                            <TextBlock Text="For cross-subnet connections, enter the server URL directly:"
+                            <TextBlock Text="For cross-subnet connections, enter the server URL directly (e.g. ws://10.0.2.8:8927):"
                                        Style="{StaticResource BodyText}"
                                        TextWrapping="Wrap"
                                        Opacity="0.7"

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -715,7 +715,8 @@ public partial class MainViewModel : ViewModelBase
     private void CreateAndConfigureManualClient()
     {
         _manualConnection = new SendspinConnection(
-            _loggerFactory.CreateLogger<SendspinConnection>());
+            _loggerFactory.CreateLogger<SendspinConnection>(),
+            new ConnectionOptions { AutoReconnect = false });
 
         _manualClient = new SendspinClientService(
             _loggerFactory.CreateLogger<SendspinClientService>(),
@@ -757,10 +758,18 @@ public partial class MainViewModel : ViewModelBase
 
         try
         {
-            // Normalize the URL - auto-prepend ws:// if no scheme provided
+            // Normalize the URL - convert http(s):// to ws(s):// or auto-prepend ws://
             var urlToParse = ManualServerUrl.Trim();
-            if (!urlToParse.StartsWith("ws://", StringComparison.OrdinalIgnoreCase) &&
-                !urlToParse.StartsWith("wss://", StringComparison.OrdinalIgnoreCase))
+            if (urlToParse.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            {
+                urlToParse = "ws://" + urlToParse[7..];
+            }
+            else if (urlToParse.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                urlToParse = "wss://" + urlToParse[8..];
+            }
+            else if (!urlToParse.StartsWith("ws://", StringComparison.OrdinalIgnoreCase) &&
+                     !urlToParse.StartsWith("wss://", StringComparison.OrdinalIgnoreCase))
             {
                 urlToParse = "ws://" + urlToParse;
             }
@@ -768,7 +777,7 @@ public partial class MainViewModel : ViewModelBase
             // Parse the URL
             if (!Uri.TryCreate(urlToParse, UriKind.Absolute, out var serverUri))
             {
-                StatusMessage = "Invalid URL format. Example: 10.0.2.8:8927";
+                StatusMessage = "Invalid URL format. Example: ws://10.0.2.8:8927";
                 IsConnecting = false;
                 return;
             }


### PR DESCRIPTION
## Summary
- Manual connect via URL was hanging on "Connecting..." for any input the user tried, even when the URL was correct.
- Root cause #1: `MainViewModel.ConnectToServerAsync` prepended `ws://` to inputs that already started with `http://` or `https://`, producing `ws://http://host:port`. `Uri.TryCreate` parsed that as `host=http, port=80`, so the WebSocket was connecting to a non-existent host.
- Root cause #2: `SendspinConnection` defaults to `AutoReconnect=true` with infinite retries. The first failed connect silently entered a reconnect loop instead of throwing, so the UI's catch block at the call site never fired and no error was shown to the user.

## Changes
- Convert `http://` -> `ws://` and `https://` -> `wss://` instead of blind prepend.
- Pass `ConnectionOptions { AutoReconnect = false }` to the manual `SendspinConnection`. Failures now throw to the UI within the SDK's 10s connect timeout. Higher-level reconnection for auto-discovered servers still works via the existing mDNS discovery loop (`OnManualClientConnectionStateChanged` -> "Will auto-reconnect when server is rediscovered").
- Update the URL hint text and error message to show the canonical `ws://` form.

## Closes
Closes #23

## Test plan
- [ ] Type `1.2.3.4:9999` -> within ~10s see `Connection failed: ...` (not stuck on "Connecting...")
- [ ] Type `http://<MA-host>:<port>` -> connects successfully
- [ ] Type `ws://<MA-host>:<port>` -> still connects (no regression)
- [ ] Auto-discovered connection (mDNS) still works
- [ ] If a manual connection drops mid-session, status shows "Disconnected" promptly (no silent infinite retry)
- [ ] Open the "Advanced: Connect by URL" expander -> hint reads `... (e.g. ws://10.0.2.8:8927)`