### PR TITLE
chore: bump Sendspin.SDK to 9.0.1

### DIFF
--- a/src/SendspinClient.Services/SendspinClient.Services.csproj
+++ b/src/SendspinClient.Services/SendspinClient.Services.csproj
@@ -23,7 +23,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.0.0" />
+    <PackageReference Include="Sendspin.SDK" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />

--- a/src/SendspinClient/SendspinClient.csproj
+++ b/src/SendspinClient/SendspinClient.csproj
@@ -63,7 +63,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.0.0" />
+    <PackageReference Include="Sendspin.SDK" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />


### PR DESCRIPTION
## Summary
- Bump `Sendspin.SDK` 9.0.0 → 9.0.1 in both csproj files
- 9.0.1 extends `Optional<T>` to all `ServerMetadata` fields, so explicit `"artwork_url": null` from the server (artless track, or `cleared_update()` on stop) clears the merged metadata instead of being swallowed by the `?? existing` merge
- Together with #41 (stale in-flight fetch guard), this fixes stale artwork persisting when the next track has no artwork

## Test plan
- [x] `dotnet restore` resolves Sendspin.SDK 9.0.1
- [x] `dotnet build SendspinClient.sln` — 0 errors
- [x] `dotnet test` — 46/46 passed
- [ ] Manual: play a track with artwork, skip to a track without artwork — artwork clears and stays cleared