### PR TITLE
feat: add Windows media key support via SMTC

### DIFF
--- a/src/SendspinClient.Services/MediaControls/IMediaTransportControlsService.cs
+++ b/src/SendspinClient.Services/MediaControls/IMediaTransportControlsService.cs
@@ -1,0 +1,20 @@
+using Sendspin.SDK.Models;
+
+namespace SendspinClient.Services.MediaControls;
+
+public interface IMediaTransportControlsService : IDisposable
+{
+    event EventHandler? PlayPauseRequested;
+
+    event EventHandler? NextRequested;
+
+    event EventHandler? PreviousRequested;
+
+    void Initialize(IntPtr windowHandle);
+
+    void UpdateState(PlaybackState state);
+
+    void UpdateMetadata(TrackMetadata? track);
+
+    void UpdateThumbnail(byte[]? imageBytes);
+}

--- a/src/SendspinClient.Services/MediaControls/MediaTransportControlsService.cs
+++ b/src/SendspinClient.Services/MediaControls/MediaTransportControlsService.cs
@@ -1,0 +1,169 @@
+using Microsoft.Extensions.Logging;
+using Sendspin.SDK.Models;
+using Windows.Media;
+using Windows.Storage.Streams;
+
+namespace SendspinClient.Services.MediaControls;
+
+public sealed class MediaTransportControlsService : IMediaTransportControlsService
+{
+    private readonly ILogger<MediaTransportControlsService> _logger;
+    private SystemMediaTransportControls? _smtc;
+    private SystemMediaTransportControlsDisplayUpdater? _displayUpdater;
+    private bool _disposed;
+
+    public MediaTransportControlsService(ILogger<MediaTransportControlsService> logger)
+    {
+        _logger = logger;
+    }
+
+    public event EventHandler? PlayPauseRequested;
+
+    public event EventHandler? NextRequested;
+
+    public event EventHandler? PreviousRequested;
+
+    public void Initialize(IntPtr windowHandle)
+    {
+        if (_smtc != null)
+        {
+            return;
+        }
+
+        try
+        {
+            _smtc = SystemMediaTransportControlsInterop.GetForWindow(windowHandle);
+            _smtc.IsEnabled = true;
+            _smtc.IsPlayEnabled = true;
+            _smtc.IsPauseEnabled = true;
+            _smtc.IsNextEnabled = true;
+            _smtc.IsPreviousEnabled = true;
+            _smtc.PlaybackStatus = MediaPlaybackStatus.Stopped;
+            _smtc.ButtonPressed += OnButtonPressed;
+
+            _displayUpdater = _smtc.DisplayUpdater;
+            _displayUpdater.Type = MediaPlaybackType.Music;
+            _displayUpdater.Update();
+
+            _logger.LogInformation("System Media Transport Controls initialized");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize System Media Transport Controls");
+            _smtc = null;
+            _displayUpdater = null;
+        }
+    }
+
+    public void UpdateState(PlaybackState state)
+    {
+        if (_smtc == null)
+        {
+            return;
+        }
+
+        _smtc.PlaybackStatus = state switch
+        {
+            PlaybackState.Playing => MediaPlaybackStatus.Playing,
+            PlaybackState.Paused => MediaPlaybackStatus.Paused,
+            _ => MediaPlaybackStatus.Stopped,
+        };
+    }
+
+    public void UpdateMetadata(TrackMetadata? track)
+    {
+        if (_displayUpdater == null)
+        {
+            return;
+        }
+
+        if (track == null)
+        {
+            _displayUpdater.ClearAll();
+            _displayUpdater.Type = MediaPlaybackType.Music;
+        }
+        else
+        {
+            var music = _displayUpdater.MusicProperties;
+            music.Title = track.Title ?? string.Empty;
+            music.Artist = track.Artist ?? string.Empty;
+            music.AlbumTitle = track.Album ?? string.Empty;
+        }
+
+        _displayUpdater.Update();
+    }
+
+    public void UpdateThumbnail(byte[]? imageBytes)
+    {
+        if (_displayUpdater == null)
+        {
+            return;
+        }
+
+        try
+        {
+            _displayUpdater.Thumbnail = imageBytes is { Length: > 0 }
+                ? CreateStreamReference(imageBytes)
+                : null;
+            _displayUpdater.Update();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to update SMTC thumbnail");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        if (_smtc != null)
+        {
+            _smtc.ButtonPressed -= OnButtonPressed;
+            _smtc.IsEnabled = false;
+            _smtc = null;
+            _displayUpdater = null;
+        }
+    }
+
+    private void OnButtonPressed(SystemMediaTransportControls sender, SystemMediaTransportControlsButtonPressedEventArgs args)
+    {
+        switch (args.Button)
+        {
+            case SystemMediaTransportControlsButton.Play:
+            case SystemMediaTransportControlsButton.Pause:
+                PlayPauseRequested?.Invoke(this, EventArgs.Empty);
+                break;
+            case SystemMediaTransportControlsButton.Next:
+                NextRequested?.Invoke(this, EventArgs.Empty);
+                break;
+            case SystemMediaTransportControlsButton.Previous:
+                PreviousRequested?.Invoke(this, EventArgs.Empty);
+                break;
+        }
+    }
+
+    private static RandomAccessStreamReference CreateStreamReference(byte[] bytes)
+    {
+        var stream = new InMemoryRandomAccessStream();
+        var writer = new DataWriter(stream);
+        try
+        {
+            writer.WriteBytes(bytes);
+            writer.StoreAsync().AsTask().GetAwaiter().GetResult();
+            writer.DetachStream();
+        }
+        finally
+        {
+            writer.Dispose();
+        }
+
+        stream.Seek(0);
+        return RandomAccessStreamReference.CreateFromStream(stream);
+    }
+}

--- a/src/SendspinClient/App.xaml.cs
+++ b/src/SendspinClient/App.xaml.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Windows;
+using System.Windows.Interop;
 using Hardcodet.Wpf.TaskbarNotification;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +14,7 @@ using Sendspin.SDK.Models;
 using Sendspin.SDK.Synchronization;
 using SendspinClient.Services.Audio;
 using SendspinClient.Services.Discord;
+using SendspinClient.Services.MediaControls;
 using SendspinClient.Services.Models;
 using SendspinClient.Services.Notifications;
 using SendspinClient.ViewModels;
@@ -99,6 +101,9 @@ public partial class App : Application
         _mainViewModel = _serviceProvider.GetRequiredService<MainViewModel>();
         mainWindow.DataContext = _mainViewModel;
         MainWindow = mainWindow;
+
+        var mainWindowHandle = new WindowInteropHelper(mainWindow).EnsureHandle();
+        _serviceProvider.GetRequiredService<IMediaTransportControlsService>().Initialize(mainWindowHandle);
 
         // Set up system tray icon
         _trayIcon = (TaskbarIcon)FindResource("TrayIcon");
@@ -388,6 +393,8 @@ public partial class App : Application
             var logger = sp.GetRequiredService<ILogger<DiscordRichPresenceService>>();
             return new DiscordRichPresenceService(logger, discordAppId);
         });
+
+        services.AddSingleton<IMediaTransportControlsService, MediaTransportControlsService>();
 
         // User settings service for persisting runtime configuration changes
         services.AddSingleton<IUserSettingsService, UserSettingsService>();

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -21,6 +21,7 @@ using Sendspin.SDK.Models;
 using Sendspin.SDK.Protocol.Messages;
 using Sendspin.SDK.Synchronization;
 using SendspinClient.Services.Discord;
+using SendspinClient.Services.MediaControls;
 using SendspinClient.Services.Notifications;
 using SendspinClient.Views;
 
@@ -77,6 +78,7 @@ public partial class MainViewModel : ViewModelBase
     private readonly IClockSynchronizer _clockSynchronizer;
     private readonly INotificationService _notificationService;
     private readonly IDiscordRichPresenceService _discordService;
+    private readonly IMediaTransportControlsService _mediaControlsService;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ClientCapabilities _clientCapabilities;
     private readonly IUserSettingsService _settingsService;
@@ -441,6 +443,7 @@ public partial class MainViewModel : ViewModelBase
         IClockSynchronizer clockSynchronizer,
         INotificationService notificationService,
         IDiscordRichPresenceService discordService,
+        IMediaTransportControlsService mediaControlsService,
         IHttpClientFactory httpClientFactory,
         ClientCapabilities clientCapabilities,
         IUserSettingsService settingsService)
@@ -454,9 +457,17 @@ public partial class MainViewModel : ViewModelBase
         _clockSynchronizer = clockSynchronizer;
         _notificationService = notificationService;
         _discordService = discordService;
+        _mediaControlsService = mediaControlsService;
         _httpClientFactory = httpClientFactory;
         _clientCapabilities = clientCapabilities;
         _settingsService = settingsService;
+
+        _mediaControlsService.PlayPauseRequested += (_, _) =>
+            App.Current.Dispatcher.InvokeAsync(() => PlayPauseCommand.Execute(null));
+        _mediaControlsService.NextRequested += (_, _) =>
+            App.Current.Dispatcher.InvokeAsync(() => NextTrackCommand.Execute(null));
+        _mediaControlsService.PreviousRequested += (_, _) =>
+            App.Current.Dispatcher.InvokeAsync(() => PreviousTrackCommand.Execute(null));
 
         // Load current logging settings
         LoadLoggingSettings();
@@ -1447,6 +1458,8 @@ public partial class MainViewModel : ViewModelBase
             _discordService.ClearPresence();
         }
 
+        _mediaControlsService.UpdateState(value);
+
         // Reset position interpolation anchor when playback stops
         if (value != PlaybackState.Playing)
         {
@@ -1479,12 +1492,19 @@ public partial class MainViewModel : ViewModelBase
     /// Detects actual track changes (vs. metadata updates) and shows notifications.
     /// </summary>
     /// <param name="value">The new track metadata.</param>
+    partial void OnAlbumArtworkChanged(byte[]? value)
+    {
+        _mediaControlsService.UpdateThumbnail(value);
+    }
+
     partial void OnCurrentTrackChanged(TrackMetadata? value)
     {
         OnPropertyChanged(nameof(DisplayTitle));
         OnPropertyChanged(nameof(DisplayArtist));
         OnPropertyChanged(nameof(DisplayAlbum));
         UpdateTrayToolTip();
+
+        _mediaControlsService.UpdateMetadata(value);
 
         // Only show notification if this is actually a different track
         // Use title+artist+album as unique track identifier


### PR DESCRIPTION
## Summary
- Adds a new `IMediaTransportControlsService` that wraps `SystemMediaTransportControls` (via the C# `SystemMediaTransportControlsInterop.GetForWindow` wrapper for desktop apps in .NET 6+).
- Routes hardware media keys to the existing `PlayPauseCommand`, `NextTrackCommand`, and `PreviousTrackCommand` on `MainViewModel`.
- Pushes playback state, track metadata, and album art to SMTC so the Windows volume-flyout "now playing" tile reflects the current track.

## Closes
Closes #20

## Test plan
- [ ] Connect to MA, start playback
- [ ] Keyboard play/pause/next/prev keys control WindowsSpin
- [ ] Volume flyout "now playing" tile shows the current track title, artist, and album art
- [ ] Tile play/pause/next/prev buttons also work
- [ ] In-app buttons still work (no regression)
- [ ] Track changes update tile + album art
- [ ] Bluetooth headset play/pause button (if available) controls playback

## Out of scope
- Settings checkbox to disable SMTC (follow-up if anyone asks)
- Position/seek support