### PR TITLE
chore: bump Sendspin.SDK to 9.0.3

### DIFF
--- a/src/SendspinClient.Services/SendspinClient.Services.csproj
+++ b/src/SendspinClient.Services/SendspinClient.Services.csproj
@@ -23,7 +23,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.0.2" />
+    <PackageReference Include="Sendspin.SDK" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />

--- a/src/SendspinClient/SendspinClient.csproj
+++ b/src/SendspinClient/SendspinClient.csproj
@@ -63,7 +63,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.0.2" />
+    <PackageReference Include="Sendspin.SDK" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />


### PR DESCRIPTION
Bumps the SDK package reference from 9.0.2 to 9.0.3 in both projects.

9.0.3 (sendspin-dotnet PR #55, published from tag v9.0.3) carries the timing-path fixes validated this morning:

- **Mid-track join fix**: segment playback times are derived from raw server timestamps at read time, so the initial burst is no longer discarded as "stale" when it arrives before clock sync converges. Joining an already-playing stream now starts at the correct position with the full ~30s buffer instead of ~1s, ~30s ahead.
- **Startup baseline self-zeroing**: constant read-pointer plumbing offsets (e.g. the WASAPI prefill gulp) are measured and subtracted at the end of the startup grace window instead of being audibly ground out via frame insertion (~880 inserts/sec for 15-20s).
- **Resampling threshold default 15ms to 100ms**: moderate sync errors now correct via inaudible rate adjustment rather than frame drop/insert.
- **MonotonicTimer clamp 50ms to 500ms**: no longer misfires on normal ~96ms chunk-receive polling gaps (26,500+ false clamps observed in one session).

Verified locally: solution builds against the published package (0 errors), `Sendspin.SDK 9.0.3` resolves from nuget.org. Fresh-play happy path validated against the SDK source build (`sdkdev.3dd1766`): sane scheduled start, zero corrections, sync error steady at +0.96ms.

Remaining field validation: launch-while-playing repro on the affected user's machine (expect no stale-skip line, ~30s buffer, no stutter).