### PR TITLE
fix: restore Combined sync-correction strategy (smooth resampling) as shipped default

### DIFF
--- a/src/SendspinClient/appsettings.json
+++ b/src/SendspinClient/appsettings.json
@@ -23,7 +23,7 @@
       "ConvergenceTimeoutMs": 1000
     },
     "SyncCorrection": {
-      "Strategy": "DropInsertOnly",
+      "Strategy": "Combined",
       "ResamplerType": "Wdl",
       "ResamplingThresholdMs": 15
     }


### PR DESCRIPTION
## Summary
The shipped `appsettings.json` has forced `Audio:SyncCorrection:Strategy = "DropInsertOnly"` ever since the Jan 2026 in-app-sync refactor (commit `1edda29`, "Shift to SDK 5.0.0 and do audio sync within the app"). That refactor changed the config from `"UseResampling": true` to the new `Strategy` enum and landed on `DropInsertOnly` — which **overrides the code default of `Combined`** (`App.xaml.cs:298`) and disables the smooth-resampling correction tier. Result: all clock-drift sync correction has been done via **audible sample drop/insert**, with no resampling for small errors.

This restores `Strategy: "Combined"`, matching the code default and the prior `UseResampling: true` behavior.

## Why (refs #33)
Reported as audible "clipping"/packet-loss-like artifacts, worst on dense passages and on AV-receiver / optical outputs. The reporter's Stats showed continuous sample **inserts at playback rate 1.000×** (drop/insert active, resampling off), with a full 30s buffer and **0 underruns/overruns** — so it's not network or buffering. Streaming to the same AVR via Chromecast/Shield is flawless, confirming it's the PC client's *correction method*, not hardware or network. The drift itself (~11 ppm) is normal clock mismatch every networked player has; the fix is to correct it inaudibly.

## Behavior after this change (`Combined`)
| Sync error | Method | Audible? |
|---|---|---|
| < 2 ms (deadband) | none | no |
| 2–15 ms | smooth resampling (≤ ~2% rate nudge) | **no** (was drop/insert) |
| 15–500 ms | frame drop/insert | rare faint click on large jumps |
| ≥ 500 ms | re-anchor (clear buffer + restart) | rare reset |

Only the 2–15 ms tier changes (audible splice → inaudible resampling). **Perfect-sync guarantees are unchanged** — this is the same correction, done smoothly. `ResamplerType: "Wdl"` and `ResamplingThresholdMs: 15` left as-is.

## Test plan
- [x] `appsettings.json` valid JSON
- [ ] CI build green
- [x] On a drifting output (e.g. optical AVR): Stats shows Correction Mode "Resampling" / playback rate deviating slightly (~0.99–1.01×) instead of continuous drop/insert, and clipping on complex passages is gone
- [x] Multi-room sync still holds (perfect-sync guarantee unchanged)

Refs #33