### PR TITLE
fix: discard stale artwork fetch results after track change

### DIFF
--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -1089,6 +1089,14 @@ public partial class MainViewModel : ViewModelBase
 
             App.Current.Dispatcher.Invoke(() =>
             {
+                // Discard stale results: a track change (or newer artwork) may have
+                // superseded this fetch while it was in flight.
+                if (url != _lastArtworkUrl)
+                {
+                    _logger.LogDebug("Discarding stale artwork from {Url} (current: {CurrentUrl})", url, _lastArtworkUrl ?? "(none)");
+                    return;
+                }
+
                 AlbumArtwork = imageData;
                 _logger.LogDebug("Artwork loaded: {Length} bytes from {Url}", imageData.Length, url);
             });


### PR DESCRIPTION
## Summary
- An in-flight `FetchArtworkAsync` could complete after a track change had already cleared `AlbumArtwork`, overwriting the clear with the previous track's image
- Guard the assignment: only apply the fetched image if its URL still matches `_lastArtworkUrl`; the check runs on the dispatcher thread, the same thread that mutates `_lastArtworkUrl`, so there is no torn-read concern

## Context
This is the client-side half of the stale-artwork issue. The root cause (SDK swallowing explicit `"artwork_url": null` in the `server/state` metadata merge via `?? existing.ArtworkUrl`) is fixed separately in Sendspin.SDK 9.0.1. This guard closes the remaining race where a slow fetch for track A lands after track B cleared the artwork.

## Test plan
- [x] `dotnet build SendspinClient.sln` — 0 errors, no new warnings at edited lines
- [ ] With SDK 9.0.1: play a track with artwork, skip to a track without artwork — artwork clears and stays cleared