### PR TITLE
chore: add diagnostics + media-key toggle for unmute auto-play (#31)

### DIFF
--- a/src/SendspinClient.Services/MediaControls/IMediaTransportControlsService.cs
+++ b/src/SendspinClient.Services/MediaControls/IMediaTransportControlsService.cs
@@ -4,6 +4,12 @@ namespace SendspinClient.Services.MediaControls;
 
 public interface IMediaTransportControlsService : IDisposable
 {
+    /// <summary>
+    /// Gets or sets whether System Media Transport Controls integration is active.
+    /// When false, Windows hides our media controls and incoming button events are ignored.
+    /// </summary>
+    bool IsEnabled { get; set; }
+
     event EventHandler? PlayPauseRequested;
 
     event EventHandler? NextRequested;

--- a/src/SendspinClient.Services/MediaControls/MediaTransportControlsService.cs
+++ b/src/SendspinClient.Services/MediaControls/MediaTransportControlsService.cs
@@ -10,11 +10,32 @@ public sealed class MediaTransportControlsService : IMediaTransportControlsServi
     private readonly ILogger<MediaTransportControlsService> _logger;
     private SystemMediaTransportControls? _smtc;
     private SystemMediaTransportControlsDisplayUpdater? _displayUpdater;
+    private bool _isEnabled = true;
     private bool _disposed;
 
     public MediaTransportControlsService(ILogger<MediaTransportControlsService> logger)
     {
         _logger = logger;
+    }
+
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set
+        {
+            if (_isEnabled == value)
+            {
+                return;
+            }
+
+            _isEnabled = value;
+            if (_smtc != null)
+            {
+                _smtc.IsEnabled = value;
+            }
+
+            _logger.LogInformation("SMTC integration toggled: {Enabled}", value);
+        }
     }
 
     public event EventHandler? PlayPauseRequested;
@@ -33,7 +54,7 @@ public sealed class MediaTransportControlsService : IMediaTransportControlsServi
         try
         {
             _smtc = SystemMediaTransportControlsInterop.GetForWindow(windowHandle);
-            _smtc.IsEnabled = true;
+            _smtc.IsEnabled = _isEnabled;
             _smtc.IsPlayEnabled = true;
             _smtc.IsPauseEnabled = true;
             _smtc.IsNextEnabled = true;
@@ -62,12 +83,23 @@ public sealed class MediaTransportControlsService : IMediaTransportControlsServi
             return;
         }
 
-        _smtc.PlaybackStatus = state switch
+        var newStatus = state switch
         {
             PlaybackState.Playing => MediaPlaybackStatus.Playing,
             PlaybackState.Paused => MediaPlaybackStatus.Paused,
             _ => MediaPlaybackStatus.Stopped,
         };
+
+        var oldStatus = _smtc.PlaybackStatus;
+        if (oldStatus != newStatus)
+        {
+            _logger.LogInformation(
+                "SMTC PlaybackStatus: {Old} -> {New} (PlaybackState={State})",
+                oldStatus,
+                newStatus,
+                state);
+            _smtc.PlaybackStatus = newStatus;
+        }
     }
 
     public void UpdateMetadata(TrackMetadata? track)
@@ -133,6 +165,17 @@ public sealed class MediaTransportControlsService : IMediaTransportControlsServi
 
     private void OnButtonPressed(SystemMediaTransportControls sender, SystemMediaTransportControlsButtonPressedEventArgs args)
     {
+        _logger.LogInformation(
+            "SMTC button pressed: {Button} (current SMTC PlaybackStatus={Status}, IsEnabled={Enabled})",
+            args.Button,
+            sender.PlaybackStatus,
+            _isEnabled);
+
+        if (!_isEnabled)
+        {
+            return;
+        }
+
         switch (args.Button)
         {
             case SystemMediaTransportControlsButton.Play:

--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -599,6 +599,25 @@
                                           VerticalAlignment="Center"/>
                             </Grid>
 
+                            <!-- Hardware Media Keys / SMTC -->
+                            <Grid Margin="0,0,0,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0">
+                                    <TextBlock Text="Hardware Media Keys" Style="{StaticResource BodyText}"/>
+                                    <TextBlock Text="Allow keyboard play/pause keys, Bluetooth headset buttons, and the Windows volume-flyout media tile to control playback"
+                                               Style="{StaticResource CaptionText}"
+                                               Foreground="{StaticResource TextMutedBrush}"
+                                               Margin="0,2,0,0"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <CheckBox Grid.Column="1"
+                                          IsChecked="{Binding SettingsEnableMediaKeys}"
+                                          VerticalAlignment="Center"/>
+                            </Grid>
+
                             <Grid Margin="0,0,0,16">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*"/>

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -266,6 +266,13 @@ public partial class MainViewModel : ViewModelBase
     [ObservableProperty]
     private bool _settingsShowDiscordPresence;
 
+    /// <summary>
+    /// Gets or sets whether System Media Transport Controls (Windows media keys, lockscreen,
+    /// volume-flyout media tile) are wired to playback commands.
+    /// </summary>
+    [ObservableProperty]
+    private bool _settingsEnableMediaKeys = true;
+
     [ObservableProperty]
     private bool _settingsStartMinimized = true;
 
@@ -463,7 +470,13 @@ public partial class MainViewModel : ViewModelBase
         _settingsService = settingsService;
 
         _mediaControlsService.PlayPauseRequested += (_, _) =>
-            App.Current.Dispatcher.InvokeAsync(() => PlayPauseCommand.Execute(null));
+            App.Current.Dispatcher.InvokeAsync(() =>
+            {
+                _logger.LogInformation(
+                    "SMTC PlayPauseRequested received: PlaybackState={State}, IsConnected={Connected}, IsMuted={Muted}",
+                    PlaybackState, IsConnected, IsMuted);
+                PlayPauseCommand.Execute(null);
+            });
         _mediaControlsService.NextRequested += (_, _) =>
             App.Current.Dispatcher.InvokeAsync(() => NextTrackCommand.Execute(null));
         _mediaControlsService.PreviousRequested += (_, _) =>
@@ -584,6 +597,9 @@ public partial class MainViewModel : ViewModelBase
             var command = PlaybackState == PlaybackState.Playing
                 ? Commands.Pause
                 : Commands.Play;
+            _logger.LogInformation(
+                "PlayPause -> sending {Command} (PlaybackState was {State}, IsMuted={Muted})",
+                command, PlaybackState, IsMuted);
             await SendCommandToActiveClientAsync(command);
         }
         catch (Exception ex)
@@ -629,7 +645,9 @@ public partial class MainViewModel : ViewModelBase
         {
             // Toggle the mute state
             var newMutedState = !IsMuted;
-            _logger.LogDebug("Toggling mute: {Muted}", newMutedState);
+            _logger.LogInformation(
+                "ToggleMute (local): {Old} -> {New}, PlaybackState={State}, IsConnected={Connected}",
+                IsMuted, newMutedState, PlaybackState, IsConnected);
 
             // Apply locally FIRST for instant feedback (even when disconnected)
             _audioPipeline?.SetMuted(newMutedState);
@@ -1241,10 +1259,22 @@ public partial class MainViewModel : ViewModelBase
             _isUpdatingFromServer = true;
             try
             {
+                var muteChanged = IsMuted != state.Muted;
+                if (muteChanged)
+                {
+                    _logger.LogInformation(
+                        "Server mute change (host): {Old} -> {New}, Volume {OldVol}->{NewVol}, PlaybackState={State}",
+                        IsMuted, state.Muted, Volume, state.Volume, PlaybackState);
+                }
+
                 Volume = state.Volume;
                 IsMuted = state.Muted;
-                _logger.LogDebug("Player state updated (host): Volume={Volume}, Muted={Muted}",
-                    state.Volume, state.Muted);
+
+                if (!muteChanged)
+                {
+                    _logger.LogDebug("Player state updated (host): Volume={Volume}, Muted={Muted}",
+                        state.Volume, state.Muted);
+                }
             }
             finally
             {
@@ -1264,10 +1294,22 @@ public partial class MainViewModel : ViewModelBase
             _isUpdatingFromServer = true;
             try
             {
+                var muteChanged = IsMuted != state.Muted;
+                if (muteChanged)
+                {
+                    _logger.LogInformation(
+                        "Server mute change (manual): {Old} -> {New}, Volume {OldVol}->{NewVol}, PlaybackState={State}",
+                        IsMuted, state.Muted, Volume, state.Volume, PlaybackState);
+                }
+
                 Volume = state.Volume;
                 IsMuted = state.Muted;
-                _logger.LogDebug("Player state updated (manual): Volume={Volume}, Muted={Muted}",
-                    state.Volume, state.Muted);
+
+                if (!muteChanged)
+                {
+                    _logger.LogDebug("Player state updated (manual): Volume={Volume}, Muted={Muted}",
+                        state.Volume, state.Muted);
+                }
             }
             finally
             {
@@ -1786,6 +1828,11 @@ public partial class MainViewModel : ViewModelBase
         }
     }
 
+    partial void OnSettingsEnableMediaKeysChanged(bool value)
+    {
+        _mediaControlsService.IsEnabled = value;
+    }
+
     partial void OnSettingsConnectionModeChanged(string value)
     {
         // Convert display name to config value
@@ -2032,6 +2079,10 @@ public partial class MainViewModel : ViewModelBase
             _discordService.Enable();
         }
 
+        // Load SMTC (Windows media key) integration setting and apply immediately
+        SettingsEnableMediaKeys = _configuration.GetValue<bool>("MediaControls:Enabled", true);
+        _mediaControlsService.IsEnabled = SettingsEnableMediaKeys;
+
         SettingsStartMinimized = _configuration.GetValue<bool>("App:StartMinimized", true);
 
         // Load player name (default to computer name)
@@ -2274,6 +2325,11 @@ public partial class MainViewModel : ViewModelBase
             discordSection["Enabled"] = SettingsShowDiscordPresence;
             root["Discord"] = discordSection;
 
+            // Update MediaControls section
+            var mediaControlsSection = root["MediaControls"]?.AsObject() ?? new JsonObject();
+            mediaControlsSection["Enabled"] = SettingsEnableMediaKeys;
+            root["MediaControls"] = mediaControlsSection;
+
             var appSection = root["App"]?.AsObject() ?? new JsonObject();
             appSection["StartMinimized"] = SettingsStartMinimized;
             root["App"] = appSection;
@@ -2302,8 +2358,8 @@ public partial class MainViewModel : ViewModelBase
                 _logger.LogInformation("Player name changed to: {PlayerName}", SettingsPlayerName);
             }
 
-            _logger.LogInformation("Settings saved: LogLevel={LogLevel}, FileLogging={FileLogging}, ConsoleLogging={ConsoleLogging}, StaticDelayMs={StaticDelayMs}, Notifications={Notifications}, Discord={Discord}, PlayerName={PlayerName}, DeviceId={DeviceId}, StartMinimized={StartMinimized}",
-                SettingsLogLevel, SettingsEnableFileLogging, SettingsEnableConsoleLogging, SettingsStaticDelayMs, SettingsShowNotifications, SettingsShowDiscordPresence, SettingsPlayerName, SettingsSelectedAudioDevice?.DeviceId ?? "default", SettingsStartMinimized);
+            _logger.LogInformation("Settings saved: LogLevel={LogLevel}, FileLogging={FileLogging}, ConsoleLogging={ConsoleLogging}, StaticDelayMs={StaticDelayMs}, Notifications={Notifications}, Discord={Discord}, MediaKeys={MediaKeys}, PlayerName={PlayerName}, DeviceId={DeviceId}, StartMinimized={StartMinimized}",
+                SettingsLogLevel, SettingsEnableFileLogging, SettingsEnableConsoleLogging, SettingsStaticDelayMs, SettingsShowNotifications, SettingsShowDiscordPresence, SettingsEnableMediaKeys, SettingsPlayerName, SettingsSelectedAudioDevice?.DeviceId ?? "default", SettingsStartMinimized);
 
             // Close settings panel first
             IsSettingsOpen = false;

--- a/src/SendspinClient/appsettings.json
+++ b/src/SendspinClient/appsettings.json
@@ -36,5 +36,8 @@
   "Discord": {
     "Enabled": false,
     "ApplicationId": "1454545426500813014"
+  },
+  "MediaControls": {
+    "Enabled": true
   }
 }


### PR DESCRIPTION
## Summary

Adds diagnostic instrumentation and a runtime kill switch for SMTC integration to investigate the regression reported in #31 ("Sometimes when switching from mute to unmute, the player will automatically play music").

**This PR does not fix the bug.** It adds the tools we need to find which 2.1.0 change is responsible and confirm whether SMTC is involved.

## Why

Two changes shipped in 2.1.0 could plausibly cause unmute -> auto-play:

- `c297c9a` — muted-buffer-drain fix (issue #25). Made mute actually responsive; pre-2.1.0 mute didn't fully work, which is why the reporter says they can't tell whether 1.14.0 had the same issue.
- `e431efd` — SMTC integration (issue #20). Wires Windows media keys, lockscreen, and the volume-flyout media tile to playback commands. Notably, `Play` and `Pause` button events both collapse into one `PlayPauseRequested` event, which then toggles based on local `PlaybackState`. If Windows fires a synthetic Play event during the unmute transition (a documented quirk where the OS treats a silent-then-audible session as a "play start"), our handler would send `Commands.Play` to MA -> auto-play.

Without a reproducer it's not clear which path is wrong, so this PR makes it observable.

## What's added

### Information-level logging on the suspect edges

| Where | What we log |
|---|---|
| `MediaTransportControlsService.OnButtonPressed` | Button name + current SMTC `PlaybackStatus` + `IsEnabled` (logged **before** the gate so we still see events when SMTC is "off") |
| `MediaTransportControlsService.UpdateState` | SMTC `PlaybackStatus` old -> new transitions only |
| `MainViewModel` PlayPauseRequested handler | `PlaybackState`, `IsConnected`, `IsMuted` at receipt |
| `MainViewModel.PlayPauseAsync` | Resolved command (Play vs Pause) and the state that drove the choice |
| `MainViewModel.ToggleMuteAsync` | Local mute toggle old -> new |
| `OnPlayerStateChanged` / `OnManualClientPlayerStateChanged` | Server-driven mute changes only (volume ticks stay at Debug) |

The `muteChanged` guard in the server-state handlers is intentional — `state.Volume` ticks too often to be useful at Information level.

### Hardware Media Keys toggle

A new checkbox in Settings -> General controls a `MediaControls:Enabled` setting (default `true`, preserves 2.1.0 behavior).

When off:
- `SystemMediaTransportControls.IsEnabled = false` (Windows hides our media controls)
- `OnButtonPressed` defensively drops events before forwarding (in case Windows still delivers them)

The setting applies immediately (no restart) so the reporter can A/B test in seconds.

## How the reporter (or anyone repro-ing) should use this

1. Update to this build.
2. In Settings set Log Level to Information + enable file logging.
3. Reproduce the bug as before (presence sensor mute/unmute via Music Assistant).
4. Attach `%LOCALAPPDATA%\Sendspin\logs\windowsspin-{date}.log` to issue #31.
5. Then toggle the new "Hardware Media Keys" setting **off** and try again. Two outcomes:
   - **Bug stops with SMTC off** -> SMTC is the cause, fix scope is `MediaTransportControlsService` (likely: split Play vs Pause button handling, or only honor a button when its action matches current state).
   - **Bug continues with SMTC off** -> SMTC is innocent. The cause is in the SDK mute path or the buffer-drain change. Logs will show whether the auto-play comes from the server or the client.

## Test plan

- [ ] Build (`dotnet build -c Debug`) — verified clean: 0 errors
- [ ] Launch app, open Settings, confirm "Hardware Media Keys" checkbox renders correctly under General
- [ ] Toggle off, press a media key on the keyboard, confirm Sendspin no longer responds (and a log line `SMTC button pressed: ... IsEnabled=False` appears)
- [ ] Toggle back on, no app restart needed, media keys work again
- [ ] Mute via Music Assistant, observe `Server mute change (host/manual): False -> True` log line
- [ ] Local mute toggle, observe `ToggleMute (local): ... -> ...` log line
- [ ] Start MA playing, manually press SMTC Play on Windows, observe `SMTC PlayPauseRequested received` followed by `PlayPause -> sending Pause`

## Out of scope

- No actual fix for #31 yet — pending data from the toggle/logs.
- No new tests; the project has no test infrastructure for SMTC interop and this PR is observational.

Refs #31