### PR TITLE
Add Reactive Backdrop intensity slider

### DIFF
--- a/docs/superpowers/plans/2026-06-05-ambient-backdrop-intensity.md
+++ b/docs/superpowers/plans/2026-06-05-ambient-backdrop-intensity.md
@@ -1,0 +1,441 @@
+# Ambient Backdrop Intensity Slider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a settings slider (0–200%, default 100%) that scales the Reactive Backdrop's reactivity, presence, and drift speed together, with a faint floor at 0%.
+
+**Architecture:** A single `intensity` scalar flows from `appsettings.json` → `MainViewModel` (bound to the slider, persisted) → `AmbientBackdropViewModel` (stores raw, exposes a floored effective value) → the `AmbientBackdropView` render loop and `AmbientMath` mapping functions. Mirrors the existing enable-toggle path exactly.
+
+**Tech Stack:** .NET 10, WPF, CommunityToolkit.Mvvm (source-generated `[ObservableProperty]`), xUnit.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-ambient-backdrop-intensity-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `src/SendspinClient.Services/Visualization/AmbientMath.cs` — add `IntensityFloor` constant and optional `intensity` param to `BlobScale`/`BlobOpacity`.
+- **Modify** `tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs` — add intensity theory cases.
+- **Modify** `src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs` — add `Intensity` getter (floored) + `SetIntensity(raw)`.
+- **Modify** `src/SendspinClient/Views/AmbientBackdropView.xaml.cs` — consume intensity in scale/opacity, accumulate drift phase.
+- **Modify** `src/SendspinClient/ViewModels/MainViewModel.cs` — `SettingsAmbientBackdropIntensity` property, change handler, load, save.
+- **Modify** `src/SendspinClient/MainWindow.xaml` — slider + percentage readout row under the existing checkbox.
+- **Modify** `src/SendspinClient/appsettings.json` — add `Visualizer:Intensity`.
+
+---
+
+## Task 1: Math — intensity in `BlobScale` / `BlobOpacity`
+
+**Files:**
+- Modify: `src/SendspinClient.Services/Visualization/AmbientMath.cs`
+- Test: `tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these to `AmbientMathTests.cs` (inside the `AmbientMathTests` class):
+
+```csharp
+[Theory]
+[InlineData(1.0, 0.0, 0.0, 0.82)]   // intensity 0 -> floor at ScaleMin
+[InlineData(1.0, 0.0, 1.0, 1.32)]   // intensity 1 -> identity (ScaleMin + 0.50)
+[InlineData(1.0, 0.0, 2.0, 1.82)]   // intensity 2 -> doubled energy span (ScaleMin + 1.00)
+[InlineData(1.0, 1.0, 2.0, 2.52)]   // intensity 2 with full pulse: 0.82 + 2*(0.50+0.35)
+public void BlobScale_ScalesReactivityByIntensity(double energy, double pulse, double intensity, double expected)
+{
+    Assert.Equal(expected, AmbientMath.BlobScale(energy, pulse, intensity), 0.0001);
+}
+
+[Theory]
+[InlineData(0.0, 0.0, 0.0)]    // intensity 0 -> invisible
+[InlineData(0.0, 1.0, 0.55)]   // intensity 1 -> identity
+[InlineData(0.0, 2.0, 1.0)]    // intensity 2 -> 2*0.55 = 1.10 clamped to 1.0
+[InlineData(1.0, 2.0, 1.0)]    // energy 1, intensity 2 -> clamped to 1.0
+public void BlobOpacity_ScalesPresenceByIntensity(double energy, double intensity, double expected)
+{
+    Assert.Equal(expected, AmbientMath.BlobOpacity(energy, intensity), 0.0001);
+}
+
+[Fact]
+public void BlobScale_NegativeIntensity_ClampsToZeroReactivity()
+{
+    Assert.Equal(0.82, AmbientMath.BlobScale(1.0, 1.0, -5.0), 0.0001);
+}
+
+[Fact]
+public void IntensityFloor_IsFaintButNonZero()
+{
+    Assert.InRange(AmbientMath.IntensityFloor, 0.05, 0.30);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/SendspinClient.Services.Tests/SendspinClient.Services.Tests.csproj --filter "FullyQualifiedName~AmbientMathTests"`
+Expected: FAIL — compile error (`BlobScale` has no 3-arg overload, `IntensityFloor` undefined).
+
+- [ ] **Step 3: Add the constant and intensity parameters**
+
+In `AmbientMath.cs`, add near the other scale/opacity constants (after `OpacityEnergySpan`):
+
+```csharp
+    /// <summary>
+    /// Minimum effective intensity. The 0% slider position floors to this so the backdrop
+    /// stays faintly alive (subtle, slow, dim) rather than going fully dark. Use the enable
+    /// toggle to disable the effect entirely. Applied at the ViewModel boundary, not here.
+    /// </summary>
+    public const double IntensityFloor = 0.15;
+```
+
+Replace `BlobScale` with:
+
+```csharp
+    /// <summary>
+    /// Blob render scale from eased energy and the current beat pulse, scaled by
+    /// <paramref name="intensity"/> (1.0 = default). Energy and pulse are clamped to [0,1];
+    /// intensity is clamped to be non-negative. <c>ScaleMin</c> is never scaled, so blobs keep
+    /// their minimum size at intensity 0.
+    /// </summary>
+    public static double BlobScale(double energy, double pulse, double intensity = 1.0)
+    {
+        var e = Math.Clamp(energy, 0.0, 1.0);
+        var p = Math.Clamp(pulse, 0.0, 1.0);
+        var i = Math.Max(0.0, intensity);
+        return ScaleMin + (i * ((e * ScaleEnergySpan) + (p * ScalePulseSpan)));
+    }
+```
+
+Replace `BlobOpacity` with:
+
+```csharp
+    /// <summary>
+    /// Blob opacity from eased energy, scaled by <paramref name="intensity"/> (1.0 = default).
+    /// The whole opacity scales, so intensity 0 is invisible; the result is clamped to [0,1].
+    /// </summary>
+    public static double BlobOpacity(double energy, double intensity = 1.0)
+    {
+        var e = Math.Clamp(energy, 0.0, 1.0);
+        var i = Math.Max(0.0, intensity);
+        return Math.Clamp(i * (OpacityMin + (e * OpacityEnergySpan)), 0.0, 1.0);
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/SendspinClient.Services.Tests/SendspinClient.Services.Tests.csproj --filter "FullyQualifiedName~AmbientMathTests"`
+Expected: PASS — all existing and new `AmbientMathTests` green (existing 2-arg cases still pass via the `intensity = 1.0` default).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/SendspinClient.Services/Visualization/AmbientMath.cs tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
+git commit -m "feat: scale ambient backdrop reactivity and presence by intensity"
+```
+
+---
+
+## Task 2: ViewModel — `Intensity` getter and `SetIntensity`
+
+**Files:**
+- Modify: `src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs`
+
+No unit test project covers this WPF-assembly ViewModel; correctness is verified by the build plus the math tests in Task 1 (the floor logic is a one-line `Math.Max`). Verification is `dotnet build`.
+
+- [ ] **Step 1: Add the intensity field, getter, and setter**
+
+In `AmbientBackdropViewModel.cs`, add after the `BlobColor3` property block (before the `BeatTriggered` event) — note `using SendspinClient.Services.Visualization;` is already imported:
+
+```csharp
+    private double _intensity = 1.0;
+
+    /// <summary>
+    /// Effective intensity (<c>IntensityFloor</c>..2.0) consumed by the renderer. The raw 0
+    /// setting is floored so the backdrop never goes fully dark via the slider; use
+    /// <see cref="SetEnabled"/> to disable entirely.
+    /// </summary>
+    public double Intensity => Math.Max(AmbientMath.IntensityFloor, _intensity);
+
+    /// <summary>Sets the raw intensity (0..2) from the settings slider. Does not affect IsActive.</summary>
+    public void SetIntensity(double raw) => _intensity = Math.Clamp(raw, 0.0, 2.0);
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build src/SendspinClient/SendspinClient.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs
+git commit -m "feat: add floored Intensity to AmbientBackdropViewModel"
+```
+
+---
+
+## Task 3: View — apply intensity to scale, opacity, and drift speed
+
+**Files:**
+- Modify: `src/SendspinClient/Views/AmbientBackdropView.xaml.cs`
+
+- [ ] **Step 1: Add a drift-phase field**
+
+In `AmbientBackdropView.xaml.cs`, add alongside the other animation fields (after `private double _pulseTarget;`):
+
+```csharp
+    // Accumulated drift phase (replaces raw monotonic time). Scaled by intensity each frame so
+    // drift speed tracks the slider; accumulating keeps phase continuous when intensity changes
+    // and across Loaded/Unloaded cycles (persists for the life of the view instance).
+    private double _driftPhase;
+```
+
+- [ ] **Step 2: Read intensity and apply it to scale/opacity**
+
+In `OnRendering`, replace these lines:
+
+```csharp
+        var scale = AmbientMath.BlobScale(_energy, _pulse);
+        var opacity = AmbientMath.BlobOpacity(_energy);
+```
+
+with:
+
+```csharp
+        var intensity = _vm.Intensity;
+        var scale = AmbientMath.BlobScale(_energy, _pulse, intensity);
+        var opacity = AmbientMath.BlobOpacity(_energy, intensity);
+```
+
+- [ ] **Step 3: Drive drift from the accumulated phase**
+
+In `OnRendering`, replace this block:
+
+```csharp
+        // Idle drift: slow sinusoidal motion so the scene is alive at low energy. Use a monotonic
+        // timestamp (not the restartable _clock) so the drift phase is continuous across
+        // Loaded/Unloaded cycles and does not snap on re-show.
+        var t = Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency;
+```
+
+with:
+
+```csharp
+        // Idle drift: slow sinusoidal motion so the scene is alive at low energy. Accumulate a
+        // phase scaled by intensity so drift SPEED tracks the slider; accumulation keeps the phase
+        // continuous across intensity changes and Loaded/Unloaded cycles (no snap on re-show).
+        _driftPhase += dt * intensity;
+        var t = _driftPhase;
+```
+
+(The six `Blob*Translate` lines that use `t` are unchanged. Amplitude stays fixed — only speed scales.)
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `dotnet build src/SendspinClient/SendspinClient.csproj`
+Expected: Build succeeded. (`Stopwatch` is still used by `_clock`, so leave the `using System.Diagnostics;` in place.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/SendspinClient/Views/AmbientBackdropView.xaml.cs
+git commit -m "feat: scale ambient backdrop drift speed and visuals by intensity"
+```
+
+---
+
+## Task 4: MainViewModel — setting property, handler, load, save
+
+**Files:**
+- Modify: `src/SendspinClient/ViewModels/MainViewModel.cs`
+
+- [ ] **Step 1: Add the observable property**
+
+After the `_settingsEnableAmbientBackdrop` property block (around line 285), add:
+
+```csharp
+    /// <summary>
+    /// Gets or sets the Ambient Glow backdrop intensity (0.0–2.0, 1.0 = default look).
+    /// Scales reactivity, presence, and drift speed together.
+    /// </summary>
+    [ObservableProperty]
+    private double _settingsAmbientBackdropIntensity = 1.0;
+```
+
+- [ ] **Step 2: Add the change handler**
+
+After the `OnSettingsEnableAmbientBackdropChanged` method (around line 1929), add:
+
+```csharp
+    partial void OnSettingsAmbientBackdropIntensityChanged(double value)
+    {
+        _ambient.SetIntensity(value);
+    }
+```
+
+- [ ] **Step 3: Load from config**
+
+After the existing ambient load lines (around line 2178–2179):
+
+```csharp
+        SettingsEnableAmbientBackdrop = _configuration.GetValue<bool>("Visualizer:Enabled", true);
+        _ambient.SetEnabled(SettingsEnableAmbientBackdrop);
+```
+
+add:
+
+```csharp
+        SettingsAmbientBackdropIntensity = _configuration.GetValue<double>("Visualizer:Intensity", 1.0);
+        _ambient.SetIntensity(SettingsAmbientBackdropIntensity);
+```
+
+- [ ] **Step 4: Save to config**
+
+In the Visualizer save block (around line 2428–2430), change:
+
+```csharp
+            var visualizerSection = root["Visualizer"]?.AsObject() ?? new JsonObject();
+            visualizerSection["Enabled"] = SettingsEnableAmbientBackdrop;
+            root["Visualizer"] = visualizerSection;
+```
+
+to:
+
+```csharp
+            var visualizerSection = root["Visualizer"]?.AsObject() ?? new JsonObject();
+            visualizerSection["Enabled"] = SettingsEnableAmbientBackdrop;
+            visualizerSection["Intensity"] = SettingsAmbientBackdropIntensity;
+            root["Visualizer"] = visualizerSection;
+```
+
+- [ ] **Step 5: Build to verify it compiles**
+
+Run: `dotnet build src/SendspinClient/SendspinClient.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/SendspinClient/ViewModels/MainViewModel.cs
+git commit -m "feat: persist and apply ambient backdrop intensity setting"
+```
+
+---
+
+## Task 5: UI — intensity slider in settings
+
+**Files:**
+- Modify: `src/SendspinClient/MainWindow.xaml`
+
+- [ ] **Step 1: Add the slider row**
+
+In `MainWindow.xaml`, immediately after the closing `</Grid>` of the "Ambient Glow reactive backdrop" checkbox row (the `</Grid>` at line ~646, before the "Hardware Media Keys / SMTC" comment), insert:
+
+```xml
+                            <!-- Ambient Glow intensity -->
+                            <Grid Margin="0,0,0,16"
+                                  IsEnabled="{Binding SettingsEnableAmbientBackdrop}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <TextBlock Text="Backdrop intensity" Style="{StaticResource BodyText}"/>
+                                    <TextBlock Text="Scale how strongly the backdrop reacts, glows, and moves"
+                                               Style="{StaticResource CaptionText}"
+                                               Foreground="{StaticResource TextMutedBrush}"
+                                               Margin="0,2,0,0"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Slider Width="160"
+                                            Minimum="0" Maximum="2"
+                                            TickFrequency="0.25" IsSnapToTickEnabled="False"
+                                            Value="{Binding SettingsAmbientBackdropIntensity, Mode=TwoWay}"
+                                            VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding SettingsAmbientBackdropIntensity, StringFormat={}{0:P0}}"
+                                               Style="{StaticResource CaptionText}"
+                                               Foreground="{StaticResource TextMutedBrush}"
+                                               Width="44" TextAlignment="Right"
+                                               Margin="8,0,0,0"
+                                               VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Grid>
+```
+
+- [ ] **Step 2: Build to verify the XAML compiles**
+
+Run: `dotnet build src/SendspinClient/SendspinClient.csproj`
+Expected: Build succeeded (no XAML parse errors; `BodyText`, `CaptionText`, `TextMutedBrush` all already resolve in this view).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/SendspinClient/MainWindow.xaml
+git commit -m "feat: add ambient backdrop intensity slider to settings"
+```
+
+---
+
+## Task 6: Config default
+
+**Files:**
+- Modify: `src/SendspinClient/appsettings.json`
+
+- [ ] **Step 1: Add the Intensity default**
+
+In `appsettings.json`, change the `Visualizer` section from:
+
+```json
+  "Visualizer": {
+    "Enabled": true,
+    "RateMax": 30,
+    "BufferCapacity": 4096
+  }
+```
+
+to:
+
+```json
+  "Visualizer": {
+    "Enabled": true,
+    "Intensity": 1.0,
+    "RateMax": 30,
+    "BufferCapacity": 4096
+  }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/SendspinClient/appsettings.json
+git commit -m "chore: add Visualizer:Intensity default to appsettings"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build SendspinClient.sln`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 2: Full test run**
+
+Run: `dotnet test`
+Expected: All tests pass (including the new `AmbientMathTests` cases).
+
+- [ ] **Step 3: Manual smoke test**
+
+Run the app (`dotnet run --project src/SendspinClient/SendspinClient.csproj`), connect, play audio, open Settings:
+- Drag the slider 0% → 200%: backdrop visibly calms then intensifies (size, glow, drift speed).
+- At 0%: backdrop is faint and slow but still alive (not black/frozen).
+- Toggle the backdrop off: the slider greys out (disabled).
+- Change the value, restart the app: the value persists (written to `%LOCALAPPDATA%\Sendspin\appsettings.json`).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** math (T1), motion (T3), ViewModel floor (T2), MainViewModel plumbing (T4), UI slider + grey-out + readout (T5), config default (T6), tests (T1). All spec sections mapped.
+- **Type consistency:** `SetIntensity(double)` / `Intensity` getter used identically in T2, T3, T4. `SettingsAmbientBackdropIntensity` used identically in T4 and T5. `IntensityFloor` defined in T1, consumed in T2.
+- **Floor location:** defined as a constant in `AmbientMath` (T1) but applied only in the ViewModel getter (T2), per the spec — the math functions remain honest multipliers.

--- a/docs/superpowers/specs/2026-06-05-ambient-backdrop-intensity-design.md
+++ b/docs/superpowers/specs/2026-06-05-ambient-backdrop-intensity-design.md
@@ -1,0 +1,157 @@
+# Ambient Backdrop Intensity Slider — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (pending spec review)
+
+## Goal
+
+Add a user-facing **intensity** slider for the Reactive Backdrop (Ambient Glow) feature
+that scales the whole effect up and down: how strongly blobs react to the music
+(reactivity), how visible the backdrop is even when quiet (presence), and how fast the
+blobs drift (motion). One knob drives all three for a single "calm ↔ energetic" feel.
+
+## Decisions
+
+| Question | Decision |
+|----------|----------|
+| What does intensity scale? | **Everything** — reactivity, presence, and motion speed together. |
+| Range / default | **0–200%, default 100%.** 100% reproduces today's shipped look exactly. |
+| Behavior at 0% | **Floored to a faint minimum** (~15%): a subtle, slow, dim backdrop. The slider never reaches fully-off; the existing enable toggle remains the only way to fully disable. |
+
+## Architecture
+
+A single scalar `intensity` (effective range `[IntensityFloor, 2.0]`, where `1.0` is the
+shipped default) is threaded into the three places that produce visible output. The value
+flows along the same path as the existing enable toggle:
+
+```
+appsettings.json (Visualizer:Intensity)
+   → MainViewModel.SettingsAmbientBackdropIntensity   (raw 0..2, bound to slider, persisted)
+   → AmbientBackdropViewModel.SetIntensity(raw)        (stores raw, clamps to [0,2])
+   → AmbientBackdropViewModel.Intensity (getter)       (raw floored to IntensityFloor)
+   → AmbientBackdropView render loop / AmbientMath     (consumes effective intensity)
+```
+
+The render loop already polls the ViewModel every frame (the same way it reads
+`TargetEnergy`), so no change-notification event is needed for the visuals.
+
+## Component changes
+
+### 1. `AmbientMath.cs` (pure math)
+
+Add a new tuning constant and an optional `intensity` parameter to the two mapping
+functions. The parameter defaults to `1.0`, so existing callers and tests are unaffected
+and `intensity = 1.0` reproduces today's output exactly.
+
+```csharp
+/// <summary>Minimum effective intensity. The 0% slider position floors to this so the
+/// backdrop stays faintly alive; use the enable toggle to disable entirely.</summary>
+public const double IntensityFloor = 0.15;
+
+// Reactivity: ScaleMin is unscaled so blobs never collapse geometrically.
+public static double BlobScale(double energy, double pulse, double intensity = 1.0)
+    => ScaleMin + (Math.Max(0.0, intensity) * ((e * ScaleEnergySpan) + (p * ScalePulseSpan)));
+
+// Presence: whole opacity scales, clamped to [0,1].
+public static double BlobOpacity(double energy, double intensity = 1.0)
+    => Math.Clamp(Math.Max(0.0, intensity) * (OpacityMin + (e * OpacityEnergySpan)), 0.0, 1.0);
+```
+
+(`e` and `p` are the existing `[0,1]`-clamped energy/pulse.)
+
+- `intensity = 0` → scale floors at `ScaleMin`, opacity → 0.
+- `intensity = 1` → unchanged from today.
+- `intensity = 2` → reactivity span doubles; opacity saturates toward 1.
+
+`IntensityFloor` lives in `AmbientMath` (the home for tuning constants) but is **applied**
+at the ViewModel boundary, not inside these functions — the functions stay honest
+multipliers so they're easy to test at any intensity.
+
+### 2. `AmbientBackdropView.xaml.cs` (motion + render)
+
+- Read `var intensity = _vm.Intensity;` once per frame.
+- Pass it to `AmbientMath.BlobScale(...)` and `AmbientMath.BlobOpacity(...)`.
+- **Drift speed:** replace the raw monotonic clock (`Stopwatch.GetTimestamp() / freq`) with
+  an accumulated phase field:
+
+  ```csharp
+  private double _driftPhase;
+  ...
+  _driftPhase += dt * intensity;   // intensity scales drift SPEED only
+  var t = _driftPhase;             // used in the existing sin/cos terms unchanged
+  ```
+
+  Accumulation (rather than multiplying raw time) keeps the drift phase continuous when the
+  slider moves and across Loaded/Unloaded cycles — preserving the existing "no snap on
+  re-show" behavior. `_driftPhase` persists for the life of the view instance.
+- **Amplitude is left unscaled.** The blob-center offsets are deliberately kept in the
+  window interior so edges only ever see the faded part of each gradient; scaling amplitude
+  could push a bright core to an edge. Only speed scales.
+
+### 3. `AmbientBackdropViewModel.cs`
+
+```csharp
+private double _intensity = 1.0;
+
+/// <summary>Effective intensity (IntensityFloor..2.0) consumed by the renderer.
+/// The raw 0 setting is floored so the backdrop never goes fully dark via the slider.</summary>
+public double Intensity => Math.Max(AmbientMath.IntensityFloor, _intensity);
+
+/// <summary>Sets the raw intensity (0..2) from the settings slider.</summary>
+public void SetIntensity(double raw) => _intensity = Math.Clamp(raw, 0.0, 2.0);
+```
+
+No effect on `IsActive` (intensity and enable are independent), so this does not call
+`UpdateActive()`.
+
+### 4. `MainViewModel.cs`
+
+Exact parallel to `SettingsEnableAmbientBackdrop`:
+
+- `[ObservableProperty] private double _settingsAmbientBackdropIntensity = 1.0;`
+- `partial void OnSettingsAmbientBackdropIntensityChanged(double value) => _ambient.SetIntensity(value);`
+- **Load:** `SettingsAmbientBackdropIntensity = _configuration.GetValue<double>("Visualizer:Intensity", 1.0);`
+  followed by `_ambient.SetIntensity(SettingsAmbientBackdropIntensity);` (alongside the
+  existing `SetEnabled` load).
+- **Save:** `visualizerSection["Intensity"] = SettingsAmbientBackdropIntensity;` in the
+  existing Visualizer section block.
+
+### 5. `MainWindow.xaml`
+
+Below the existing "Reactive backdrop (Ambient Glow)" checkbox row, add a slider row:
+
+- A `Slider` with `Minimum="0"`, `Maximum="2"`, default value bound to
+  `SettingsAmbientBackdropIntensity` (two-way), a sensible `TickFrequency` (e.g. `0.25`).
+- A percentage readout `TextBlock` bound with `StringFormat={}{0:P0}` (1.0 → "100%").
+- The slider's `IsEnabled` binds to `SettingsEnableAmbientBackdrop` so it greys out when the
+  backdrop is toggled off.
+- Follow the existing settings-row layout (label + caption in a `StackPanel`, control in the
+  second column), matching surrounding styles (`BodyText`, `CaptionText`, `TextMutedBrush`).
+
+### 6. `appsettings.json`
+
+Add `"Intensity": 1.0` to the existing `Visualizer` section.
+
+### 7. Tests — `AmbientMathTests.cs`
+
+Add theory cases covering the new parameter; existing no-intensity cases stay valid (they
+assert the `intensity = 1.0` default):
+
+- `BlobScale` with `intensity` 0 / 1 / 2: floor at `ScaleMin` at 0, identity at 1, doubled
+  span at 2.
+- `BlobOpacity` with `intensity` 0 / 1 / 2: 0 at intensity 0, identity at 1, clamp to ≤1 at 2.
+- Negative intensity clamped to 0 (defensive).
+
+## Out of scope
+
+- No new animation modes or color controls.
+- No per-axis sliders (single combined knob only).
+- Amplitude of drift is not scaled (speed only).
+
+## Verification
+
+- `dotnet build` clean.
+- `dotnet test` — new and existing `AmbientMathTests` pass.
+- Manual: launch the app, play audio, drag the slider 0%→200% and confirm the backdrop
+  visibly calms/intensifies; confirm 0% is faint-but-alive, not dead; confirm the slider
+  greys out when the backdrop toggle is off; confirm the value persists across restart.

--- a/src/SendspinClient.Services/Visualization/AmbientMath.cs
+++ b/src/SendspinClient.Services/Visualization/AmbientMath.cs
@@ -81,20 +81,34 @@ public static class AmbientMath
     public const double OpacityEnergySpan = 0.42;
 
     /// <summary>
-    /// Blob render scale from eased energy and the current beat pulse. Energy and pulse are each
-    /// clamped to [0,1], so the result is bounded to [ScaleMin, ScaleMin+ScaleEnergySpan+ScalePulseSpan].
+    /// Minimum effective intensity. The 0% slider position floors to this so the backdrop
+    /// stays faintly alive (subtle, slow, dim) rather than going fully dark. Use the enable
+    /// toggle to disable the effect entirely. Applied at the ViewModel boundary, not here.
     /// </summary>
-    public static double BlobScale(double energy, double pulse)
+    public const double IntensityFloor = 0.15;
+
+    /// <summary>
+    /// Blob render scale from eased energy and the current beat pulse, scaled by
+    /// <paramref name="intensity"/> (1.0 = default). Energy and pulse are clamped to [0,1];
+    /// intensity is clamped to be non-negative. <c>ScaleMin</c> is never scaled, so blobs keep
+    /// their minimum size at intensity 0.
+    /// </summary>
+    public static double BlobScale(double energy, double pulse, double intensity = 1.0)
     {
         var e = Math.Clamp(energy, 0.0, 1.0);
         var p = Math.Clamp(pulse, 0.0, 1.0);
-        return ScaleMin + (e * ScaleEnergySpan) + (p * ScalePulseSpan);
+        var i = Math.Max(0.0, intensity);
+        return ScaleMin + (i * ((e * ScaleEnergySpan) + (p * ScalePulseSpan)));
     }
 
-    /// <summary>Blob opacity from eased energy.</summary>
-    public static double BlobOpacity(double energy)
+    /// <summary>
+    /// Blob opacity from eased energy, scaled by <paramref name="intensity"/> (1.0 = default).
+    /// The whole opacity scales, so intensity 0 is invisible; the result is clamped to [0,1].
+    /// </summary>
+    public static double BlobOpacity(double energy, double intensity = 1.0)
     {
         var e = Math.Clamp(energy, 0.0, 1.0);
-        return OpacityMin + (e * OpacityEnergySpan);
+        var i = Math.Max(0.0, intensity);
+        return Math.Clamp(i * (OpacityMin + (e * OpacityEnergySpan)), 0.0, 1.0);
     }
 }

--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -645,6 +645,36 @@
                                           VerticalAlignment="Center"/>
                             </Grid>
 
+                            <!-- Ambient Glow intensity -->
+                            <Grid Margin="0,0,0,16"
+                                  IsEnabled="{Binding SettingsEnableAmbientBackdrop}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <TextBlock Text="Backdrop intensity" Style="{StaticResource BodyText}"/>
+                                    <TextBlock Text="Scale how strongly the backdrop reacts, glows, and moves"
+                                               Style="{StaticResource CaptionText}"
+                                               Foreground="{StaticResource TextMutedBrush}"
+                                               Margin="0,2,0,0"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Slider Width="160"
+                                            Minimum="0" Maximum="2"
+                                            TickFrequency="0.25" IsSnapToTickEnabled="False"
+                                            Value="{Binding SettingsAmbientBackdropIntensity, Mode=TwoWay}"
+                                            VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding SettingsAmbientBackdropIntensity, StringFormat={}{0:P0}}"
+                                               Style="{StaticResource CaptionText}"
+                                               Foreground="{StaticResource TextMutedBrush}"
+                                               Width="44" TextAlignment="Right"
+                                               Margin="8,0,0,0"
+                                               VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Grid>
+
                             <!-- Hardware Media Keys / SMTC -->
                             <Grid Margin="0,0,0,16">
                                 <Grid.ColumnDefinitions>

--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -645,35 +645,34 @@
                                           VerticalAlignment="Center"/>
                             </Grid>
 
-                            <!-- Ambient Glow intensity -->
-                            <Grid Margin="0,0,0,16"
-                                  IsEnabled="{Binding SettingsEnableAmbientBackdrop}">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                                    <TextBlock Text="Backdrop intensity" Style="{StaticResource BodyText}"/>
-                                    <TextBlock Text="Scale how strongly the backdrop reacts, glows, and moves"
-                                               Style="{StaticResource CaptionText}"
-                                               Foreground="{StaticResource TextMutedBrush}"
-                                               Margin="0,2,0,0"
-                                               TextWrapping="Wrap"/>
-                                </StackPanel>
-                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                                    <Slider Width="160"
+                            <!-- Ambient Glow intensity (hidden when the backdrop is disabled) -->
+                            <StackPanel Margin="0,0,0,16"
+                                        Visibility="{Binding SettingsEnableAmbientBackdrop, Converter={StaticResource BoolToVisibilityConverter}}">
+                                <TextBlock Text="Backdrop intensity" Style="{StaticResource BodyText}"/>
+                                <TextBlock Text="Scale how strongly the backdrop reacts, glows, and moves"
+                                           Style="{StaticResource CaptionText}"
+                                           Foreground="{StaticResource TextMutedBrush}"
+                                           Margin="0,2,0,0"
+                                           TextWrapping="Wrap"/>
+                                <Grid Margin="0,8,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Slider Grid.Column="0"
                                             Minimum="0" Maximum="2"
                                             TickFrequency="0.25" IsSnapToTickEnabled="False"
                                             Value="{Binding SettingsAmbientBackdropIntensity, Mode=TwoWay}"
                                             VerticalAlignment="Center"/>
-                                    <TextBlock Text="{Binding SettingsAmbientBackdropIntensity, StringFormat={}{0:P0}}"
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding SettingsAmbientBackdropIntensity, StringFormat={}{0:P0}}"
                                                Style="{StaticResource CaptionText}"
                                                Foreground="{StaticResource TextMutedBrush}"
                                                Width="44" TextAlignment="Right"
                                                Margin="8,0,0,0"
                                                VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </Grid>
+                                </Grid>
+                            </StackPanel>
 
                             <!-- Hardware Media Keys / SMTC -->
                             <Grid Margin="0,0,0,16">

--- a/src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs
+++ b/src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs
@@ -36,6 +36,18 @@ public partial class AmbientBackdropViewModel : ObservableObject
     public Color BlobColor2 { get; private set; } = FallbackBlob2;
     public Color BlobColor3 { get; private set; } = FallbackBlob3;
 
+    private double _intensity = 1.0;
+
+    /// <summary>
+    /// Effective intensity (<c>IntensityFloor</c>..2.0) consumed by the renderer. The raw 0
+    /// setting is floored so the backdrop never goes fully dark via the slider; use
+    /// <see cref="SetEnabled"/> to disable entirely.
+    /// </summary>
+    public double Intensity => Math.Max(AmbientMath.IntensityFloor, _intensity);
+
+    /// <summary>Sets the raw intensity (0..2) from the settings slider. Does not affect IsActive.</summary>
+    public void SetIntensity(double raw) => _intensity = Math.Clamp(raw, 0.0, 2.0);
+
     /// <summary>Raised when a beat frame arrives; strength is ~0.6 for a beat, 1.0 for a downbeat.</summary>
     public event EventHandler<double>? BeatTriggered;
 

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -285,6 +285,13 @@ public partial class MainViewModel : ViewModelBase
     private bool _settingsEnableAmbientBackdrop = true;
 
     /// <summary>
+    /// Gets or sets the Ambient Glow backdrop intensity (0.0–2.0, 1.0 = default look).
+    /// Scales reactivity, presence, and drift speed together.
+    /// </summary>
+    [ObservableProperty]
+    private double _settingsAmbientBackdropIntensity = 1.0;
+
+    /// <summary>
     /// Gets or sets whether System Media Transport Controls (Windows media keys, lockscreen,
     /// volume-flyout media tile) are wired to playback commands.
     /// </summary>
@@ -1928,6 +1935,11 @@ public partial class MainViewModel : ViewModelBase
         _ambient.SetEnabled(value);
     }
 
+    partial void OnSettingsAmbientBackdropIntensityChanged(double value)
+    {
+        _ambient.SetIntensity(value);
+    }
+
     partial void OnSettingsConnectionModeChanged(string value)
     {
         // Convert display name to config value
@@ -2177,6 +2189,8 @@ public partial class MainViewModel : ViewModelBase
         // Load Ambient Glow backdrop setting and apply immediately
         SettingsEnableAmbientBackdrop = _configuration.GetValue<bool>("Visualizer:Enabled", true);
         _ambient.SetEnabled(SettingsEnableAmbientBackdrop);
+        SettingsAmbientBackdropIntensity = _configuration.GetValue<double>("Visualizer:Intensity", 1.0);
+        _ambient.SetIntensity(SettingsAmbientBackdropIntensity);
 
         // Load SMTC (Windows media key) integration setting and apply immediately
         SettingsEnableMediaKeys = _configuration.GetValue<bool>("MediaControls:Enabled", true);
@@ -2427,6 +2441,7 @@ public partial class MainViewModel : ViewModelBase
             // Update Visualizer section
             var visualizerSection = root["Visualizer"]?.AsObject() ?? new JsonObject();
             visualizerSection["Enabled"] = SettingsEnableAmbientBackdrop;
+            visualizerSection["Intensity"] = SettingsAmbientBackdropIntensity;
             root["Visualizer"] = visualizerSection;
 
             // Update MediaControls section

--- a/src/SendspinClient/Views/AmbientBackdropView.xaml.cs
+++ b/src/SendspinClient/Views/AmbientBackdropView.xaml.cs
@@ -26,6 +26,11 @@ public partial class AmbientBackdropView : UserControl
     private double _pulse;
     private double _pulseTarget;
 
+    // Accumulated drift phase (replaces raw monotonic time). Scaled by intensity each frame so
+    // drift speed tracks the slider; accumulating keeps phase continuous when intensity changes
+    // and across Loaded/Unloaded cycles (persists for the life of the view instance).
+    private double _driftPhase;
+
     // Eased colors (R,G,B as doubles for smooth interpolation).
     private double _b1r, _b1g, _b1b, _b2r, _b2g, _b2b, _b3r, _b3g, _b3b;
     private double _baseR, _baseG, _baseB;
@@ -127,17 +132,19 @@ public partial class AmbientBackdropView : UserControl
         _pulseTarget = AmbientMath.Decay(_pulseTarget, dt, BeatHalfLife);
         _pulse = AmbientMath.Ease(_pulse, _pulseTarget, dt, BeatAttack);
 
-        var scale = AmbientMath.BlobScale(_energy, _pulse);
-        var opacity = AmbientMath.BlobOpacity(_energy);
+        var intensity = _vm.Intensity;
+        var scale = AmbientMath.BlobScale(_energy, _pulse, intensity);
+        var opacity = AmbientMath.BlobOpacity(_energy, intensity);
 
         ApplyBlob(Blob1Scale, Blob1, scale, opacity);
         ApplyBlob(Blob2Scale, Blob2, scale * 0.95, opacity * 0.9);
         ApplyBlob(Blob3Scale, Blob3, scale * 1.05, opacity * 0.8);
 
-        // Idle drift: slow sinusoidal motion so the scene is alive at low energy. Use a monotonic
-        // timestamp (not the restartable _clock) so the drift phase is continuous across
-        // Loaded/Unloaded cycles and does not snap on re-show.
-        var t = Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency;
+        // Idle drift: slow sinusoidal motion so the scene is alive at low energy. Accumulate a
+        // phase scaled by intensity so drift SPEED tracks the slider; accumulation keeps the phase
+        // continuous across intensity changes and Loaded/Unloaded cycles (no snap on re-show).
+        _driftPhase += dt * intensity;
+        var t = _driftPhase;
         // Blob centers sit in the interior (base offsets) so the window edges only ever see the
         // soft, faded part of each gradient — never a hard-clipped bright core. Drift is gentle.
         Blob1Translate.X = -110.0 + (Math.Sin(t * 0.13) * 55.0);

--- a/src/SendspinClient/appsettings.json
+++ b/src/SendspinClient/appsettings.json
@@ -42,6 +42,7 @@
   },
   "Visualizer": {
     "Enabled": true,
+    "Intensity": 1.0,
     "RateMax": 30,
     "BufferCapacity": 4096
   }

--- a/tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
+++ b/tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
@@ -119,7 +119,7 @@ public class AmbientMathTests
     }
 
     [Theory]
-    [InlineData(1.0, 0.0, 0.0, 0.82)]   // intensity 0 -> floor at ScaleMin
+    [InlineData(1.0, 0.0, 0.0, 0.82)]   // intensity 0 -> only ScaleMin remains (no IntensityFloor here)
     [InlineData(1.0, 0.0, 1.0, 1.32)]   // intensity 1 -> identity (ScaleMin + 0.50)
     [InlineData(1.0, 0.0, 2.0, 1.82)]   // intensity 2 -> doubled energy span (ScaleMin + 1.00)
     [InlineData(1.0, 1.0, 2.0, 2.52)]   // intensity 2 with full pulse: 0.82 + 2*(0.50+0.35)
@@ -142,6 +142,12 @@ public class AmbientMathTests
     public void BlobScale_NegativeIntensity_ClampsToZeroReactivity()
     {
         Assert.Equal(0.82, AmbientMath.BlobScale(1.0, 1.0, -5.0), 0.0001);
+    }
+
+    [Fact]
+    public void BlobOpacity_NegativeIntensity_ClampsToInvisible()
+    {
+        Assert.Equal(0.0, AmbientMath.BlobOpacity(1.0, -5.0), 0.0001);
     }
 
     [Fact]

--- a/tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
+++ b/tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
@@ -117,4 +117,36 @@ public class AmbientMathTests
         Assert.Equal(0.55, AmbientMath.BlobOpacity(-1.0), 0.0001);
         Assert.Equal(0.97, AmbientMath.BlobOpacity(2.0), 0.0001);
     }
+
+    [Theory]
+    [InlineData(1.0, 0.0, 0.0, 0.82)]   // intensity 0 -> floor at ScaleMin
+    [InlineData(1.0, 0.0, 1.0, 1.32)]   // intensity 1 -> identity (ScaleMin + 0.50)
+    [InlineData(1.0, 0.0, 2.0, 1.82)]   // intensity 2 -> doubled energy span (ScaleMin + 1.00)
+    [InlineData(1.0, 1.0, 2.0, 2.52)]   // intensity 2 with full pulse: 0.82 + 2*(0.50+0.35)
+    public void BlobScale_ScalesReactivityByIntensity(double energy, double pulse, double intensity, double expected)
+    {
+        Assert.Equal(expected, AmbientMath.BlobScale(energy, pulse, intensity), 0.0001);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0, 0.0)]    // intensity 0 -> invisible
+    [InlineData(0.0, 1.0, 0.55)]   // intensity 1 -> identity
+    [InlineData(0.0, 2.0, 1.0)]    // intensity 2 -> 2*0.55 = 1.10 clamped to 1.0
+    [InlineData(1.0, 2.0, 1.0)]    // energy 1, intensity 2 -> clamped to 1.0
+    public void BlobOpacity_ScalesPresenceByIntensity(double energy, double intensity, double expected)
+    {
+        Assert.Equal(expected, AmbientMath.BlobOpacity(energy, intensity), 0.0001);
+    }
+
+    [Fact]
+    public void BlobScale_NegativeIntensity_ClampsToZeroReactivity()
+    {
+        Assert.Equal(0.82, AmbientMath.BlobScale(1.0, 1.0, -5.0), 0.0001);
+    }
+
+    [Fact]
+    public void IntensityFloor_IsFaintButNonZero()
+    {
+        Assert.InRange(AmbientMath.IntensityFloor, 0.05, 0.30);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a **Backdrop intensity** slider (0–200%, default 100%) to Settings for the Reactive Backdrop (Ambient Glow) feature. One knob scales the whole effect together:

- **Reactivity** — how strongly blobs grow/brighten/pulse with loudness and beats
- **Presence** — overall blob opacity/visibility
- **Motion** — drift speed

100% reproduces the current shipped look exactly. The 0% end is floored to a faint minimum (~15%) so the backdrop stays subtly alive rather than going dark — the existing enable toggle remains the way to fully disable it.

## How it works

A single `intensity` scalar flows along the same path as the existing enable toggle:

`appsettings.json (Visualizer:Intensity)` → `MainViewModel.SettingsAmbientBackdropIntensity` (bound to the slider, persisted) → `AmbientBackdropViewModel.SetIntensity` → floored `Intensity` getter → `AmbientBackdropView` render loop → `AmbientMath`.

- `AmbientMath.BlobScale`/`BlobOpacity` gain an optional `intensity` param (default 1.0, so existing behavior/tests are unchanged); `ScaleMin` stays unscaled so blobs never collapse.
- The floor is applied at exactly one place (the ViewModel getter); the math functions stay honest multipliers.
- Drift uses an accumulated phase (`_driftPhase += dt * intensity`) so speed tracks the slider while staying continuous across slider changes and show/hide (no snap). Drift amplitude is intentionally not scaled.
- The settings row stacks vertically (title / caption / slider) and is hidden when the backdrop is disabled.

## Tests

- 11 new `AmbientMathTests` cases covering intensity at 0 / 1 / 2, clamping, and the floor constant.
- Full suite: 34 passed, 0 failed. Solution build: 0 errors.

## Test Plan

- [ ] Play audio, drag the slider 0% → 200%: backdrop calms then intensifies (size, glow, drift speed)
- [ ] At 0%: faint and slow but still alive (not black/frozen)
- [ ] At 200%: bold/energetic, opacity saturates
- [ ] Uncheck "Reactive backdrop": the intensity title/caption/slider block disappears entirely
- [ ] Change the value, restart the app: value persists (`%LOCALAPPDATA%\Sendspin\appsettings.json` → `Visualizer:Intensity`)