### PR TITLE
Clamp Static Delay to non-negative (negative static_delay_ms breaks the server connection)

### DIFF
--- a/src/SendspinClient/App.xaml.cs
+++ b/src/SendspinClient/App.xaml.cs
@@ -284,8 +284,10 @@ public partial class App : Application
                 adaptiveCutoff: adaptiveCutoff,
                 minSamplesForForgetting: minSamplesForForgetting);
 
-            // Apply static delay from configuration
-            var staticDelayMs = _configuration!.GetValue<double>("Audio:StaticDelayMs", 0);
+            // Apply static delay from configuration. Must be non-negative: the Sendspin server
+            // (aiosendspin) validates static_delay_ms in 0-5000 and drops the connection if a client
+            // reports a negative value, so clamp on read (a stale negative config becomes 0).
+            var staticDelayMs = Math.Max(0, _configuration!.GetValue<double>("Audio:StaticDelayMs", 0));
             clockSync.StaticDelayMs = staticDelayMs;
 
             return clockSync;

--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -946,7 +946,7 @@
                                     </Button>
                                     <!-- Slider -->
                                     <Slider Grid.Column="1"
-                                            Minimum="-5000" Maximum="5000"
+                                            Minimum="0" Maximum="5000"
                                             Value="{Binding SettingsStaticDelayMs}"
                                             TickFrequency="500"
                                             IsSnapToTickEnabled="False"

--- a/src/SendspinClient/MainWindow.xaml.cs
+++ b/src/SendspinClient/MainWindow.xaml.cs
@@ -104,14 +104,15 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Validates that only numeric input (including negative sign) is entered in TextBox.
+    /// Validates that only non-negative numeric input is entered in the TextBox.
+    /// Used by the Static Delay field, which the server requires to be 0 or greater.
     /// </summary>
     private void NumericTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
     {
-        // Allow digits and minus sign (for negative numbers)
+        // Digits only — no minus sign: static delay must be non-negative (server rejects negatives).
         foreach (char c in e.Text)
         {
-            if (!char.IsDigit(c) && c != '-')
+            if (!char.IsDigit(c))
             {
                 e.Handled = true;
                 return;
@@ -127,7 +128,7 @@ public partial class MainWindow : Window
         if (e.DataObject.GetDataPresent(typeof(string)))
         {
             string text = (string)e.DataObject.GetData(typeof(string));
-            if (!int.TryParse(text, out _))
+            if (!int.TryParse(text, out var pasted) || pasted < 0)
             {
                 e.CancelCommand();
             }

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -1717,6 +1717,10 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     partial void OnSettingsStaticDelayMsChanged(double value)
     {
+        // Static delay must be non-negative — the server rejects a negative static_delay_ms
+        // (valid range 0-5000) and drops the connection. Clamp before applying/persisting.
+        value = Math.Max(0, value);
+
         // Apply delay value immediately (this is cheap)
         _clockSynchronizer.StaticDelayMs = value;
 
@@ -2198,7 +2202,7 @@ public partial class MainViewModel : ViewModelBase
         SettingsEnableConsoleLogging = settings.EnableConsoleLogging;
 
         // Load audio settings
-        SettingsStaticDelayMs = _configuration.GetValue<double>("Audio:StaticDelayMs", 0);
+        SettingsStaticDelayMs = Math.Max(0, _configuration.GetValue<double>("Audio:StaticDelayMs", 0));
 
         // Load persisted player volume/mute (these get applied via OnVolumeChanged/OnIsMutedChanged)
         Volume = _configuration.GetValue<int>("Audio:PlayerVolume", 100);
@@ -2327,7 +2331,7 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private void DecrementStaticDelay()
     {
-        SettingsStaticDelayMs = Math.Max(-5000, SettingsStaticDelayMs - 10);
+        SettingsStaticDelayMs = Math.Max(0, SettingsStaticDelayMs - 10);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

A negative **Static Delay** silently kills the connection. The client reports `static_delay_ms` in its `client/state`; Music Assistant's `aiosendspin` server validates it to **0–5000** and throws on a negative value, so the client never completes its initial-state handshake and the server drops it — an endless connect → `server/hello` → rejected → reconnect loop. A stray `Audio:StaticDelayMs: -40` in a user config triggered exactly this (hours of phantom "won't connect" debugging).

Per the **SDK 9.0.0** docs, the `set_static_delay` command path is *always non-negative*; a negative `static_delay_ms` is only legitimate as an SDK-internal **GroupSync calibration offset**, never a user-facing setting. So the client should never let a user configure a negative static delay.

## Fix

Clamp the user-facing static delay to **≥ 0** at every entry point:

- **Startup apply** from config (`App.xaml.cs`) and **MainViewModel config load** — a stale negative config now loads/applies as 0.
- **Runtime apply/save handler** (`OnSettingsStaticDelayMsChanged`) clamps before applying to the clock synchronizer and persisting.
- **Decrement command** floored at 0 (was −5000).
- **Settings UI:** slider `Minimum` 0 (was −5000); the Static Delay text field is now digits-only (no `-` typing or negative paste).

Also corrects the stale **CLAUDE.md** "Static Delay Tuning" note (v8.0.0 "−500 to +500 / negative = play later") to the v9.0.0 reality (non-negative, 0–5000).

Internal SDK GroupSync offsets are unaffected — this only constrains the user-configurable value.

## Test plan
- [x] Set Static Delay via slider/field — can't go below 0; can't type or paste a negative.
- [ ] A config with `Audio:StaticDelayMs: -40` loads as 0 and connects/stays connected (no handshake-drop loop).
- [ ] Positive values (e.g. 200 ms) still apply and persist normally.