### PR TITLE
style: align Stats for Nerds with the shared design system

### DIFF
--- a/src/SendspinClient/ViewModels/StatsViewModel.cs
+++ b/src/SendspinClient/ViewModels/StatsViewModel.cs
@@ -36,6 +36,15 @@ public partial class StatsViewModel : ViewModelBase
     private long? _lastSyncInsertedForSync;
     private const int UpdateIntervalMs = 100; // 10 updates per second
 
+    // Shared design-system brushes (Resources/Styles/Colors.xaml) so stat colors match the
+    // rest of the app instead of redefining their own palette. Resolved once, not per tick.
+    private static readonly Brush StatusGood = AppBrush("SuccessBrush");
+    private static readonly Brush StatusWarning = AppBrush("WarningBrush");
+    private static readonly Brush StatusBad = AppBrush("ErrorBrush");
+    private static readonly Brush StatusActive = AppBrush("AccentBrush");
+    private static readonly Brush ValueNeutral = AppBrush("TextPrimaryBrush");
+    private static readonly Brush ValueMuted = AppBrush("TextMutedBrush");
+
     #region Sync Status Properties
 
     /// <summary>
@@ -48,7 +57,7 @@ public partial class StatsViewModel : ViewModelBase
     /// Gets the color for the sync error display (green=good, yellow=warning, red=bad).
     /// </summary>
     [ObservableProperty]
-    private Brush _syncErrorColor = Brushes.Gray;
+    private Brush _syncErrorColor = ValueMuted;
 
     /// <summary>
     /// Gets the current correction mode display string.
@@ -60,7 +69,7 @@ public partial class StatsViewModel : ViewModelBase
     /// Gets the color for the correction mode display.
     /// </summary>
     [ObservableProperty]
-    private Brush _correctionModeColor = Brushes.Gray;
+    private Brush _correctionModeColor = ValueMuted;
 
     /// <summary>
     /// Gets whether playback is currently active.
@@ -78,7 +87,7 @@ public partial class StatsViewModel : ViewModelBase
     /// Gets the color for the health display (green all-clear, yellow when episodes exist).
     /// </summary>
     [ObservableProperty]
-    private Brush _healthColor = Brushes.Gray;
+    private Brush _healthColor = ValueMuted;
 
     #endregion
 
@@ -106,7 +115,7 @@ public partial class StatsViewModel : ViewModelBase
     /// Gets the color for underrun count (red if > 0).
     /// </summary>
     [ObservableProperty]
-    private Brush _underrunColor = Brushes.White;
+    private Brush _underrunColor = ValueNeutral;
 
     /// <summary>
     /// Gets the overrun count.
@@ -146,7 +155,7 @@ public partial class StatsViewModel : ViewModelBase
     /// Gets the color for the playback rate (cyan when actively correcting).
     /// </summary>
     [ObservableProperty]
-    private Brush _playbackRateColor = Brushes.White;
+    private Brush _playbackRateColor = ValueNeutral;
 
     #endregion
 
@@ -162,7 +171,7 @@ public partial class StatsViewModel : ViewModelBase
     /// Gets the color for the clock sync status.
     /// </summary>
     [ObservableProperty]
-    private Brush _clockSyncStatusColor = Brushes.Gray;
+    private Brush _clockSyncStatusColor = ValueMuted;
 
     /// <summary>
     /// Gets the clock offset display string.
@@ -198,7 +207,7 @@ public partial class StatsViewModel : ViewModelBase
     /// Gets the color for the drift reliable indicator.
     /// </summary>
     [ObservableProperty]
-    private Brush _driftReliableColor = Brushes.Gray;
+    private Brush _driftReliableColor = ValueMuted;
 
     /// <summary>
     /// Gets the static delay display string.
@@ -324,7 +333,7 @@ public partial class StatsViewModel : ViewModelBase
     /// Gets the color for the device capabilities display (green for hi-res, white otherwise).
     /// </summary>
     [ObservableProperty]
-    private Brush _deviceCapabilitiesColor = Brushes.White;
+    private Brush _deviceCapabilitiesColor = ValueNeutral;
 
     #endregion
 
@@ -396,8 +405,8 @@ public partial class StatsViewModel : ViewModelBase
     {
         HealthDisplay = _syncHealthMonitor.HealthDisplay;
         HealthColor = _syncHealthMonitor.EpisodeCount == 0
-            ? new SolidColorBrush(Color.FromRgb(0x4a, 0xde, 0x80))  // Green
-            : new SolidColorBrush(Color.FromRgb(0xfb, 0xbf, 0x24)); // Yellow
+            ? StatusGood  // Green
+            : StatusWarning; // Yellow
     }
 
     private void UpdateBufferStats()
@@ -407,9 +416,9 @@ public partial class StatsViewModel : ViewModelBase
         {
             // Pipeline not active
             SyncErrorDisplay = "-- ms";
-            SyncErrorColor = Brushes.Gray;
+            SyncErrorColor = ValueMuted;
             CorrectionModeDisplay = "Idle";
-            CorrectionModeColor = Brushes.Gray;
+            CorrectionModeColor = ValueMuted;
             IsPlaybackActive = "No";
             BufferedMsDisplay = "-- ms";
             TargetMsDisplay = "-- ms";
@@ -425,15 +434,15 @@ public partial class StatsViewModel : ViewModelBase
         var absError = Math.Abs(syncErrorMs);
         if (absError < 5)
         {
-            SyncErrorColor = new SolidColorBrush(Color.FromRgb(0x4a, 0xde, 0x80)); // Green
+            SyncErrorColor = StatusGood; // Green
         }
         else if (absError < 20)
         {
-            SyncErrorColor = new SolidColorBrush(Color.FromRgb(0xfb, 0xbf, 0x24)); // Yellow
+            SyncErrorColor = StatusWarning; // Yellow
         }
         else
         {
-            SyncErrorColor = new SolidColorBrush(Color.FromRgb(0xf8, 0x71, 0x71)); // Red
+            SyncErrorColor = StatusBad; // Red
         }
 
         // Correction Mode - show the tier actually acting this tick. The shipped strategy is
@@ -456,22 +465,22 @@ public partial class StatsViewModel : ViewModelBase
         if (droppedDelta > 0)
         {
             CorrectionModeDisplay = "Dropping";
-            CorrectionModeColor = new SolidColorBrush(Color.FromRgb(0xfb, 0xbf, 0x24)); // Yellow
+            CorrectionModeColor = StatusWarning; // Yellow
         }
         else if (insertedDelta > 0)
         {
             CorrectionModeDisplay = "Inserting";
-            CorrectionModeColor = new SolidColorBrush(Color.FromRgb(0xfb, 0xbf, 0x24)); // Yellow
+            CorrectionModeColor = StatusWarning; // Yellow
         }
         else if (resamplingActive)
         {
             CorrectionModeDisplay = "Resampling";
-            CorrectionModeColor = new SolidColorBrush(Color.FromRgb(0x60, 0xa5, 0xfa)); // Blue
+            CorrectionModeColor = StatusActive; // Blue
         }
         else
         {
             CorrectionModeDisplay = "None";
-            CorrectionModeColor = new SolidColorBrush(Color.FromRgb(0x4a, 0xde, 0x80)); // Green
+            CorrectionModeColor = StatusGood; // Green
         }
 
         // Playback Rate (for resampling-based sync correction). F5 so sub-0.1% trims are visible
@@ -479,8 +488,8 @@ public partial class StatsViewModel : ViewModelBase
         var rate = stats.TargetPlaybackRate;
         PlaybackRateDisplay = $"{rate:F5}x";
         PlaybackRateColor = Math.Abs(rate - 1.0) > 0.00002
-            ? new SolidColorBrush(Color.FromRgb(0x60, 0xa5, 0xfa)) // Blue when actively adjusting
-            : Brushes.White;
+            ? StatusActive // Blue when actively adjusting
+            : ValueNeutral;
 
         // Playback state
         IsPlaybackActive = stats.IsPlaybackActive ? "Yes" : "No";
@@ -492,8 +501,8 @@ public partial class StatsViewModel : ViewModelBase
         // Underruns/Overruns
         UnderrunCount = stats.UnderrunCount;
         UnderrunColor = stats.UnderrunCount > 0
-            ? new SolidColorBrush(Color.FromRgb(0xf8, 0x71, 0x71))
-            : Brushes.White;
+            ? StatusBad
+            : ValueNeutral;
         OverrunCount = stats.OverrunCount;
 
         // Sync correction stats
@@ -514,17 +523,17 @@ public partial class StatsViewModel : ViewModelBase
         if (status.IsConverged)
         {
             ClockSyncStatusDisplay = "✓ Synchronized";
-            ClockSyncStatusColor = new SolidColorBrush(Color.FromRgb(0x4a, 0xde, 0x80)); // Green
+            ClockSyncStatusColor = StatusGood; // Green
         }
         else if (status.MeasurementCount > 0)
         {
             ClockSyncStatusDisplay = "Syncing...";
-            ClockSyncStatusColor = new SolidColorBrush(Color.FromRgb(0xfb, 0xbf, 0x24)); // Yellow
+            ClockSyncStatusColor = StatusWarning; // Yellow
         }
         else
         {
             ClockSyncStatusDisplay = "Not synced";
-            ClockSyncStatusColor = Brushes.Gray;
+            ClockSyncStatusColor = ValueMuted;
         }
 
         ClockOffsetDisplay = $"{status.OffsetMilliseconds:+0.00;-0.00} ms";
@@ -541,17 +550,17 @@ public partial class StatsViewModel : ViewModelBase
         if (status.IsDriftReliable)
         {
             DriftReliableDisplay = "✓ Yes";
-            DriftReliableColor = new SolidColorBrush(Color.FromRgb(0x4a, 0xde, 0x80)); // Green
+            DriftReliableColor = StatusGood; // Green
         }
         else if (status.MeasurementCount > 0)
         {
             DriftReliableDisplay = "Calibrating...";
-            DriftReliableColor = new SolidColorBrush(Color.FromRgb(0xfb, 0xbf, 0x24)); // Yellow
+            DriftReliableColor = StatusWarning; // Yellow
         }
         else
         {
             DriftReliableDisplay = "No";
-            DriftReliableColor = Brushes.Gray;
+            DriftReliableColor = ValueMuted;
         }
 
         // Static delay (from clock synchronizer)
@@ -561,6 +570,15 @@ public partial class StatsViewModel : ViewModelBase
         var detectedLatency = _audioPipeline.DetectedOutputLatencyMs;
         OutputLatencyDisplay = detectedLatency > 0 ? $"{detectedLatency} ms" : "-- ms";
     }
+
+    /// <summary>
+    /// Resolves a brush from the application's shared style resources.
+    /// Falls back to a plain gray brush when resources are unavailable (e.g. design time).
+    /// </summary>
+    /// <param name="key">The resource key from Resources/Styles/Colors.xaml.</param>
+    /// <returns>The shared brush, or a gray fallback.</returns>
+    private static Brush AppBrush(string key) =>
+        System.Windows.Application.Current?.Resources[key] as Brush ?? new SolidColorBrush(Colors.Gray);
 
     private static string FormatSampleCount(long samples)
     {
@@ -648,8 +666,8 @@ public partial class StatsViewModel : ViewModelBase
 
         // Green for hi-res, white for standard
         DeviceCapabilitiesColor = isHiRes
-            ? new SolidColorBrush(Color.FromRgb(0x4a, 0xde, 0x80)) // Green
-            : Brushes.White;
+            ? StatusGood // Green
+            : ValueNeutral;
     }
 
     /// <summary>

--- a/src/SendspinClient/Views/StatsWindow.xaml
+++ b/src/SendspinClient/Views/StatsWindow.xaml
@@ -7,34 +7,18 @@
         Title="Stats for Nerds"
         Height="650" Width="420"
         MinHeight="500" MinWidth="350"
-        Background="#1a1a2e"
+        Style="{StaticResource MainWindowStyle}"
         WindowStartupLocation="CenterOwner">
 
     <Window.Resources>
-        <Style x:Key="StatLabel" TargetType="TextBlock">
-            <Setter Property="Foreground" Value="#888"/>
-            <Setter Property="FontSize" Value="11"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+        <!-- Local aliases derived from the shared design system (Resources/Styles/Controls.xaml).
+             Keep these BasedOn shared styles - no custom fonts/colors here. -->
+        <Style x:Key="StatLabel" TargetType="TextBlock" BasedOn="{StaticResource BodyText}"/>
+        <Style x:Key="StatValue" TargetType="TextBlock" BasedOn="{StaticResource BodyText}">
+            <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+            <Setter Property="FontWeight" Value="Medium"/>
         </Style>
-        <Style x:Key="StatValue" TargetType="TextBlock">
-            <Setter Property="Foreground" Value="#fff"/>
-            <Setter Property="FontSize" Value="13"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-        </Style>
-        <Style x:Key="StatValueGood" TargetType="TextBlock" BasedOn="{StaticResource StatValue}">
-            <Setter Property="Foreground" Value="#4ade80"/>
-        </Style>
-        <Style x:Key="StatValueWarning" TargetType="TextBlock" BasedOn="{StaticResource StatValue}">
-            <Setter Property="Foreground" Value="#fbbf24"/>
-        </Style>
-        <Style x:Key="StatValueBad" TargetType="TextBlock" BasedOn="{StaticResource StatValue}">
-            <Setter Property="Foreground" Value="#f87171"/>
-        </Style>
-        <Style x:Key="SectionHeader" TargetType="TextBlock">
-            <Setter Property="Foreground" Value="#a78bfa"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="FontWeight" Value="Bold"/>
+        <Style x:Key="SectionHeader" TargetType="TextBlock" BasedOn="{StaticResource CaptionText}">
             <Setter Property="Margin" Value="0,16,0,8"/>
         </Style>
     </Window.Resources>
@@ -48,16 +32,17 @@
 
         <!-- Header -->
         <StackPanel Grid.Row="0">
-            <TextBlock Text="Stats for Nerds" FontSize="18" FontWeight="Bold" Foreground="#fff"/>
-            <TextBlock Text="Real-time audio sync diagnostics" FontSize="11" Foreground="#888" Margin="0,4,0,0"/>
+            <TextBlock Text="Stats for Nerds" Style="{StaticResource SubHeaderText}"/>
+            <TextBlock Text="Real-time audio sync diagnostics" Style="{StaticResource CaptionText}" Margin="0,4,0,0"/>
         </StackPanel>
 
         <!-- Stats Content -->
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,16,0,0">
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,16,0,0"
+                      Style="{StaticResource DarkScrollViewer}">
             <StackPanel>
                 <!-- Audio Format -->
                 <TextBlock Text="AUDIO FORMAT" Style="{StaticResource SectionHeader}" Margin="0,0,0,8"/>
-                <Border Background="#2d2d44" CornerRadius="8" Padding="12" Margin="0,0,0,8">
+                <Border Background="{StaticResource SurfaceBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -76,11 +61,11 @@
 
                         <!-- Input (Incoming) Section Header -->
                         <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Incoming Stream"
-                                   Foreground="#60a5fa" FontSize="10" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                                   Style="{StaticResource CaptionText}" Foreground="{StaticResource AccentBrush}" Margin="0,0,0,6"/>
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Format" Style="{StaticResource StatLabel}"/>
                         <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding InputFormatDisplay}"
-                                   Style="{StaticResource StatValue}" Foreground="#4ade80"/>
+                                   Style="{StaticResource StatValue}" Foreground="{StaticResource SuccessBrush}"/>
 
                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Sample Rate" Style="{StaticResource StatLabel}" Margin="0,6,0,0"/>
                         <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding InputSampleRateDisplay}"
@@ -92,11 +77,11 @@
 
                         <!-- Output Section Header -->
                         <TextBlock Grid.Row="4" Grid.ColumnSpan="2" Text="Output to Device"
-                                   Foreground="#60a5fa" FontSize="10" FontWeight="SemiBold" Margin="0,14,0,6"/>
+                                   Style="{StaticResource CaptionText}" Foreground="{StaticResource AccentBrush}" Margin="0,14,0,6"/>
 
                         <TextBlock Grid.Row="5" Grid.Column="0" Text="Format" Style="{StaticResource StatLabel}"/>
                         <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding OutputFormatDisplay}"
-                                   Style="{StaticResource StatValue}" Foreground="#a78bfa"/>
+                                   Style="{StaticResource StatValue}" Foreground="{StaticResource PrimaryLightBrush}"/>
 
                         <TextBlock Grid.Row="6" Grid.Column="0" Text="Sample Rate" Style="{StaticResource StatLabel}" Margin="0,6,0,0"/>
                         <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding OutputSampleRateDisplay}"
@@ -110,7 +95,7 @@
 
                 <!-- Advertised Capabilities -->
                 <TextBlock Text="ADVERTISED CAPABILITIES" Style="{StaticResource SectionHeader}"/>
-                <Border Background="#2d2d44" CornerRadius="8" Padding="12" Margin="0,0,0,8">
+                <Border Background="{StaticResource SurfaceBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -124,7 +109,7 @@
 
                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Codec Priority" Style="{StaticResource StatLabel}"/>
                         <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding AdvertisedCodecOrder}"
-                                   Style="{StaticResource StatValue}" Foreground="#a78bfa"/>
+                                   Style="{StaticResource StatValue}" Foreground="{StaticResource PrimaryLightBrush}"/>
 
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="Supported Formats" Style="{StaticResource StatLabel}" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding AdvertisedFormatsDisplay}"
@@ -139,7 +124,7 @@
 
                 <!-- Sync Status -->
                 <TextBlock Text="SYNC STATUS" Style="{StaticResource SectionHeader}"/>
-                <Border Background="#2d2d44" CornerRadius="8" Padding="12" Margin="0,0,0,8">
+                <Border Background="{StaticResource SurfaceBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -175,7 +160,7 @@
 
                 <!-- Buffer Stats -->
                 <TextBlock Text="BUFFER" Style="{StaticResource SectionHeader}"/>
-                <Border Background="#2d2d44" CornerRadius="8" Padding="12" Margin="0,0,0,8">
+                <Border Background="{StaticResource SurfaceBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -206,7 +191,7 @@
 
                 <!-- Correction Stats -->
                 <TextBlock Text="SYNC CORRECTION" Style="{StaticResource SectionHeader}"/>
-                <Border Background="#2d2d44" CornerRadius="8" Padding="12" Margin="0,0,0,8">
+                <Border Background="{StaticResource SurfaceBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -237,7 +222,7 @@
 
                 <!-- Clock Sync -->
                 <TextBlock Text="CLOCK SYNC" Style="{StaticResource SectionHeader}"/>
-                <Border Background="#2d2d44" CornerRadius="8" Padding="12" Margin="0,0,0,8">
+                <Border Background="{StaticResource SurfaceBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -278,17 +263,17 @@
 
                         <TextBlock Grid.Row="6" Grid.Column="0" Text="Output Latency" Style="{StaticResource StatLabel}" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding OutputLatencyDisplay}" Style="{StaticResource StatValue}" Margin="0,8,0,0"
-                                   Foreground="#fbbf24"/>
+                                   Foreground="{StaticResource WarningBrush}"/>
 
                         <TextBlock Grid.Row="7" Grid.Column="0" Text="Static Delay" Style="{StaticResource StatLabel}" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding StaticDelayDisplay}" Style="{StaticResource StatValue}" Margin="0,8,0,0"
-                                   Foreground="#60a5fa"/>
+                                   Foreground="{StaticResource AccentBrush}"/>
                     </Grid>
                 </Border>
 
                 <!-- Throughput -->
                 <TextBlock Text="THROUGHPUT" Style="{StaticResource SectionHeader}"/>
-                <Border Background="#2d2d44" CornerRadius="8" Padding="12" Margin="0,0,0,8">
+                <Border Background="{StaticResource SurfaceBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -314,31 +299,9 @@
         <StackPanel Grid.Row="2" Margin="0,16,0,0">
             <TextBlock Text="{Binding UpdateRateDisplay}" Style="{StaticResource StatLabel}" HorizontalAlignment="Center"/>
             <Button Content="Close" Click="CloseButton_Click"
+                    Style="{StaticResource PrimaryButton}"
                     HorizontalAlignment="Center" Margin="0,12,0,0"
-                    Padding="24,8"
-                    Background="#4f46e5" Foreground="White"
-                    BorderThickness="0" Cursor="Hand">
-                <Button.Style>
-                    <Style TargetType="Button">
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="Button">
-                                    <Border Background="{TemplateBinding Background}"
-                                            CornerRadius="6"
-                                            Padding="{TemplateBinding Padding}">
-                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                    </Border>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                        <Style.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter Property="Opacity" Value="0.9"/>
-                            </Trigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Style>
-            </Button>
+                    Padding="24,8"/>
         </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- StatsWindow now uses the shared design system instead of its own custom styling:
  - Window: `MainWindowStyle` (was hardcoded `#1a1a2e`, a near-miss of the real `#1E1E2E` token)
  - Type: Segoe UI via `BodyText`/`CaptionText`/`SubHeaderText` (was Consolas at custom sizes)
  - Cards: `SurfaceBrush` (matches the Settings panel surface)
  - Accent colors: `SuccessBrush`/`WarningBrush`/`ErrorBrush`/`AccentBrush`/`PrimaryLightBrush` tokens (was `#4ade80`/`#fbbf24`/`#f87171`/`#60a5fa`/`#a78bfa`)
  - Close button: `PrimaryButton` style (was a duplicated inline template with off-palette `#4f46e5`)
  - Scrollbar: `DarkScrollViewer` (was default Windows chrome)
- Local `StatLabel`/`StatValue`/`SectionHeader` styles kept as thin `BasedOn` aliases of the shared styles; unused `StatValueGood/Warning/Bad` removed
- `StatsViewModel` status colors resolve the shared brushes once at startup (also removes per-tick `SolidColorBrush` allocations at 10 Hz)

## Test plan
- [x] Build clean, 86/86 tests
- [x] All referenced resource keys verified present in Colors.xaml/Controls.xaml (StaticResource failures are runtime errors)
- [ ] Visual check: open Stats for Nerds next to Settings - same surfaces, type, and accent palette