### PR TITLE
Backdrop style picker + Breathing Art

### DIFF
--- a/docs/superpowers/plans/2026-06-05-backdrop-style-breathing-art.md
+++ b/docs/superpowers/plans/2026-06-05-backdrop-style-breathing-art.md
@@ -1,0 +1,737 @@
+# Backdrop Style Picker + Breathing Art Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the backdrop enable checkbox with a Off / Ambient Glow / Breathing Art dropdown, and add the Breathing Art style (album art scales + glows with the music), with the existing intensity slider scaling whichever style is active.
+
+**Architecture:** `AmbientBackdropViewModel` gains a `Mode` (Off/AmbientGlow/BreathingArt) that gates two consumers of its existing reactive signal: the current `AmbientBackdropView` (blobs, shown only in AmbientGlow) and a new `BreathingArtAnimator` (scales+glows the album-art element, only in BreathingArt). Mode flows from a new `Visualizer:Mode` config through `MainViewModel.SettingsBackdropStyle` (a ComboBox), migrating from the legacy `Visualizer:Enabled` bool.
+
+**Tech Stack:** .NET 10, WPF, CommunityToolkit.Mvvm (source-generated `[ObservableProperty]` + `OnXChanged` partials), xUnit.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-backdrop-style-breathing-art-design.md`
+
+**Base:** branched off master after PR #36 (intensity slider) merged, so `AmbientMath.IntensityFloor`, the 3-arg `BlobScale`/`BlobOpacity`, `AmbientBackdropViewModel.Intensity`/`SetIntensity`, `MainViewModel.SettingsAmbientBackdropIntensity`, and the intensity slider all already exist.
+
+---
+
+## File Structure
+
+- **Modify** `src/SendspinClient.Services/Visualization/AmbientMath.cs` — add `BreathScale`/`BreathGlow` + constants.
+- **Modify** `tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs` — breathing tests.
+- **Create** `src/SendspinClient/ViewModels/BackdropMode.cs` — the mode enum.
+- **Modify** `src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs` — replace `Enabled`/`SetEnabled` with `Mode`/`SetMode`.
+- **Modify** `src/SendspinClient/ViewModels/MainViewModel.cs` — style property, list, mapping, load/save migration.
+- **Modify** `src/SendspinClient/MainWindow.xaml` — style ComboBox; slider visibility; album-art wrapper.
+- **Modify** `src/SendspinClient/MainWindow.xaml.cs` — construct the `BreathingArtAnimator`.
+- **Create** `src/SendspinClient/Views/BreathingArtAnimator.cs` — the breathing render loop.
+- **Modify** `src/SendspinClient/appsettings.json` — `Visualizer:Mode` default.
+
+---
+
+## Task 1: Breathing math in `AmbientMath` (TDD)
+
+**Files:**
+- Modify: `src/SendspinClient.Services/Visualization/AmbientMath.cs`
+- Test: `tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `AmbientMathTests.cs` inside the `AmbientMathTests` class:
+
+```csharp
+[Theory]
+[InlineData(0.0, 0.0, 1.0, 1.0)]    // rest = 1.0 (art never shrinks)
+[InlineData(1.0, 0.0, 1.0, 1.06)]   // +6% energy span at intensity 1
+[InlineData(1.0, 1.0, 1.0, 1.10)]   // +6% energy +4% pulse
+[InlineData(1.0, 1.0, 2.0, 1.20)]   // intensity 2 doubles the reactive part
+[InlineData(1.0, 1.0, 0.0, 1.0)]    // intensity 0 -> rest
+public void BreathScale_RestsAtOneAndScalesByIntensity(double energy, double pulse, double intensity, double expected)
+{
+    Assert.Equal(expected, AmbientMath.BreathScale(energy, pulse, intensity), 0.0001);
+}
+
+[Theory]
+[InlineData(0.0, 1.0, 0.15)]   // quiet -> faint base aura at intensity 1
+[InlineData(1.0, 1.0, 1.0)]    // full energy -> clamp to 1
+[InlineData(1.0, 2.0, 1.0)]    // intensity 2 -> clamp to 1
+[InlineData(0.0, 0.0, 0.0)]    // intensity 0 -> no glow
+public void BreathGlow_BaseAuraScalesAndClamps(double energy, double intensity, double expected)
+{
+    Assert.Equal(expected, AmbientMath.BreathGlow(energy, intensity), 0.0001);
+}
+
+[Fact]
+public void BreathScale_NegativeIntensity_RestsAtOne()
+{
+    Assert.Equal(1.0, AmbientMath.BreathScale(1.0, 1.0, -3.0), 0.0001);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error)**
+
+Run: `dotnet test tests/SendspinClient.Services.Tests/SendspinClient.Services.Tests.csproj --filter "FullyQualifiedName~AmbientMathTests" --nologo`
+Expected: FAIL — `BreathScale`/`BreathGlow` undefined.
+
+- [ ] **Step 3: Add constants + functions**
+
+In `AmbientMath.cs`, after the `BlobOpacity` method (before the final closing brace of the class), add:
+
+```csharp
+    /// <summary>Album-art breathe scale span from energy (0..1) at intensity 1.</summary>
+    public const double BreathScaleEnergySpan = 0.06;
+
+    /// <summary>Album-art breathe scale span from a full beat pulse at intensity 1.</summary>
+    public const double BreathScalePulseSpan = 0.04;
+
+    /// <summary>Baseline glow strength so the art keeps a faint aura even when quiet.</summary>
+    public const double BreathGlowBase = 0.15;
+
+    /// <summary>Glow strength span contributed by energy (0..1).</summary>
+    public const double BreathGlowEnergySpan = 0.85;
+
+    /// <summary>
+    /// Album-art breathe scale from eased energy and beat pulse, scaled by
+    /// <paramref name="intensity"/> (1.0 = default). Rests at 1.0 (the art is never shrunk);
+    /// energy/pulse are clamped to [0,1] and intensity to non-negative.
+    /// </summary>
+    public static double BreathScale(double energy, double pulse, double intensity = 1.0)
+    {
+        var e = Math.Clamp(energy, 0.0, 1.0);
+        var p = Math.Clamp(pulse, 0.0, 1.0);
+        var i = Math.Max(0.0, intensity);
+        return 1.0 + (i * ((e * BreathScaleEnergySpan) + (p * BreathScalePulseSpan)));
+    }
+
+    /// <summary>
+    /// Album-art glow strength (0..1) from eased energy, scaled by <paramref name="intensity"/>
+    /// (1.0 = default). The animator maps this to blur/opacity. Clamped to [0,1].
+    /// </summary>
+    public static double BreathGlow(double energy, double intensity = 1.0)
+    {
+        var e = Math.Clamp(energy, 0.0, 1.0);
+        var i = Math.Max(0.0, intensity);
+        return Math.Clamp(i * (BreathGlowBase + (e * BreathGlowEnergySpan)), 0.0, 1.0);
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/SendspinClient.Services.Tests/SendspinClient.Services.Tests.csproj --filter "FullyQualifiedName~AmbientMathTests" --nologo`
+Expected: PASS — all existing + new (9 new) cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/SendspinClient.Services/Visualization/AmbientMath.cs tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
+git commit -m "feat: add breathing-art scale and glow math"
+```
+
+---
+
+## Task 2: Mode model + plumbing (enum, ViewModel, MainViewModel)
+
+The `Enabled`→`Mode` type change ripples across the ViewModel and MainViewModel, so they change together to keep the build green. (The XAML still binds the old `SettingsEnableAmbientBackdrop` until Task 3 — that produces only a non-fatal runtime binding warning, not a build error.)
+
+**Files:**
+- Create: `src/SendspinClient/ViewModels/BackdropMode.cs`
+- Modify: `src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs`
+- Modify: `src/SendspinClient/ViewModels/MainViewModel.cs`
+
+- [ ] **Step 1: Create the enum**
+
+Create `src/SendspinClient/ViewModels/BackdropMode.cs`:
+
+```csharp
+namespace SendspinClient.ViewModels;
+
+/// <summary>Which ambient visualization (if any) is shown.</summary>
+public enum BackdropMode
+{
+    Off,
+    AmbientGlow,
+    BreathingArt,
+}
+```
+
+- [ ] **Step 2: ViewModel — replace `Enabled` with `Mode`**
+
+In `AmbientBackdropViewModel.cs`:
+
+(a) Replace the `Enabled` property block:
+```csharp
+    /// <summary>Whether the feature is enabled in settings.</summary>
+    [ObservableProperty]
+    private bool _enabled = true;
+```
+with:
+```csharp
+    /// <summary>The selected backdrop style. The blob backdrop renders only in AmbientGlow mode.</summary>
+    [ObservableProperty]
+    private BackdropMode _mode = BackdropMode.AmbientGlow;
+
+    partial void OnModeChanged(BackdropMode value) => UpdateActive();
+```
+
+(b) Update the `IsActive` doc comment:
+```csharp
+    /// <summary>True when a real color palette has been received and the feature is enabled.</summary>
+```
+to:
+```csharp
+    /// <summary>True when the style is Ambient Glow and a real color palette has been received.</summary>
+```
+
+(c) Fix the `Intensity` doc comment's stale cref (it referenced `SetEnabled`):
+```csharp
+    /// setting is floored so the backdrop never goes fully dark via the slider; use
+    /// <see cref="SetEnabled"/> to disable entirely.
+```
+to:
+```csharp
+    /// setting is floored so the backdrop never goes fully dark via the slider; choose the Off
+    /// style (<see cref="SetMode"/>) to disable entirely.
+```
+
+(d) Replace the `SetEnabled` method:
+```csharp
+    /// <summary>Enables/disables the effect (from the settings toggle). Immediate, no reconnect.</summary>
+    public void SetEnabled(bool enabled)
+    {
+        Enabled = enabled;
+        UpdateActive();
+    }
+```
+with:
+```csharp
+    /// <summary>Sets the backdrop style (from the settings dropdown). Immediate, no reconnect.</summary>
+    public void SetMode(BackdropMode mode) => Mode = mode;
+```
+
+(e) Replace `UpdateActive`:
+```csharp
+    private void UpdateActive() => IsActive = Enabled && _hasPalette;
+```
+with:
+```csharp
+    private void UpdateActive() => IsActive = Mode == BackdropMode.AmbientGlow && _hasPalette;
+```
+
+- [ ] **Step 3: MainViewModel — replace the enable property with a style property**
+
+In `MainViewModel.cs`, replace:
+```csharp
+    /// <summary>
+    /// Gets or sets whether the Ambient Glow reactive backdrop is enabled.
+    /// </summary>
+    [ObservableProperty]
+    private bool _settingsEnableAmbientBackdrop = true;
+```
+with:
+```csharp
+    /// <summary>Available backdrop style options for the settings dropdown.</summary>
+    public string[] AvailableBackdropStyles { get; } = new[]
+    {
+        "Off",
+        "Ambient Glow",
+        "Breathing Art",
+    };
+
+    /// <summary>Gets or sets the selected backdrop style (display string, bound to the dropdown).</summary>
+    [ObservableProperty]
+    private string _settingsBackdropStyle = "Ambient Glow";
+
+    /// <summary>True when a style other than Off is selected (drives the intensity slider's visibility).</summary>
+    public bool IsBackdropEnabled => SettingsBackdropStyle != "Off";
+```
+
+- [ ] **Step 4: MainViewModel — replace the change handler + add mapping helpers**
+
+In `MainViewModel.cs`, replace:
+```csharp
+    partial void OnSettingsEnableAmbientBackdropChanged(bool value)
+    {
+        _ambient.SetEnabled(value);
+    }
+```
+with:
+```csharp
+    partial void OnSettingsBackdropStyleChanged(string value)
+    {
+        _ambient.SetMode(StyleToMode(value));
+        OnPropertyChanged(nameof(IsBackdropEnabled));
+    }
+
+    private static BackdropMode StyleToMode(string style) => style switch
+    {
+        "Off" => BackdropMode.Off,
+        "Breathing Art" => BackdropMode.BreathingArt,
+        _ => BackdropMode.AmbientGlow,
+    };
+
+    private static string StyleToToken(string style) => style switch
+    {
+        "Off" => "Off",
+        "Breathing Art" => "BreathingArt",
+        _ => "AmbientGlow",
+    };
+
+    private static string TokenToStyle(string token) => token switch
+    {
+        "Off" => "Off",
+        "BreathingArt" => "Breathing Art",
+        _ => "Ambient Glow",
+    };
+```
+
+- [ ] **Step 5: MainViewModel — load with migration**
+
+In `MainViewModel.cs`, replace:
+```csharp
+        // Load Ambient Glow backdrop setting and apply immediately
+        SettingsEnableAmbientBackdrop = _configuration.GetValue<bool>("Visualizer:Enabled", true);
+        _ambient.SetEnabled(SettingsEnableAmbientBackdrop);
+        SettingsAmbientBackdropIntensity = _configuration.GetValue<double>("Visualizer:Intensity", 1.0);
+        _ambient.SetIntensity(SettingsAmbientBackdropIntensity);
+```
+with:
+```csharp
+        // Load backdrop style (migrating from the legacy Visualizer:Enabled bool) and apply immediately
+        var backdropModeToken = _configuration.GetValue<string?>("Visualizer:Mode", null);
+        if (string.IsNullOrEmpty(backdropModeToken))
+        {
+            backdropModeToken = _configuration.GetValue<bool>("Visualizer:Enabled", true) ? "AmbientGlow" : "Off";
+        }
+        SettingsBackdropStyle = TokenToStyle(backdropModeToken);
+        _ambient.SetMode(StyleToMode(SettingsBackdropStyle));
+        SettingsAmbientBackdropIntensity = _configuration.GetValue<double>("Visualizer:Intensity", 1.0);
+        _ambient.SetIntensity(SettingsAmbientBackdropIntensity);
+```
+
+- [ ] **Step 6: MainViewModel — save the mode (keep legacy key in sync)**
+
+In `MainViewModel.cs`, replace:
+```csharp
+            var visualizerSection = root["Visualizer"]?.AsObject() ?? new JsonObject();
+            visualizerSection["Enabled"] = SettingsEnableAmbientBackdrop;
+            visualizerSection["Intensity"] = SettingsAmbientBackdropIntensity;
+            root["Visualizer"] = visualizerSection;
+```
+with:
+```csharp
+            var visualizerSection = root["Visualizer"]?.AsObject() ?? new JsonObject();
+            visualizerSection["Mode"] = StyleToToken(SettingsBackdropStyle);
+            visualizerSection["Enabled"] = SettingsBackdropStyle != "Off";
+            visualizerSection["Intensity"] = SettingsAmbientBackdropIntensity;
+            root["Visualizer"] = visualizerSection;
+```
+
+- [ ] **Step 7: Build**
+
+Run: `dotnet build src/SendspinClient/SendspinClient.csproj --nologo`
+Expected: Build succeeded, 0 errors. (Pre-existing warnings in unrelated files are fine.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/SendspinClient/ViewModels/BackdropMode.cs src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs src/SendspinClient/ViewModels/MainViewModel.cs
+git commit -m "feat: replace backdrop enable flag with Off/AmbientGlow/BreathingArt mode"
+```
+
+---
+
+## Task 3: Settings UI — style dropdown + slider visibility
+
+**Files:**
+- Modify: `src/SendspinClient/MainWindow.xaml`
+
+- [ ] **Step 1: Replace the checkbox row with a style dropdown**
+
+In `MainWindow.xaml`, replace this block (the "Ambient Glow reactive backdrop" Grid):
+```xml
+                            <!-- Ambient Glow reactive backdrop -->
+                            <Grid Margin="0,0,0,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0">
+                                    <TextBlock Text="Reactive backdrop (Ambient Glow)" Style="{StaticResource BodyText}"/>
+                                    <TextBlock Text="Animate the background with colors and energy from the music"
+                                               Style="{StaticResource CaptionText}"
+                                               Foreground="{StaticResource TextMutedBrush}"
+                                               Margin="0,2,0,0"/>
+                                </StackPanel>
+                                <CheckBox Grid.Column="1"
+                                          IsChecked="{Binding SettingsEnableAmbientBackdrop}"
+                                          VerticalAlignment="Center"/>
+                            </Grid>
+```
+with:
+```xml
+                            <!-- Backdrop style -->
+                            <StackPanel Margin="0,0,0,16">
+                                <TextBlock Text="Backdrop style" Style="{StaticResource BodyText}"/>
+                                <TextBlock Text="Animate the window with the music, or breathe the album art — or turn it off"
+                                           Style="{StaticResource CaptionText}"
+                                           Foreground="{StaticResource TextMutedBrush}"
+                                           Margin="0,2,0,0"
+                                           TextWrapping="Wrap"/>
+                                <ComboBox Margin="0,8,0,0"
+                                          HorizontalAlignment="Stretch"
+                                          ItemsSource="{Binding AvailableBackdropStyles}"
+                                          SelectedItem="{Binding SettingsBackdropStyle}"
+                                          Style="{StaticResource DarkComboBox}"
+                                          ItemContainerStyle="{StaticResource DarkComboBoxItem}"/>
+                            </StackPanel>
+```
+
+- [ ] **Step 2: Point the intensity block's visibility at the new property**
+
+In the same file, in the intensity `StackPanel` immediately below, replace:
+```xml
+                                        Visibility="{Binding SettingsEnableAmbientBackdrop, Converter={StaticResource BoolToVisibilityConverter}}">
+```
+with:
+```xml
+                                        Visibility="{Binding IsBackdropEnabled, Converter={StaticResource BoolToVisibilityConverter}}">
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/SendspinClient/SendspinClient.csproj --nologo`
+Expected: Build succeeded, 0 errors (XAML parses; `DarkComboBox`/`DarkComboBoxItem`/`BoolToVisibilityConverter` already resolve in this view).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/SendspinClient/MainWindow.xaml
+git commit -m "feat: replace backdrop checkbox with style dropdown in settings"
+```
+
+---
+
+## Task 4: `BreathingArtAnimator`
+
+**Files:**
+- Create: `src/SendspinClient/Views/BreathingArtAnimator.cs`
+
+- [ ] **Step 1: Create the animator class**
+
+Create `src/SendspinClient/Views/BreathingArtAnimator.cs`:
+
+```csharp
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using SendspinClient.Services.Visualization;
+using SendspinClient.ViewModels;
+
+namespace SendspinClient.Views;
+
+/// <summary>
+/// Drives the Breathing Art backdrop style: scales the album-art element and adds a palette-accent
+/// glow that ease toward the loudness/beat signal from <see cref="AmbientBackdropViewModel"/>.
+/// Runs a render loop only while <see cref="AmbientBackdropViewModel.Mode"/> is
+/// <see cref="BackdropMode.BreathingArt"/>; in any other mode the art rests at scale 1.0 with no glow.
+/// Mirrors the easing constants used by <c>AmbientBackdropView</c>.
+/// </summary>
+public sealed class BreathingArtAnimator
+{
+    private const double EnergyTimeConstant = 0.45;
+    private const double BeatHalfLife = 0.30;
+    private const double BeatAttack = 0.06;
+    private const double GlowColorTimeConstant = 0.8;
+
+    // BreathGlow (0..1) -> effect mapping (view concern).
+    private const double MaxGlowBlur = 40.0;
+    private const double MaxGlowOpacity = 0.85;
+
+    private readonly ScaleTransform _scale;
+    private readonly DropShadowEffect _glow;
+    private readonly AmbientBackdropViewModel _vm;
+
+    private readonly Stopwatch _clock = new();
+    private long _lastTicks;
+
+    private double _energy;
+    private double _pulse;
+    private double _pulseTarget;
+
+    private double _glowR, _glowG, _glowB;
+    private bool _glowColorInitialized;
+
+    private bool _hooked;
+
+    public BreathingArtAnimator(ScaleTransform scale, DropShadowEffect glow, AmbientBackdropViewModel vm)
+    {
+        _scale = scale;
+        _glow = glow;
+        _vm = vm;
+        _vm.PropertyChanged += OnVmPropertyChanged;
+        ApplyModeState();
+    }
+
+    private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(AmbientBackdropViewModel.Mode))
+        {
+            ApplyModeState();
+        }
+    }
+
+    private void ApplyModeState()
+    {
+        if (_vm.Mode == BackdropMode.BreathingArt)
+        {
+            Hook();
+        }
+        else
+        {
+            Unhook();
+            ResetToRest();
+        }
+    }
+
+    private void Hook()
+    {
+        if (_hooked)
+        {
+            return;
+        }
+
+        _clock.Restart();
+        _lastTicks = _clock.ElapsedTicks;
+        _vm.BeatTriggered += OnBeat;
+        CompositionTarget.Rendering += OnRendering;
+        _hooked = true;
+    }
+
+    private void Unhook()
+    {
+        if (!_hooked)
+        {
+            return;
+        }
+
+        CompositionTarget.Rendering -= OnRendering;
+        _vm.BeatTriggered -= OnBeat;
+        _clock.Stop();
+        _hooked = false;
+    }
+
+    private void OnBeat(object? sender, double strength) => _pulseTarget += strength;
+
+    private void ResetToRest()
+    {
+        _energy = 0.0;
+        _pulse = 0.0;
+        _pulseTarget = 0.0;
+        _scale.ScaleX = 1.0;
+        _scale.ScaleY = 1.0;
+        _glow.BlurRadius = 0.0;
+        _glow.Opacity = 0.0;
+    }
+
+    private void OnRendering(object? sender, EventArgs e)
+    {
+        var now = _clock.ElapsedTicks;
+        var dt = (now - _lastTicks) / (double)Stopwatch.Frequency;
+        _lastTicks = now;
+        if (dt <= 0.0)
+        {
+            return;
+        }
+
+        _energy = AmbientMath.Ease(_energy, _vm.TargetEnergy, dt, EnergyTimeConstant);
+        _pulseTarget = AmbientMath.Decay(_pulseTarget, dt, BeatHalfLife);
+        _pulse = AmbientMath.Ease(_pulse, _pulseTarget, dt, BeatAttack);
+
+        var intensity = _vm.Intensity;
+        var scale = AmbientMath.BreathScale(_energy, _pulse, intensity);
+        _scale.ScaleX = scale;
+        _scale.ScaleY = scale;
+
+        var g = AmbientMath.BreathGlow(_energy, intensity);
+        _glow.BlurRadius = g * MaxGlowBlur;
+        _glow.Opacity = g * MaxGlowOpacity;
+
+        var c = _vm.BlobColor2;
+        if (!_glowColorInitialized)
+        {
+            (_glowR, _glowG, _glowB) = (c.R, c.G, c.B);
+            _glowColorInitialized = true;
+        }
+
+        _glowR = AmbientMath.Ease(_glowR, c.R, dt, GlowColorTimeConstant);
+        _glowG = AmbientMath.Ease(_glowG, c.G, dt, GlowColorTimeConstant);
+        _glowB = AmbientMath.Ease(_glowB, c.B, dt, GlowColorTimeConstant);
+        _glow.Color = Color.FromRgb(
+            (byte)Math.Clamp(_glowR, 0, 255),
+            (byte)Math.Clamp(_glowG, 0, 255),
+            (byte)Math.Clamp(_glowB, 0, 255));
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build src/SendspinClient/SendspinClient.csproj --nologo`
+Expected: Build succeeded, 0 errors (uses `AmbientMath.Ease`/`Decay`/`BreathScale`/`BreathGlow`, all present).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/SendspinClient/Views/BreathingArtAnimator.cs
+git commit -m "feat: add BreathingArtAnimator for album-art breathing style"
+```
+
+---
+
+## Task 5: Album-art wrapper + wire the animator
+
+**Files:**
+- Modify: `src/SendspinClient/MainWindow.xaml`
+- Modify: `src/SendspinClient/MainWindow.xaml.cs`
+
+- [ ] **Step 1: Wrap the album-art Border with the breathing transform + glow**
+
+In `MainWindow.xaml`, replace the opening of the album-art Border:
+```xml
+                    <!-- Large Album Art with Shadow (280x280) -->
+                    <Border Width="280" Height="280"
+                            CornerRadius="12"
+                            HorizontalAlignment="Center"
+                            Margin="0,0,0,24">
+```
+with (add the outer wrapper; the inner Border loses its `HorizontalAlignment`/`Margin`, which move to the wrapper):
+```xml
+                    <!-- Large Album Art with Shadow (280x280); outer wrapper carries the Breathing Art transform + glow -->
+                    <Border x:Name="AlbumArtBreath"
+                            HorizontalAlignment="Center"
+                            Margin="0,0,0,24"
+                            RenderTransformOrigin="0.5,0.5">
+                        <Border.RenderTransform>
+                            <ScaleTransform x:Name="AlbumArtScale"/>
+                        </Border.RenderTransform>
+                        <Border.Effect>
+                            <DropShadowEffect x:Name="AlbumArtGlow" ShadowDepth="0" BlurRadius="0" Opacity="0"/>
+                        </Border.Effect>
+                        <Border Width="280" Height="280"
+                                CornerRadius="12">
+```
+
+Then find the matching close of the original album-art Border — the `</Border>` that pairs with the `<Border Width="280" Height="280" ...>` (immediately after the inner artwork/placeholder `</Grid>`):
+```xml
+                        </Grid>
+                    </Border>
+```
+and add one more closing `</Border>` for the new wrapper:
+```xml
+                        </Grid>
+                        </Border>
+                    </Border>
+```
+
+(Net: the inner `<Border Width="280" Height="280" CornerRadius="12">` keeps its `DropShadowEffect` black depth-shadow and the artwork `Grid` unchanged; only the outer wrapper is new.)
+
+- [ ] **Step 2: Construct the animator in code-behind**
+
+In `MainWindow.xaml.cs`, add a field next to the constants:
+```csharp
+    private BreathingArtAnimator? _breathingAnimator;
+```
+
+Add `using SendspinClient.Views;` if not already present (the class lives in that namespace; `MainWindow` is in `SendspinClient`).
+
+In `OnDataContextChanged`, after the existing `newVm` subscription block, add:
+```csharp
+        if (_breathingAnimator is null && e.NewValue is MainViewModel mainVm)
+        {
+            _breathingAnimator = new BreathingArtAnimator(AlbumArtScale, AlbumArtGlow, mainVm.Ambient);
+        }
+```
+
+(`AlbumArtScale` and `AlbumArtGlow` are the `x:Name`d elements from Step 1 — available as generated fields after `InitializeComponent`. The DataContext is set once at startup, and the `_breathingAnimator is null` guard keeps it a single instance.)
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/SendspinClient/SendspinClient.csproj --nologo`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/SendspinClient/MainWindow.xaml src/SendspinClient/MainWindow.xaml.cs
+git commit -m "feat: wire breathing animator to the album art element"
+```
+
+---
+
+## Task 6: Config default
+
+**Files:**
+- Modify: `src/SendspinClient/appsettings.json`
+
+- [ ] **Step 1: Add the Mode default**
+
+In `appsettings.json`, change the `Visualizer` section from:
+```json
+  "Visualizer": {
+    "Enabled": true,
+    "Intensity": 1.0,
+    "RateMax": 30,
+    "BufferCapacity": 4096
+  }
+```
+to:
+```json
+  "Visualizer": {
+    "Mode": "AmbientGlow",
+    "Enabled": true,
+    "Intensity": 1.0,
+    "RateMax": 30,
+    "BufferCapacity": 4096
+  }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/SendspinClient/appsettings.json
+git commit -m "chore: add Visualizer:Mode default to appsettings"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build SendspinClient.sln --nologo`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 2: Full test run**
+
+Run: `dotnet test --nologo`
+Expected: All tests pass (existing + new breathing-math cases).
+
+- [ ] **Step 3: Manual smoke test**
+
+Run `dotnet run --project src/SendspinClient/SendspinClient.csproj`, connect, play audio, open Settings:
+- "Backdrop style" dropdown shows Off / Ambient Glow / Breathing Art and switches live (no reconnect).
+- **Ambient Glow:** the blob backdrop behaves as before; album art is static.
+- **Breathing Art:** the blob backdrop is gone; the album art gently scales and glows (palette-accent) with the music; beats give a small bump.
+- **Off:** neither effect; the intensity slider is hidden.
+- Intensity slider scales the active style (Glow and Breathing); at 0% the active style is faint/subtle, not dead.
+- Change style, restart the app: selection persists (`%LOCALAPPDATA%\Sendspin\appsettings.json` → `Visualizer:Mode`).
+- A config with only the legacy `Visualizer:Enabled` (no `Mode`) opens as Ambient Glow (true) or Off (false).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** mode enum (T2), VM mode + IsActive gating (T2), breathing math (T1), animator (T4), album-art wrapper + wiring (T5), dropdown + slider visibility (T3), MainViewModel style/migration/save (T2), config default (T6), tests (T1). All spec sections mapped.
+- **Type/name consistency:** `BackdropMode.{Off,AmbientGlow,BreathingArt}`, `SetMode`, `Mode`, `SettingsBackdropStyle`, `AvailableBackdropStyles`, `IsBackdropEnabled`, `StyleToMode`/`StyleToToken`/`TokenToStyle`, `AlbumArtScale`/`AlbumArtGlow`/`AlbumArtBreath`, `BreathScale`/`BreathGlow` are used identically across tasks.
+- **Build-green ordering:** T2 changes VM+MainViewModel together (the type change is atomic); the XAML still references the removed `SettingsEnableAmbientBackdrop` between T2 and T3, which is a non-fatal WPF runtime binding warning, not a build error — resolved in T3.
+- **Floor reuse:** breathing uses `vm.Intensity` (already floored), so 0% is faint-but-alive in both styles with no new floor logic.

--- a/docs/superpowers/specs/2026-06-05-backdrop-style-breathing-art-design.md
+++ b/docs/superpowers/specs/2026-06-05-backdrop-style-breathing-art-design.md
@@ -109,8 +109,9 @@ A small class (not a UserControl) that animates a target element. Constructed wi
 easing in `AmbientBackdropView`:
 
 - Subscribes to `vm.PropertyChanged`; when `Mode` becomes `BreathingArt`, hooks
-  `CompositionTarget.Rendering`; when it leaves, eases the art back to rest over a few frames
-  then unhooks (so no idle render cost in Off/Glow modes). Also subscribes to
+  `CompositionTarget.Rendering`; when it leaves, snaps the art to rest (scale 1.0, no glow) and
+  unhooks (so no idle render cost in Off/Glow modes). A mode change is a deliberate user action,
+  so an instant reset reads fine and avoids a teardown render loop. Also subscribes to
   `vm.BeatTriggered` for pulse impulses while hooked.
 - Per frame: ease energy toward `vm.TargetEnergy`; decay+ease the beat pulse (same constants
   as `AmbientBackdropView`: energy τ≈0.45, beat half-life 0.30, attack 0.06). Read

--- a/docs/superpowers/specs/2026-06-05-backdrop-style-breathing-art-design.md
+++ b/docs/superpowers/specs/2026-06-05-backdrop-style-breathing-art-design.md
@@ -1,0 +1,224 @@
+# Backdrop Style Picker + Breathing Art — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (pending spec review)
+
+## Goal
+
+Let the user choose *which* ambient visualization they get via a dropdown, and add a
+second style — **Breathing Art** (the album cover gently scales and glows with the music) —
+alongside the existing **Ambient Glow** reactive backdrop. The dropdown also carries an
+**Off** option, replacing the current enable checkbox. The existing intensity slider scales
+whichever style is active.
+
+## Decisions
+
+| Question | Decision |
+|----------|----------|
+| Picker shape | **One dropdown**: Off / Ambient Glow / Breathing Art. Replaces the enable checkbox. The intensity slider is shown whenever the style is not Off. |
+| Intensity scope | **Applies to the active style.** For Breathing Art it scales breathe depth + glow; floored to a faint minimum at 0% (same `IntensityFloor` as Glow). |
+| Breathing implementation | **Animator on the existing album-art element** (not a new UserControl). Surgical — keeps the album-art markup and the working backdrop view untouched. |
+| Glow color | The album's **palette accent** (`BlobColor2`), eased; falls back to the existing default accent when no palette. |
+
+## Background
+
+The reactive signal (energy from loudness, beat/downbeat events, and the color palette)
+flows continuously into `AmbientBackdropViewModel` via `ApplyVisualizerFrame` /
+`ApplyColorPalette`, independent of what is rendered. Adding a style is therefore adding a
+second *consumer* of that signal plus a *mode gate* — no new data plumbing. Ambient Glow and
+Breathing Art are mutually exclusive renderers; the dropdown selects the consumer.
+
+## Architecture
+
+```
+Visualizer:Mode (config)
+  → MainViewModel.SettingsBackdropStyle  (display string, bound to ComboBox, persisted)
+  → AmbientBackdropViewModel.SetMode(BackdropMode)   (raises Mode change; recomputes IsActive)
+  → consumers:
+       • AmbientBackdropView  — shows blob backdrop only when Mode == AmbientGlow (IsActive)
+       • BreathingArtAnimator — scales+glows album art only when Mode == BreathingArt
+  + AmbientBackdropViewModel.Intensity (floored) scales whichever consumer is active
+```
+
+## Component changes
+
+### 1. `BackdropMode` enum — new file `src/SendspinClient/ViewModels/BackdropMode.cs`
+
+```csharp
+namespace SendspinClient.ViewModels;
+
+/// <summary>Which ambient visualization (if any) is shown.</summary>
+public enum BackdropMode
+{
+    Off,
+    AmbientGlow,
+    BreathingArt,
+}
+```
+
+### 2. `AmbientBackdropViewModel.cs`
+
+- Remove the `Enabled` observable property and `SetEnabled(bool)`.
+- Add `[ObservableProperty] private BackdropMode _mode = BackdropMode.AmbientGlow;` with
+  `partial void OnModeChanged(BackdropMode value) => UpdateActive();`
+- Add `public void SetMode(BackdropMode mode) => Mode = mode;` (symmetry with `SetIntensity`;
+  the observable property raises change notification so the animator can react).
+- `UpdateActive()` becomes: `IsActive = Mode == BackdropMode.AmbientGlow && _hasPalette;`
+  (so the blob backdrop layer shows only in Ambient Glow mode — unchanged binding, new meaning).
+- Keep `Intensity`/`SetIntensity`, `TargetEnergy`, `BlobColor1..3`, `BaseColor`, `BeatTriggered`.
+- `Reset()` is unchanged except it no longer touches `Enabled`.
+
+The breathing animator consumes: `TargetEnergy`, `BeatTriggered`, `Intensity`, `Mode`
+(for hook/unhook), and `BlobColor2` (glow color).
+
+### 3. Breathing math (`AmbientMath.cs`, pure + tested)
+
+Mirrors `BlobScale`/`BlobOpacity`. Rest scale is **1.0** (album art is never shrunk).
+
+```csharp
+public const double BreathScaleEnergySpan = 0.06;   // +6% at full energy, intensity 1
+public const double BreathScalePulseSpan  = 0.04;   // +4% on a full beat, intensity 1
+public const double BreathGlowBase        = 0.15;   // faint aura even when quiet
+public const double BreathGlowEnergySpan  = 0.85;
+
+/// <summary>Album-art breathe scale (rests at 1.0). Intensity scales the reactive part.</summary>
+public static double BreathScale(double energy, double pulse, double intensity = 1.0)
+{
+    var e = Math.Clamp(energy, 0.0, 1.0);
+    var p = Math.Clamp(pulse, 0.0, 1.0);
+    var i = Math.Max(0.0, intensity);
+    return 1.0 + (i * ((e * BreathScaleEnergySpan) + (p * BreathScalePulseSpan)));
+}
+
+/// <summary>Album-art glow strength 0..1 (mapped to blur/opacity by the animator).</summary>
+public static double BreathGlow(double energy, double intensity = 1.0)
+{
+    var e = Math.Clamp(energy, 0.0, 1.0);
+    var i = Math.Max(0.0, intensity);
+    return Math.Clamp(i * (BreathGlowBase + (e * BreathGlowEnergySpan)), 0.0, 1.0);
+}
+```
+
+Expected test values: `BreathScale(0,0,1)=1.0`, `(1,0,1)=1.06`, `(1,1,1)=1.10`,
+`(1,1,2)=1.20`, `(1,1,0)=1.0`; `BreathGlow(0,1)=0.15`, `(1,1)=1.0`, `(1,2)=1.0`, `(0,0)=0.0`.
+
+### 4. `BreathingArtAnimator` — new file `src/SendspinClient/Views/BreathingArtAnimator.cs`
+
+A small class (not a UserControl) that animates a target element. Constructed with the
+`ScaleTransform`, the `DropShadowEffect`, and the `AmbientBackdropViewModel`. Mirrors the
+easing in `AmbientBackdropView`:
+
+- Subscribes to `vm.PropertyChanged`; when `Mode` becomes `BreathingArt`, hooks
+  `CompositionTarget.Rendering`; when it leaves, eases the art back to rest over a few frames
+  then unhooks (so no idle render cost in Off/Glow modes). Also subscribes to
+  `vm.BeatTriggered` for pulse impulses while hooked.
+- Per frame: ease energy toward `vm.TargetEnergy`; decay+ease the beat pulse (same constants
+  as `AmbientBackdropView`: energy τ≈0.45, beat half-life 0.30, attack 0.06). Read
+  `intensity = vm.Intensity` (already floored).
+- Apply `scale = AmbientMath.BreathScale(energy, pulse, intensity)` to the `ScaleTransform`
+  (X and Y); compute `g = AmbientMath.BreathGlow(energy, intensity)` and map to the glow:
+  `BlurRadius = g * MaxGlowBlur` (≈40), `Opacity = g * MaxGlowOpacity` (≈0.85), `Color` eased
+  toward `vm.BlobColor2`.
+- At rest: scale 1.0, glow opacity 0.
+
+The mapping constants (`MaxGlowBlur`, `MaxGlowOpacity`, easing τ) live in the animator (view
+concern); `AmbientMath` returns only normalized 0..1 / scale values.
+
+### 5. Album-art XAML (`MainWindow.xaml`)
+
+Wrap the existing 280×280 album-art `Border` in a thin outer `Border` that carries the
+breathing transform + glow, so the inner border keeps its existing black depth-shadow:
+
+```xml
+<Border x:Name="AlbumArtBreath"
+        HorizontalAlignment="Center" Margin="0,0,0,24"
+        RenderTransformOrigin="0.5,0.5">
+    <Border.RenderTransform>
+        <ScaleTransform x:Name="AlbumArtScale"/>
+    </Border.RenderTransform>
+    <Border.Effect>
+        <DropShadowEffect x:Name="AlbumArtGlow" ShadowDepth="0" BlurRadius="0" Opacity="0"/>
+    </Border.Effect>
+    <!-- existing 280x280 Border (depth shadow + artwork/placeholder Grid) moves here,
+         minus its own HorizontalAlignment/Margin which now live on the wrapper -->
+</Border>
+```
+
+The artwork `Image` and placeholder bindings are unchanged. `MainWindow` code-behind
+constructs the `BreathingArtAnimator` in `OnDataContextChanged` (where it already gets the
+`MainViewModel`), passing `AlbumArtScale`, `AlbumArtGlow`, and `vm.Ambient`.
+
+### 6. Settings UI (`MainWindow.xaml`)
+
+- Replace the "Reactive backdrop (Ambient Glow)" checkbox row with a **"Backdrop style"**
+  row: label + caption + a `ComboBox` (`ItemsSource="{Binding AvailableBackdropStyles}"`,
+  `SelectedItem="{Binding SettingsBackdropStyle}"`, `DarkComboBox` / `DarkComboBoxItem`
+  styles — same pattern as Connection Mode).
+- The intensity slider block's visibility binds to `IsBackdropEnabled` (style ≠ Off) instead
+  of the removed `SettingsEnableAmbientBackdrop`. Caption generalized to
+  "Scale how strongly the backdrop reacts, glows, and moves".
+
+### 7. `MainViewModel.cs`
+
+- Remove `SettingsEnableAmbientBackdrop` and `OnSettingsEnableAmbientBackdropChanged`.
+- Add:
+  ```csharp
+  public IReadOnlyList<string> AvailableBackdropStyles { get; } =
+      new[] { "Off", "Ambient Glow", "Breathing Art" };
+
+  [ObservableProperty]
+  private string _settingsBackdropStyle = "Ambient Glow";
+
+  /// <summary>True when a style other than Off is selected (drives the intensity slider's visibility).</summary>
+  public bool IsBackdropEnabled => SettingsBackdropStyle != "Off";
+
+  partial void OnSettingsBackdropStyleChanged(string value)
+  {
+      _ambient.SetMode(StyleToMode(value));
+      OnPropertyChanged(nameof(IsBackdropEnabled));
+  }
+  ```
+- Mapping helpers (display ↔ `BackdropMode` ↔ config token), a small switch:
+  - "Off" ↔ `Off` ↔ `"Off"`
+  - "Ambient Glow" ↔ `AmbientGlow` ↔ `"AmbientGlow"`
+  - "Breathing Art" ↔ `BreathingArt` ↔ `"BreathingArt"`
+- Keep `SettingsAmbientBackdropIntensity` + `OnSettingsAmbientBackdropIntensityChanged`.
+- **Load:**
+  ```csharp
+  var modeToken = _configuration.GetValue<string?>("Visualizer:Mode", null);
+  if (string.IsNullOrEmpty(modeToken))
+  {
+      // migrate from legacy bool
+      modeToken = _configuration.GetValue<bool>("Visualizer:Enabled", true) ? "AmbientGlow" : "Off";
+  }
+  SettingsBackdropStyle = TokenToStyle(modeToken);   // sets ComboBox; handler calls SetMode
+  ```
+  (Intensity load unchanged.)
+- **Save** (in the Visualizer section block):
+  ```csharp
+  visualizerSection["Mode"] = StyleToToken(SettingsBackdropStyle);
+  visualizerSection["Enabled"] = SettingsBackdropStyle != "Off";   // keep legacy key in sync
+  visualizerSection["Intensity"] = SettingsAmbientBackdropIntensity;
+  ```
+
+### 8. Config default (`appsettings.json`)
+
+Add `"Mode": "AmbientGlow"` to the `Visualizer` section (keep `Enabled: true` and the
+`Intensity: 1.0` added previously).
+
+## Out of scope
+
+- No additional styles beyond Off / Ambient Glow / Breathing Art.
+- No per-style intensity (one shared slider).
+- Breathing animates the existing album-art element only; it does not introduce a ring,
+  rim-light, or other effects from the earlier sketch.
+- No rename of `AmbientBackdropViewModel` (it remains the shared reactive-signal VM; renaming
+  is deferred to avoid churn across DI/bindings).
+
+## Verification
+
+- `dotnet build SendspinClient.sln` clean; `dotnet test` green (new `AmbientMath` breathing tests).
+- Manual: dropdown switches Off / Ambient Glow / Breathing Art live (no reconnect); Breathing
+  Art scales + glows the cover with the music; intensity slider scales the active style and
+  hides when Off; 0% is faint-but-alive in both styles; selection persists across restart
+  (`Visualizer:Mode`); legacy configs with only `Visualizer:Enabled` migrate correctly.

--- a/docs/superpowers/specs/2026-06-05-backdrop-style-breathing-art-design.md
+++ b/docs/superpowers/specs/2026-06-05-backdrop-style-breathing-art-design.md
@@ -116,11 +116,22 @@ easing in `AmbientBackdropView`:
 - Per frame: ease energy toward `vm.TargetEnergy`; decay+ease the beat pulse (same constants
   as `AmbientBackdropView`: energy τ≈0.45, beat half-life 0.30, attack 0.06). Read
   `intensity = vm.Intensity` (already floored).
-- Apply `scale = AmbientMath.BreathScale(energy, pulse, intensity)` to the `ScaleTransform`
-  (X and Y); compute `g = AmbientMath.BreathGlow(energy, intensity)` and map to the glow:
-  `BlurRadius = g * MaxGlowBlur` (≈40), `Opacity = g * MaxGlowOpacity` (≈0.85), `Color` eased
-  toward `vm.BlobColor2`.
-- At rest: scale 1.0, glow opacity 0.
+- **Breathe only while playing.** The Sendspin server ends the stream on pause (playback drops
+  to `Idle`) and the visualizer loudness signal does not reliably resume on a same-track resume —
+  it only re-flows on a track change. So the renderer gates liveness on `vm.IsPlaying`
+  (`PlaybackState == Playing`, pushed from `MainViewModel.OnPlaybackStateChanged`) rather than on
+  the energy signal: a `_playLevel` eases toward 1 while playing / 0 otherwise, and the energy
+  easing target is `vm.TargetEnergy` while playing / `0` otherwise, so the art settles to a clean
+  rest when paused/stopped.
+- **Continuous idle breath** so the art stays gently alive while playing even when no loudness
+  frames arrive: a slow time-based oscillation `idle = intensity * IdleBreathSpan *
+  sin(idlePhase * IdleBreathSpeed) * playLevel` (≈±2% scale at intensity 1, ~5s cycle). The music
+  energy/beat reactivity from `BreathScale` adds on top.
+- Apply `scale = AmbientMath.BreathScale(energy, pulse, intensity) + idle` to the `ScaleTransform`
+  (X and Y); compute `g = AmbientMath.BreathGlow(energy, intensity) * playLevel` and map to the
+  glow: `BlurRadius = g * MaxGlowBlur` (≈40), `Opacity = g * MaxGlowOpacity` (≈0.85), `Color`
+  eased toward `vm.BlobColor2`.
+- At rest (paused/stopped, or Off/Glow modes): scale 1.0, glow opacity 0.
 
 The mapping constants (`MaxGlowBlur`, `MaxGlowOpacity`, easing τ) live in the animator (view
 concern); `AmbientMath` returns only normalized 0..1 / scale values.

--- a/src/SendspinClient.Services/Visualization/AmbientMath.cs
+++ b/src/SendspinClient.Services/Visualization/AmbientMath.cs
@@ -111,4 +111,40 @@ public static class AmbientMath
         var i = Math.Max(0.0, intensity);
         return Math.Clamp(i * (OpacityMin + (e * OpacityEnergySpan)), 0.0, 1.0);
     }
+
+    /// <summary>Album-art breathe scale span from energy (0..1) at intensity 1.</summary>
+    public const double BreathScaleEnergySpan = 0.06;
+
+    /// <summary>Album-art breathe scale span from a full beat pulse at intensity 1.</summary>
+    public const double BreathScalePulseSpan = 0.04;
+
+    /// <summary>Baseline glow strength so the art keeps a faint aura even when quiet.</summary>
+    public const double BreathGlowBase = 0.15;
+
+    /// <summary>Glow strength span contributed by energy (0..1).</summary>
+    public const double BreathGlowEnergySpan = 0.85;
+
+    /// <summary>
+    /// Album-art breathe scale from eased energy and beat pulse, scaled by
+    /// <paramref name="intensity"/> (1.0 = default). Rests at 1.0 (the art is never shrunk);
+    /// energy/pulse are clamped to [0,1] and intensity to non-negative.
+    /// </summary>
+    public static double BreathScale(double energy, double pulse, double intensity = 1.0)
+    {
+        var e = Math.Clamp(energy, 0.0, 1.0);
+        var p = Math.Clamp(pulse, 0.0, 1.0);
+        var i = Math.Max(0.0, intensity);
+        return 1.0 + (i * ((e * BreathScaleEnergySpan) + (p * BreathScalePulseSpan)));
+    }
+
+    /// <summary>
+    /// Album-art glow strength (0..1) from eased energy, scaled by <paramref name="intensity"/>
+    /// (1.0 = default). The animator maps this to blur/opacity. Clamped to [0,1].
+    /// </summary>
+    public static double BreathGlow(double energy, double intensity = 1.0)
+    {
+        var e = Math.Clamp(energy, 0.0, 1.0);
+        var i = Math.Max(0.0, intensity);
+        return Math.Clamp(i * (BreathGlowBase + (e * BreathGlowEnergySpan)), 0.0, 1.0);
+    }
 }

--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -405,48 +405,57 @@
                 </Grid.Style>
 
                 <StackPanel HorizontalAlignment="Center" Margin="24">
-                    <!-- Large Album Art with Shadow (280x280) -->
-                    <Border Width="280" Height="280"
-                            CornerRadius="12"
+                    <!-- Large Album Art with Shadow (280x280); outer wrapper carries the Breathing Art transform + glow -->
+                    <Border x:Name="AlbumArtBreath"
                             HorizontalAlignment="Center"
-                            Margin="0,0,0,24">
+                            Margin="0,0,0,24"
+                            RenderTransformOrigin="0.5,0.5">
+                        <Border.RenderTransform>
+                            <ScaleTransform x:Name="AlbumArtScale"/>
+                        </Border.RenderTransform>
                         <Border.Effect>
-                            <DropShadowEffect Color="Black" BlurRadius="40" ShadowDepth="8" Opacity="0.6"/>
+                            <DropShadowEffect x:Name="AlbumArtGlow" ShadowDepth="0" BlurRadius="0" Opacity="0"/>
                         </Border.Effect>
-                        <Grid>
-                            <!-- Actual artwork with clipped corners -->
-                            <Border CornerRadius="12" ClipToBounds="True">
-                                <Border.Style>
-                                    <Style TargetType="Border">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding AlbumArtwork}" Value="{x:Null}">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Border.Style>
-                                <Image Source="{Binding AlbumArtwork, Converter={StaticResource ByteArrayToImageConverter}}"
-                                       Stretch="UniformToFill"/>
-                            </Border>
-                            <!-- Placeholder when no artwork -->
-                            <Border Background="{StaticResource SurfaceLightBrush}" CornerRadius="12">
-                                <Border.Style>
-                                    <Style TargetType="Border">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding AlbumArtwork}" Value="{x:Null}">
-                                                <Setter Property="Visibility" Value="Visible"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Border.Style>
-                                <TextBlock Text="&#x1F3B5;"
-                                           FontSize="96"
-                                           HorizontalAlignment="Center"
-                                           VerticalAlignment="Center"/>
-                            </Border>
-                        </Grid>
+                        <Border Width="280" Height="280"
+                                CornerRadius="12">
+                            <Border.Effect>
+                                <DropShadowEffect Color="Black" BlurRadius="40" ShadowDepth="8" Opacity="0.6"/>
+                            </Border.Effect>
+                            <Grid>
+                                <!-- Actual artwork with clipped corners -->
+                                <Border CornerRadius="12" ClipToBounds="True">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding AlbumArtwork}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <Image Source="{Binding AlbumArtwork, Converter={StaticResource ByteArrayToImageConverter}}"
+                                           Stretch="UniformToFill"/>
+                                </Border>
+                                <!-- Placeholder when no artwork -->
+                                <Border Background="{StaticResource SurfaceLightBrush}" CornerRadius="12">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding AlbumArtwork}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <TextBlock Text="&#x1F3B5;"
+                                               FontSize="96"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"/>
+                                </Border>
+                            </Grid>
+                        </Border>
                     </Border>
 
                     <!-- Track Title -->

--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -627,27 +627,25 @@
                                           VerticalAlignment="Center"/>
                             </Grid>
 
-                            <!-- Ambient Glow reactive backdrop -->
-                            <Grid Margin="0,0,0,16">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <StackPanel Grid.Column="0">
-                                    <TextBlock Text="Reactive backdrop (Ambient Glow)" Style="{StaticResource BodyText}"/>
-                                    <TextBlock Text="Animate the background with colors and energy from the music"
-                                               Style="{StaticResource CaptionText}"
-                                               Foreground="{StaticResource TextMutedBrush}"
-                                               Margin="0,2,0,0"/>
-                                </StackPanel>
-                                <CheckBox Grid.Column="1"
-                                          IsChecked="{Binding SettingsEnableAmbientBackdrop}"
-                                          VerticalAlignment="Center"/>
-                            </Grid>
+                            <!-- Backdrop style -->
+                            <StackPanel Margin="0,0,0,16">
+                                <TextBlock Text="Backdrop style" Style="{StaticResource BodyText}"/>
+                                <TextBlock Text="Animate the window with the music, or breathe the album art — or turn it off"
+                                           Style="{StaticResource CaptionText}"
+                                           Foreground="{StaticResource TextMutedBrush}"
+                                           Margin="0,2,0,0"
+                                           TextWrapping="Wrap"/>
+                                <ComboBox Margin="0,8,0,0"
+                                          HorizontalAlignment="Stretch"
+                                          ItemsSource="{Binding AvailableBackdropStyles}"
+                                          SelectedItem="{Binding SettingsBackdropStyle}"
+                                          Style="{StaticResource DarkComboBox}"
+                                          ItemContainerStyle="{StaticResource DarkComboBoxItem}"/>
+                            </StackPanel>
 
                             <!-- Ambient Glow intensity (hidden when the backdrop is disabled) -->
                             <StackPanel Margin="0,0,0,16"
-                                        Visibility="{Binding SettingsEnableAmbientBackdrop, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        Visibility="{Binding IsBackdropEnabled, Converter={StaticResource BoolToVisibilityConverter}}">
                                 <TextBlock Text="Backdrop intensity" Style="{StaticResource BodyText}"/>
                                 <TextBlock Text="Scale how strongly the backdrop reacts, glows, and moves"
                                            Style="{StaticResource CaptionText}"

--- a/src/SendspinClient/MainWindow.xaml.cs
+++ b/src/SendspinClient/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Input;
 using Sendspin.SDK.Discovery;
 using SendspinClient.ViewModels;
+using SendspinClient.Views;
 
 namespace SendspinClient;
 
@@ -13,6 +14,7 @@ public partial class MainWindow : Window
 {
     private const double DefaultWidth = 400;
     private const double DefaultHeight = 780;
+    private BreathingArtAnimator? _breathingAnimator;
 
     public MainWindow()
     {
@@ -37,6 +39,11 @@ public partial class MainWindow : Window
         if (e.NewValue is INotifyPropertyChanged newVm)
         {
             newVm.PropertyChanged += OnViewModelPropertyChanged;
+        }
+
+        if (_breathingAnimator is null && e.NewValue is MainViewModel mainVm)
+        {
+            _breathingAnimator = new BreathingArtAnimator(AlbumArtScale, AlbumArtGlow, mainVm.Ambient);
         }
     }
 

--- a/src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs
+++ b/src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs
@@ -17,11 +17,13 @@ public partial class AmbientBackdropViewModel : ObservableObject
     private static readonly Color FallbackBlob2 = Color.FromRgb(0x06, 0xB6, 0xD4);
     private static readonly Color FallbackBlob3 = Color.FromRgb(0xDB, 0x27, 0x77);
 
-    /// <summary>Whether the feature is enabled in settings.</summary>
+    /// <summary>The selected backdrop style. The blob backdrop renders only in AmbientGlow mode.</summary>
     [ObservableProperty]
-    private bool _enabled = true;
+    private BackdropMode _mode = BackdropMode.AmbientGlow;
 
-    /// <summary>True when a real color palette has been received and the feature is enabled.</summary>
+    partial void OnModeChanged(BackdropMode value) => UpdateActive();
+
+    /// <summary>True when the style is Ambient Glow and a real color palette has been received.</summary>
     [ObservableProperty]
     private bool _isActive;
 
@@ -40,8 +42,8 @@ public partial class AmbientBackdropViewModel : ObservableObject
 
     /// <summary>
     /// Effective intensity (<c>IntensityFloor</c>..2.0) consumed by the renderer. The raw 0
-    /// setting is floored so the backdrop never goes fully dark via the slider; use
-    /// <see cref="SetEnabled"/> to disable entirely.
+    /// setting is floored so the backdrop never goes fully dark via the slider; choose the Off
+    /// style (<see cref="SetMode"/>) to disable entirely.
     /// </summary>
     public double Intensity => Math.Max(AmbientMath.IntensityFloor, _intensity);
 
@@ -88,12 +90,8 @@ public partial class AmbientBackdropViewModel : ObservableObject
         }
     }
 
-    /// <summary>Enables/disables the effect (from the settings toggle). Immediate, no reconnect.</summary>
-    public void SetEnabled(bool enabled)
-    {
-        Enabled = enabled;
-        UpdateActive();
-    }
+    /// <summary>Sets the backdrop style (from the settings dropdown). Immediate, no reconnect.</summary>
+    public void SetMode(BackdropMode mode) => Mode = mode;
 
     /// <summary>Resets to the inactive/idle state (e.g. on disconnect).</summary>
     public void Reset()
@@ -103,7 +101,7 @@ public partial class AmbientBackdropViewModel : ObservableObject
         UpdateActive();
     }
 
-    private void UpdateActive() => IsActive = Enabled && _hasPalette;
+    private void UpdateActive() => IsActive = Mode == BackdropMode.AmbientGlow && _hasPalette;
 
     private static Color ToColor(RgbColor? rgb, Color fallback)
         => rgb is { } c ? Color.FromRgb(c.R, c.G, c.B) : fallback;

--- a/src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs
+++ b/src/SendspinClient/ViewModels/AmbientBackdropViewModel.cs
@@ -50,6 +50,16 @@ public partial class AmbientBackdropViewModel : ObservableObject
     /// <summary>Sets the raw intensity (0..2) from the settings slider. Does not affect IsActive.</summary>
     public void SetIntensity(double raw) => _intensity = Math.Clamp(raw, 0.0, 2.0);
 
+    /// <summary>
+    /// Whether playback is currently active. Breathing Art breathes only while playing; the
+    /// visualizer signal does not reliably resume on a same-track pause/resume, so the renderer
+    /// relies on this rather than energy alone to decide when to be alive.
+    /// </summary>
+    public bool IsPlaying { get; private set; }
+
+    /// <summary>Sets whether playback is active (from MainViewModel's PlaybackState). Polled by the renderer.</summary>
+    public void SetPlaying(bool playing) => IsPlaying = playing;
+
     /// <summary>Raised when a beat frame arrives; strength is ~0.6 for a beat, 1.0 for a downbeat.</summary>
     public event EventHandler<double>? BeatTriggered;
 

--- a/src/SendspinClient/ViewModels/BackdropMode.cs
+++ b/src/SendspinClient/ViewModels/BackdropMode.cs
@@ -1,0 +1,9 @@
+namespace SendspinClient.ViewModels;
+
+/// <summary>Which ambient visualization (if any) is shown.</summary>
+public enum BackdropMode
+{
+    Off,
+    AmbientGlow,
+    BreathingArt,
+}

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -278,11 +278,20 @@ public partial class MainViewModel : ViewModelBase
     [ObservableProperty]
     private bool _settingsShowDiscordPresence;
 
-    /// <summary>
-    /// Gets or sets whether the Ambient Glow reactive backdrop is enabled.
-    /// </summary>
+    /// <summary>Available backdrop style options for the settings dropdown.</summary>
+    public string[] AvailableBackdropStyles { get; } = new[]
+    {
+        "Off",
+        "Ambient Glow",
+        "Breathing Art",
+    };
+
+    /// <summary>Gets or sets the selected backdrop style (display string, bound to the dropdown).</summary>
     [ObservableProperty]
-    private bool _settingsEnableAmbientBackdrop = true;
+    private string _settingsBackdropStyle = "Ambient Glow";
+
+    /// <summary>True when a style other than Off is selected (drives the intensity slider's visibility).</summary>
+    public bool IsBackdropEnabled => SettingsBackdropStyle != "Off";
 
     /// <summary>
     /// Gets or sets the Ambient Glow backdrop intensity (0.0–2.0, 1.0 = default look).
@@ -1930,10 +1939,32 @@ public partial class MainViewModel : ViewModelBase
         _mediaControlsService.IsEnabled = value;
     }
 
-    partial void OnSettingsEnableAmbientBackdropChanged(bool value)
+    partial void OnSettingsBackdropStyleChanged(string value)
     {
-        _ambient.SetEnabled(value);
+        _ambient.SetMode(StyleToMode(value));
+        OnPropertyChanged(nameof(IsBackdropEnabled));
     }
+
+    private static BackdropMode StyleToMode(string style) => style switch
+    {
+        "Off" => BackdropMode.Off,
+        "Breathing Art" => BackdropMode.BreathingArt,
+        _ => BackdropMode.AmbientGlow,
+    };
+
+    private static string StyleToToken(string style) => style switch
+    {
+        "Off" => "Off",
+        "Breathing Art" => "BreathingArt",
+        _ => "AmbientGlow",
+    };
+
+    private static string TokenToStyle(string token) => token switch
+    {
+        "Off" => "Off",
+        "BreathingArt" => "Breathing Art",
+        _ => "Ambient Glow",
+    };
 
     partial void OnSettingsAmbientBackdropIntensityChanged(double value)
     {
@@ -2186,9 +2217,14 @@ public partial class MainViewModel : ViewModelBase
             _discordService.Enable();
         }
 
-        // Load Ambient Glow backdrop setting and apply immediately
-        SettingsEnableAmbientBackdrop = _configuration.GetValue<bool>("Visualizer:Enabled", true);
-        _ambient.SetEnabled(SettingsEnableAmbientBackdrop);
+        // Load backdrop style (migrating from the legacy Visualizer:Enabled bool) and apply immediately
+        var backdropModeToken = _configuration.GetValue<string?>("Visualizer:Mode", null);
+        if (string.IsNullOrEmpty(backdropModeToken))
+        {
+            backdropModeToken = _configuration.GetValue<bool>("Visualizer:Enabled", true) ? "AmbientGlow" : "Off";
+        }
+        SettingsBackdropStyle = TokenToStyle(backdropModeToken);
+        _ambient.SetMode(StyleToMode(SettingsBackdropStyle));
         SettingsAmbientBackdropIntensity = _configuration.GetValue<double>("Visualizer:Intensity", 1.0);
         _ambient.SetIntensity(SettingsAmbientBackdropIntensity);
 
@@ -2440,7 +2476,8 @@ public partial class MainViewModel : ViewModelBase
 
             // Update Visualizer section
             var visualizerSection = root["Visualizer"]?.AsObject() ?? new JsonObject();
-            visualizerSection["Enabled"] = SettingsEnableAmbientBackdrop;
+            visualizerSection["Mode"] = StyleToToken(SettingsBackdropStyle);
+            visualizerSection["Enabled"] = SettingsBackdropStyle != "Off";
             visualizerSection["Intensity"] = SettingsAmbientBackdropIntensity;
             root["Visualizer"] = visualizerSection;
 

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -1586,6 +1586,10 @@ public partial class MainViewModel : ViewModelBase
     /// <param name="value">The new playback state.</param>
     partial void OnPlaybackStateChanged(PlaybackState value)
     {
+        // Breathing Art breathes only while playing (the visualizer signal doesn't reliably
+        // resume on a same-track pause/resume, which ends the stream and drops to Idle).
+        _ambient.SetPlaying(value == PlaybackState.Playing);
+
         OnPropertyChanged(nameof(IsPlaying));
         OnPropertyChanged(nameof(DisplayTitle));
         OnPropertyChanged(nameof(DisplayArtist));

--- a/src/SendspinClient/Views/BreathingArtAnimator.cs
+++ b/src/SendspinClient/Views/BreathingArtAnimator.cs
@@ -25,6 +25,12 @@ public sealed class BreathingArtAnimator
     private const double MaxGlowBlur = 40.0;
     private const double MaxGlowOpacity = 0.85;
 
+    // Continuous idle breath so the art stays alive while playing even when no loudness frames
+    // arrive (e.g. after a same-track resume). Energy/beats add reactivity on top.
+    private const double IdleBreathSpan = 0.02;   // +/- 2% scale at intensity 1
+    private const double IdleBreathSpeed = 1.25;  // rad/s -> ~5s breath cycle
+    private const double PlayLevelTimeConstant = 0.45; // ease in/out of the "alive" level on play/pause
+
     private readonly ScaleTransform _scale;
     private readonly DropShadowEffect _glow;
     private readonly AmbientBackdropViewModel _vm;
@@ -35,6 +41,8 @@ public sealed class BreathingArtAnimator
     private double _energy;
     private double _pulse;
     private double _pulseTarget;
+    private double _idlePhase;
+    private double _playLevel;
 
     private double _glowR, _glowG, _glowB;
     private bool _glowColorInitialized;
@@ -109,6 +117,7 @@ public sealed class BreathingArtAnimator
         _energy = 0.0;
         _pulse = 0.0;
         _pulseTarget = 0.0;
+        _playLevel = 0.0;
         _scale.ScaleX = 1.0;
         _scale.ScaleY = 1.0;
         _glow.BlurRadius = 0.0;
@@ -125,16 +134,26 @@ public sealed class BreathingArtAnimator
             return;
         }
 
-        _energy = AmbientMath.Ease(_energy, _vm.TargetEnergy, dt, EnergyTimeConstant);
+        // Breathe only while playing. When paused/stopped, ease the play-level and the energy
+        // target to zero so the art settles to a clean rest — the visualizer signal does not
+        // reliably resume on a same-track resume, so liveness is gated on playback, not energy.
+        _playLevel = AmbientMath.Ease(_playLevel, _vm.IsPlaying ? 1.0 : 0.0, dt, PlayLevelTimeConstant);
+        var energyTarget = _vm.IsPlaying ? _vm.TargetEnergy : 0.0;
+        _energy = AmbientMath.Ease(_energy, energyTarget, dt, EnergyTimeConstant);
         _pulseTarget = AmbientMath.Decay(_pulseTarget, dt, BeatHalfLife);
         _pulse = AmbientMath.Ease(_pulse, _pulseTarget, dt, BeatAttack);
 
         var intensity = _vm.Intensity;
-        var scale = AmbientMath.BreathScale(_energy, _pulse, intensity);
+
+        // Continuous idle breath (energy-independent), faded by the play-level so it only breathes
+        // while playing; the eased energy/beat reactivity from BreathScale adds on top.
+        _idlePhase += dt;
+        var idle = intensity * IdleBreathSpan * Math.Sin(_idlePhase * IdleBreathSpeed) * _playLevel;
+        var scale = AmbientMath.BreathScale(_energy, _pulse, intensity) + idle;
         _scale.ScaleX = scale;
         _scale.ScaleY = scale;
 
-        var g = AmbientMath.BreathGlow(_energy, intensity);
+        var g = AmbientMath.BreathGlow(_energy, intensity) * _playLevel;
         _glow.BlurRadius = g * MaxGlowBlur;
         _glow.Opacity = g * MaxGlowOpacity;
 

--- a/src/SendspinClient/Views/BreathingArtAnimator.cs
+++ b/src/SendspinClient/Views/BreathingArtAnimator.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using SendspinClient.Services.Visualization;
+using SendspinClient.ViewModels;
+
+namespace SendspinClient.Views;
+
+/// <summary>
+/// Drives the Breathing Art backdrop style: scales the album-art element and adds a palette-accent
+/// glow that ease toward the loudness/beat signal from <see cref="AmbientBackdropViewModel"/>.
+/// Runs a render loop only while <see cref="AmbientBackdropViewModel.Mode"/> is
+/// <see cref="BackdropMode.BreathingArt"/>; in any other mode the art rests at scale 1.0 with no glow.
+/// Mirrors the easing constants used by <c>AmbientBackdropView</c>.
+/// </summary>
+public sealed class BreathingArtAnimator
+{
+    private const double EnergyTimeConstant = 0.45;
+    private const double BeatHalfLife = 0.30;
+    private const double BeatAttack = 0.06;
+    private const double GlowColorTimeConstant = 0.8;
+
+    // BreathGlow (0..1) -> effect mapping (view concern).
+    private const double MaxGlowBlur = 40.0;
+    private const double MaxGlowOpacity = 0.85;
+
+    private readonly ScaleTransform _scale;
+    private readonly DropShadowEffect _glow;
+    private readonly AmbientBackdropViewModel _vm;
+
+    private readonly Stopwatch _clock = new();
+    private long _lastTicks;
+
+    private double _energy;
+    private double _pulse;
+    private double _pulseTarget;
+
+    private double _glowR, _glowG, _glowB;
+    private bool _glowColorInitialized;
+
+    private bool _hooked;
+
+    public BreathingArtAnimator(ScaleTransform scale, DropShadowEffect glow, AmbientBackdropViewModel vm)
+    {
+        _scale = scale;
+        _glow = glow;
+        _vm = vm;
+        _vm.PropertyChanged += OnVmPropertyChanged;
+        ApplyModeState();
+    }
+
+    private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(AmbientBackdropViewModel.Mode))
+        {
+            ApplyModeState();
+        }
+    }
+
+    private void ApplyModeState()
+    {
+        if (_vm.Mode == BackdropMode.BreathingArt)
+        {
+            Hook();
+        }
+        else
+        {
+            Unhook();
+            ResetToRest();
+        }
+    }
+
+    private void Hook()
+    {
+        if (_hooked)
+        {
+            return;
+        }
+
+        _clock.Restart();
+        _lastTicks = _clock.ElapsedTicks;
+        _vm.BeatTriggered += OnBeat;
+        CompositionTarget.Rendering += OnRendering;
+        _hooked = true;
+    }
+
+    private void Unhook()
+    {
+        if (!_hooked)
+        {
+            return;
+        }
+
+        CompositionTarget.Rendering -= OnRendering;
+        _vm.BeatTriggered -= OnBeat;
+        _clock.Stop();
+        _hooked = false;
+    }
+
+    private void OnBeat(object? sender, double strength) => _pulseTarget += strength;
+
+    private void ResetToRest()
+    {
+        _energy = 0.0;
+        _pulse = 0.0;
+        _pulseTarget = 0.0;
+        _scale.ScaleX = 1.0;
+        _scale.ScaleY = 1.0;
+        _glow.BlurRadius = 0.0;
+        _glow.Opacity = 0.0;
+    }
+
+    private void OnRendering(object? sender, EventArgs e)
+    {
+        var now = _clock.ElapsedTicks;
+        var dt = (now - _lastTicks) / (double)Stopwatch.Frequency;
+        _lastTicks = now;
+        if (dt <= 0.0)
+        {
+            return;
+        }
+
+        _energy = AmbientMath.Ease(_energy, _vm.TargetEnergy, dt, EnergyTimeConstant);
+        _pulseTarget = AmbientMath.Decay(_pulseTarget, dt, BeatHalfLife);
+        _pulse = AmbientMath.Ease(_pulse, _pulseTarget, dt, BeatAttack);
+
+        var intensity = _vm.Intensity;
+        var scale = AmbientMath.BreathScale(_energy, _pulse, intensity);
+        _scale.ScaleX = scale;
+        _scale.ScaleY = scale;
+
+        var g = AmbientMath.BreathGlow(_energy, intensity);
+        _glow.BlurRadius = g * MaxGlowBlur;
+        _glow.Opacity = g * MaxGlowOpacity;
+
+        var c = _vm.BlobColor2;
+        if (!_glowColorInitialized)
+        {
+            (_glowR, _glowG, _glowB) = (c.R, c.G, c.B);
+            _glowColorInitialized = true;
+        }
+
+        _glowR = AmbientMath.Ease(_glowR, c.R, dt, GlowColorTimeConstant);
+        _glowG = AmbientMath.Ease(_glowG, c.G, dt, GlowColorTimeConstant);
+        _glowB = AmbientMath.Ease(_glowB, c.B, dt, GlowColorTimeConstant);
+        _glow.Color = Color.FromRgb(
+            (byte)Math.Clamp(_glowR, 0, 255),
+            (byte)Math.Clamp(_glowG, 0, 255),
+            (byte)Math.Clamp(_glowB, 0, 255));
+    }
+}

--- a/src/SendspinClient/Views/BreathingArtAnimator.cs
+++ b/src/SendspinClient/Views/BreathingArtAnimator.cs
@@ -46,6 +46,10 @@ public sealed class BreathingArtAnimator
         _scale = scale;
         _glow = glow;
         _vm = vm;
+
+        // Animator and VM are both app-lifetime singletons, so this subscription lives for the
+        // life of the process; no unsubscribe/IDisposable is needed (unlike AmbientBackdropView,
+        // whose VM can be swapped via DataContextChanged).
         _vm.PropertyChanged += OnVmPropertyChanged;
         ApplyModeState();
     }

--- a/src/SendspinClient/appsettings.json
+++ b/src/SendspinClient/appsettings.json
@@ -41,6 +41,7 @@
     "Enabled": true
   },
   "Visualizer": {
+    "Mode": "AmbientGlow",
     "Enabled": true,
     "Intensity": 1.0,
     "RateMax": 30,

--- a/tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
+++ b/tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
@@ -155,4 +155,31 @@ public class AmbientMathTests
     {
         Assert.InRange(AmbientMath.IntensityFloor, 0.05, 0.30);
     }
+
+    [Theory]
+    [InlineData(0.0, 0.0, 1.0, 1.0)]    // rest = 1.0 (art never shrinks)
+    [InlineData(1.0, 0.0, 1.0, 1.06)]   // +6% energy span at intensity 1
+    [InlineData(1.0, 1.0, 1.0, 1.10)]   // +6% energy +4% pulse
+    [InlineData(1.0, 1.0, 2.0, 1.20)]   // intensity 2 doubles the reactive part
+    [InlineData(1.0, 1.0, 0.0, 1.0)]    // intensity 0 -> rest
+    public void BreathScale_RestsAtOneAndScalesByIntensity(double energy, double pulse, double intensity, double expected)
+    {
+        Assert.Equal(expected, AmbientMath.BreathScale(energy, pulse, intensity), 0.0001);
+    }
+
+    [Theory]
+    [InlineData(0.0, 1.0, 0.15)]   // quiet -> faint base aura at intensity 1
+    [InlineData(1.0, 1.0, 1.0)]    // full energy -> clamp to 1
+    [InlineData(1.0, 2.0, 1.0)]    // intensity 2 -> clamp to 1
+    [InlineData(0.0, 0.0, 0.0)]    // intensity 0 -> no glow
+    public void BreathGlow_BaseAuraScalesAndClamps(double energy, double intensity, double expected)
+    {
+        Assert.Equal(expected, AmbientMath.BreathGlow(energy, intensity), 0.0001);
+    }
+
+    [Fact]
+    public void BreathScale_NegativeIntensity_RestsAtOne()
+    {
+        Assert.Equal(1.0, AmbientMath.BreathScale(1.0, 1.0, -3.0), 0.0001);
+    }
 }

--- a/tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
+++ b/tests/SendspinClient.Services.Tests/Visualization/AmbientMathTests.cs
@@ -182,4 +182,16 @@ public class AmbientMathTests
     {
         Assert.Equal(1.0, AmbientMath.BreathScale(1.0, 1.0, -3.0), 0.0001);
     }
+
+    [Fact]
+    public void BreathScale_NegativeEnergyAndPulse_RestsAtOne()
+    {
+        Assert.Equal(1.0, AmbientMath.BreathScale(-1.0, -1.0), 0.0001);
+    }
+
+    [Fact]
+    public void BreathGlow_NegativeIntensity_ReturnsZero()
+    {
+        Assert.Equal(0.0, AmbientMath.BreathGlow(1.0, -3.0), 0.0001);
+    }
 }


### PR DESCRIPTION
> **Draft** — feature-complete and verified locally (build clean, tests green, manual smoke incl. pause/resume). Opening as draft for review.

## Summary

Replaces the Reactive Backdrop's enable checkbox with a **Backdrop style** dropdown — **Off / Ambient Glow / Breathing Art** — and adds the new **Breathing Art** style, where the album cover gently scales and glows (palette-accent) with the music. The existing intensity slider scales whichever style is active.

## What's included

- **Backdrop style dropdown** replacing the checkbox; `Visualizer:Mode` config (`Off`/`AmbientGlow`/`BreathingArt`) with automatic migration from the legacy `Visualizer:Enabled` bool.
- **Breathing Art** via a small `BreathingArtAnimator` that reads the same reactive signal as Ambient Glow and animates the album-art element (scale + `DropShadowEffect` glow). Mutually exclusive with the blob backdrop.
- **One intensity slider** scales the active style (floored faint at 0% in both).
- **Breathing math** (`AmbientMath.BreathScale`/`BreathGlow`) — pure, TDD, mirrors `BlobScale`/`BlobOpacity`.
- **Pause/resume fix:** the Sendspin server ends the stream on pause (drops to `Idle`) and the visualizer signal doesn't reliably resume on a same-track resume (only on track change). Breathing Art now has a **play-gated idle breath** (slow ~5s oscillation, energy-independent) so it stays alive while playing regardless of the signal, and eases to a clean rest when paused. Music energy/beats still add reactivity on top.

## Tests

- New `AmbientMath` breathing cases (scale rest/scale/clamp, glow base/clamp, negative inputs). Full suite **46 passing**, solution build **0 errors**.

## Review status

- Each task passed spec + code-quality review during implementation; the animator and the whole feature got deeper (Opus) reviews — lifecycle, threading, persistence round-trip, and mutual exclusivity all verified.

## Test plan

- [ ] Dropdown switches Off / Ambient Glow / Breathing Art live (no reconnect).
- [ ] Breathing Art scales + glows the cover with the music; beats give a bump.
- [ ] Pause → art calms to rest; resume (same track) → breathing resumes (the original bug).
- [ ] Intensity slider scales the active style; hidden when Off; 0% faint-but-alive.
- [ ] Selection persists across restart (`Visualizer:Mode`); legacy `Visualizer:Enabled`-only config migrates.