### PR TITLE
feat: add Start Minimized to Tray setting

### DIFF
--- a/src/SendspinClient/App.xaml.cs
+++ b/src/SendspinClient/App.xaml.cs
@@ -114,7 +114,10 @@ public partial class App : Application
             // Mark as launched (save immediately to prevent showing again if app crashes)
             _ = SaveFirstLaunchFlagAsync();
         }
-        // else: stays hidden in system tray (normal behavior)
+        else if (!_configuration!.GetValue<bool>("App:StartMinimized", true))
+        {
+            mainWindow.Show();
+        }
 
         // Initialize the view model
         _ = _mainViewModel.InitializeAsync();

--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -599,6 +599,24 @@
                                           VerticalAlignment="Center"/>
                             </Grid>
 
+                            <Grid Margin="0,0,0,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0">
+                                    <TextBlock Text="Start Minimized to Tray" Style="{StaticResource BodyText}"/>
+                                    <TextBlock Text="Keep the window hidden in the system tray on launch (e.g. when starting with Windows)"
+                                               Style="{StaticResource CaptionText}"
+                                               Foreground="{StaticResource TextMutedBrush}"
+                                               Margin="0,2,0,0"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <CheckBox Grid.Column="1"
+                                          IsChecked="{Binding SettingsStartMinimized}"
+                                          VerticalAlignment="Center"/>
+                            </Grid>
+
                             <!-- Player Name -->
                             <StackPanel Margin="0,0,0,16">
                                 <TextBlock Text="Player Name" Style="{StaticResource BodyText}"/>

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -264,6 +264,9 @@ public partial class MainViewModel : ViewModelBase
     [ObservableProperty]
     private bool _settingsShowDiscordPresence;
 
+    [ObservableProperty]
+    private bool _settingsStartMinimized = true;
+
     /// <summary>
     /// Gets or sets the player name shown to servers.
     /// Defaults to the computer name.
@@ -2009,6 +2012,8 @@ public partial class MainViewModel : ViewModelBase
             _discordService.Enable();
         }
 
+        SettingsStartMinimized = _configuration.GetValue<bool>("App:StartMinimized", true);
+
         // Load player name (default to computer name)
         SettingsPlayerName = _configuration.GetValue<string>("Player:Name", Environment.MachineName) ?? Environment.MachineName;
 
@@ -2249,6 +2254,10 @@ public partial class MainViewModel : ViewModelBase
             discordSection["Enabled"] = SettingsShowDiscordPresence;
             root["Discord"] = discordSection;
 
+            var appSection = root["App"]?.AsObject() ?? new JsonObject();
+            appSection["StartMinimized"] = SettingsStartMinimized;
+            root["App"] = appSection;
+
             // Update player section
             var playerSection = root["Player"]?.AsObject() ?? new JsonObject();
             playerSection["Name"] = SettingsPlayerName;
@@ -2273,8 +2282,8 @@ public partial class MainViewModel : ViewModelBase
                 _logger.LogInformation("Player name changed to: {PlayerName}", SettingsPlayerName);
             }
 
-            _logger.LogInformation("Settings saved: LogLevel={LogLevel}, FileLogging={FileLogging}, ConsoleLogging={ConsoleLogging}, StaticDelayMs={StaticDelayMs}, Notifications={Notifications}, Discord={Discord}, PlayerName={PlayerName}, DeviceId={DeviceId}",
-                SettingsLogLevel, SettingsEnableFileLogging, SettingsEnableConsoleLogging, SettingsStaticDelayMs, SettingsShowNotifications, SettingsShowDiscordPresence, SettingsPlayerName, SettingsSelectedAudioDevice?.DeviceId ?? "default");
+            _logger.LogInformation("Settings saved: LogLevel={LogLevel}, FileLogging={FileLogging}, ConsoleLogging={ConsoleLogging}, StaticDelayMs={StaticDelayMs}, Notifications={Notifications}, Discord={Discord}, PlayerName={PlayerName}, DeviceId={DeviceId}, StartMinimized={StartMinimized}",
+                SettingsLogLevel, SettingsEnableFileLogging, SettingsEnableConsoleLogging, SettingsStaticDelayMs, SettingsShowNotifications, SettingsShowDiscordPresence, SettingsPlayerName, SettingsSelectedAudioDevice?.DeviceId ?? "default", SettingsStartMinimized);
 
             // Close settings panel first
             IsSettingsOpen = false;


### PR DESCRIPTION
## Summary
- Adds a "Start Minimized to Tray" checkbox in the General settings section.
- Default ON, persisted as `App:StartMinimized` in user appsettings.json.
- On non-first-launch, the main window is shown only when this setting is OFF.
- First-launch welcome screen is unchanged.

## Closes
Closes #22

## Test plan
- [x] Fresh install -> welcome appears (unchanged)
- [ ] Restart app with default setting -> stays in tray (unchanged)
- [ ] Uncheck "Start Minimized to Tray", save, restart -> window appears on launch
- [ ] Re-check the setting, restart -> stays in tray
- [ ] Tray icon click still opens the window when running
- [ ] `%LOCALAPPDATA%\Sendspin\appsettings.json` contains the new key