### PR TITLE
Actually enable resampling in Combined sync correction (+ surface it in Stats)

### DIFF
--- a/src/SendspinClient.Services/Audio/SyncCorrectedSampleSource.cs
+++ b/src/SendspinClient.Services/Audio/SyncCorrectedSampleSource.cs
@@ -208,11 +208,13 @@ public sealed class SyncCorrectedSampleSource : IAudioSampleSource, IDisposable
 
         var syncError = _buffer.SmoothedSyncErrorMicroseconds / 1000.0; // Convert to ms
         var mode = _correctionProvider.CurrentMode;
+        var rate = _correctionProvider.TargetPlaybackRate;
 
         _logger.LogDebug(
-            "SyncCorrection: error={SyncError:+0.00;-0.00}ms mode={Mode} dropEveryN={DropN} insertEveryN={InsertN} totalDropped={Dropped} totalInserted={Inserted}",
+            "SyncCorrection: error={SyncError:+0.00;-0.00}ms mode={Mode} rate={Rate:F5}x dropEveryN={DropN} insertEveryN={InsertN} totalDropped={Dropped} totalInserted={Inserted}",
             syncError,
             mode,
+            rate,
             dropEveryN,
             insertEveryN,
             _totalDropped,

--- a/src/SendspinClient.Services/Audio/WasapiAudioPlayer.cs
+++ b/src/SendspinClient.Services/Audio/WasapiAudioPlayer.cs
@@ -279,14 +279,20 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
         {
             _buffer = bufferedSource.Buffer;
 
-            // Create correction options for drop/insert only (no resampling tier)
-            // Set resampling threshold equal to deadband so it jumps straight to drop/insert
-            var dropInsertOptions = _buffer.SyncOptions.Clone();
-            dropInsertOptions.ResamplingThresholdMicroseconds = dropInsertOptions.DeadbandMicroseconds;
+            // Clone the buffer's sync options for the external correction calculator.
+            // In Combined mode, keep the configured resampling threshold (default 15ms) so small
+            // errors are corrected by smooth playback-rate resampling and only larger errors fall
+            // back to drop/insert. In DropInsertOnly mode, collapse the resampling band to the
+            // deadband so corrections skip straight to drop/insert (no resampler in the chain).
+            var correctionOptions = _buffer.SyncOptions.Clone();
+            if (_syncStrategy == SyncCorrectionStrategy.DropInsertOnly)
+            {
+                correctionOptions.ResamplingThresholdMicroseconds = correctionOptions.DeadbandMicroseconds;
+            }
 
             // Create correction provider for external sync correction
             var calculator = new SyncCorrectionCalculator(
-                dropInsertOptions,
+                correctionOptions,
                 _buffer.Format.SampleRate,
                 _buffer.Format.Channels);
             _correctionProvider = calculator;

--- a/src/SendspinClient/ViewModels/StatsViewModel.cs
+++ b/src/SendspinClient/ViewModels/StatsViewModel.cs
@@ -423,7 +423,9 @@ public partial class StatsViewModel : ViewModelBase
         _lastSyncDroppedForSync = stats.SamplesDroppedForSync;
         _lastSyncInsertedForSync = stats.SamplesInsertedForSync;
 
-        var resamplingActive = Math.Abs(stats.TargetPlaybackRate - 1.0) > 0.001;
+        // Cancelling typical clock drift only needs ~50 ppm of rate trim, so use a fine epsilon.
+        // The old 0.001 (1000 ppm) was far too coarse to ever register real resampling.
+        var resamplingActive = Math.Abs(stats.TargetPlaybackRate - 1.0) > 0.00002;
 
         if (droppedDelta > 0)
         {
@@ -446,10 +448,11 @@ public partial class StatsViewModel : ViewModelBase
             CorrectionModeColor = new SolidColorBrush(Color.FromRgb(0x4a, 0xde, 0x80)); // Green
         }
 
-        // Playback Rate (for resampling-based sync correction)
+        // Playback Rate (for resampling-based sync correction). F5 so sub-0.1% trims are visible
+        // (e.g. 1.00005x); F3 rounded every correction down to a flat "1.000x".
         var rate = stats.TargetPlaybackRate;
-        PlaybackRateDisplay = $"{rate:F3}x";
-        PlaybackRateColor = Math.Abs(rate - 1.0) > 0.001
+        PlaybackRateDisplay = $"{rate:F5}x";
+        PlaybackRateColor = Math.Abs(rate - 1.0) > 0.00002
             ? new SolidColorBrush(Color.FromRgb(0x60, 0xa5, 0xfa)) // Blue when actively adjusting
             : Brushes.White;
 


### PR DESCRIPTION
Follow-up to #38. That PR landed only the display-inference change; the **real resampling fix and the visibility work were never pushed**. This branches off current master (which has #37 breathing art + #38's display commit) and adds the two missing commits.

## 1. Enable resampling in Combined mode (the actual bug)

`WasapiAudioPlayer` configured the external sync-correction calculator with the resampling threshold **collapsed to the deadband for every strategy**, so the calculator only ever emitted drop/insert and never a playback-rate adjustment. In `Combined` mode the WDL resampler was spliced into the chain but fed a rate fixed at 1.0 — pure overhead doing nothing, while drop/insert performed all correction. (This is why #35's "restore Combined" never changed the audible behavior.)

Now the band-collapse is gated on `DropInsertOnly`; `Combined` keeps the configured 15 ms threshold, so 2–15 ms errors are smoothed by resampling and only larger errors fall back to drop/insert.

**Verified via verbose logs:** after the fix, sync error holds <1 ms with **zero** frame drops (was ~2–3 drops/sec continuously), and `mode="Resampling"` engages — the steady ~52 µs/s clock drift is now absorbed by a ~1.00005x rate trim instead of dropped frames.

## 2. Make the correction visible in Stats

A ~50 ppm trim was invisible: Playback Rate read `F3` (rounded to `1.000x`) and the "is resampling" check used a `0.001` (1000 ppm) threshold, so steady resampling showed as `None`/`1.000x`. Now uses `F5` and a ~20 ppm threshold, and the verbose `SyncCorrection` log line includes the actual `rate=`.

## Test plan
- [ ] Play audio, open Stats: **Correction Mode = Resampling** (blue) during steady playback, **Playback Rate** ticks around `1.0000x` (e.g. `1.00005x`), **Samples Dropped** stays flat.
- [ ] No audible pitch wobble on sustained notes.
- [ ] `DropInsertOnly` mode still works (no resampler in chain, drop/insert as before).