### PR TITLE
fix: conceal resampler shortfalls (issue #33 stutter) - feeding + hold-pad

### DIFF
--- a/src/SendspinClient.Services/Audio/DynamicResamplerSampleProvider.cs
+++ b/src/SendspinClient.Services/Audio/DynamicResamplerSampleProvider.cs
@@ -34,6 +34,9 @@ public sealed class DynamicResamplerSampleProvider : ISampleProvider, IDisposabl
     private double _playbackRate = 1.0;
     private bool _disposed;
 
+    // Last frame actually produced, held across a shortfall instead of writing silence.
+    private readonly float[] _lastFrame;
+
     // Underrun tracking for diagnostics
     private long _sourceEmptyCount;
     private long _resamplerShortCount;
@@ -161,6 +164,8 @@ public sealed class DynamicResamplerSampleProvider : ISampleProvider, IDisposabl
             _logger?.LogDebug("Resampler configured for sync correction only (no sample rate conversion)");
         }
 
+        _lastFrame = new float[WaveFormat.Channels];
+
         // Initialize WDL resampler
         // Reduced from 32 to 16 taps - 32-tap was causing audible artifacts during
         // dynamic rate changes. 16-tap provides good quality with faster adaptation
@@ -199,20 +204,22 @@ public sealed class DynamicResamplerSampleProvider : ISampleProvider, IDisposabl
         // history - then read exactly that many straight into the resampler's own buffer.
         // This is NAudio's canonical WdlResamplingSampleProvider usage.
         //
-        // The previous implementation computed the input count itself (count * rate *
-        // sourceRate/targetRate). That figure ignores the WDL filter's priming latency, so the
-        // resampler was perpetually under-fed by a frame or two and emitted fewer samples than
-        // requested - padded with silence. At rate ~1.0 it fired on nearly every callback,
-        // surfacing as audible stutter on revealing external DACs.
+        // ResamplePrepare's count is ratio*out + filter-priming margin - already-buffered input
+        // (see NAudio's WdlResamplingSampleProvider). The previous implementation computed the
+        // read size itself as count * rate * sourceRate/targetRate, which omits that priming
+        // margin, so the filter was under-fed and emitted fewer samples than requested whenever
+        // the rate sat off 1.0 (i.e. under continuous drift correction). The shortfall was padded
+        // with digital silence and surfaced as audible stutter on revealing external DACs.
         //
-        // We intentionally do NOT bypass the resampler at rate 1.0: the WDL filter carries
-        // state across calls, and dropping out of the path disrupts it and causes pops.
+        // We intentionally do NOT bypass the resampler at rate 1.0: the WDL filter carries state
+        // across calls, and dropping out of the path disrupts it and causes pops.
         var framesNeeded = _resampler.ResamplePrepare(outputFrames, channels, out var inBuffer, out var inBufferOffset);
         var framesRead = _source.Read(inBuffer, inBufferOffset, framesNeeded * channels) / channels;
 
         if (framesRead == 0)
         {
-            // Source genuinely empty - fill with silence and track the underrun.
+            // Source genuinely empty (sustained upstream/network stall) - silence is correct here;
+            // holding a sample across a long gap would leave an audible stuck DC offset.
             Interlocked.Increment(ref _sourceEmptyCount);
             LogUnderrunIfNeeded("source empty");
             Array.Fill(buffer, 0f, offset, count);
@@ -222,13 +229,29 @@ public sealed class DynamicResamplerSampleProvider : ISampleProvider, IDisposabl
         var framesGenerated = _resampler.ResampleOut(buffer, offset, framesRead, outputFrames, channels);
         var samplesGenerated = framesGenerated * channels;
 
-        // A shortfall here now means the source delivered fewer frames than the resampler
-        // asked for (a real upstream/network underrun), not a filter-priming deficit.
+        // Remember the last frame actually produced, for zero-order-hold concealment.
+        if (samplesGenerated >= channels)
+        {
+            Array.Copy(buffer, offset + samplesGenerated - channels, _lastFrame, 0, channels);
+        }
+
+        // Output-driven feeding removes the priming deficit, but the WDL filter can still come up
+        // a frame or two short on a rate change (the input/output accounting momentarily shifts
+        // when SetRates changes the ratio). Conceal that residual by holding the last produced
+        // frame (zero-order hold) rather than writing silence: a silence gap is a step
+        // discontinuity - a broadband click - while a held sample keeps the waveform continuous
+        // and is inaudible at 1-2 frames. This is standard packet-loss concealment. If a callback
+        // produced nothing at all, _lastFrame carries the previous callback's frame; it is zero
+        // only before the very first frame of the stream.
         if (samplesGenerated < count)
         {
             Interlocked.Increment(ref _resamplerShortCount);
             LogUnderrunIfNeeded($"resampler short: got {samplesGenerated}, needed {count}");
-            Array.Fill(buffer, 0f, offset + samplesGenerated, count - samplesGenerated);
+
+            for (var i = samplesGenerated; i < count; i++)
+            {
+                buffer[offset + i] = _lastFrame[i % channels];
+            }
         }
 
         return count;

--- a/src/SendspinClient.Services/Audio/DynamicResamplerSampleProvider.cs
+++ b/src/SendspinClient.Services/Audio/DynamicResamplerSampleProvider.cs
@@ -32,7 +32,6 @@ public sealed class DynamicResamplerSampleProvider : ISampleProvider, IDisposabl
     private readonly int _targetSampleRate;
 
     private double _playbackRate = 1.0;
-    private float[] _sourceBuffer;
     private bool _disposed;
 
     // Underrun tracking for diagnostics
@@ -172,19 +171,6 @@ public sealed class DynamicResamplerSampleProvider : ISampleProvider, IDisposabl
         _resampler.SetFeedMode(true); // We're in output-driven mode (request N output samples)
         UpdateResamplerRates();
 
-        // Pre-allocate source buffer sized for worst-case to avoid audio thread allocations.
-        // Must account for:
-        // - Max WASAPI buffer request (~16384 samples for 100ms+ latency at 48kHz stereo)
-        // - Max playback rate (1.04x)
-        // - Sample rate conversion ratio (e.g., 96kHz→48kHz = 2.0x)
-        //
-        // Formula: maxOutputRequest * MaxRate * sampleRateRatio * safetyMargin
-        const int MaxExpectedOutputRequest = 16384;
-        const double SafetyMargin = 1.2; // 20% extra headroom
-        var sampleRateRatio = (double)source.WaveFormat.SampleRate / _targetSampleRate;
-        var bufferSize = (int)(MaxExpectedOutputRequest * MaxRate * sampleRateRatio * SafetyMargin);
-        _sourceBuffer = new float[bufferSize];
-
         // Subscribe to correction provider rate changes if available
         if (_correctionProvider != null)
         {
@@ -205,100 +191,47 @@ public sealed class DynamicResamplerSampleProvider : ISampleProvider, IDisposabl
             return 0;
         }
 
-        double currentRate;
-        lock (_rateLock)
-        {
-            currentRate = _playbackRate;
-        }
+        var channels = WaveFormat.Channels;
+        var outputFrames = count / channels;
 
-        // NOTE: We intentionally do NOT bypass the resampler even at rate 1.0.
-        // Bypassing causes audible pops when transitioning in/out of resampling mode
-        // because the WDL resampler has internal filter state that gets disrupted.
-        // At rate 1.0, the resampler acts as a passthrough but maintains consistent state.
-
-        // Calculate how many source samples we need for the requested output samples.
-        // Must account for BOTH sample rate conversion AND sync correction:
-        // - Sample rate ratio: sourceRate / targetRate (e.g., 48k/44.1k = 1.088)
-        // - Playback rate: currentRate (e.g., 1.02 for 2% speedup)
+        // Output-driven (feed) mode: ask the resampler how many INPUT frames it needs to
+        // produce outputFrames - accounting for its current rate AND its internal sinc-filter
+        // history - then read exactly that many straight into the resampler's own buffer.
+        // This is NAudio's canonical WdlResamplingSampleProvider usage.
         //
-        // Example: 48kHz source, 44.1kHz target, 1.02x playback, 2048 output samples:
-        // inputNeeded = 2048 * 1.02 * (48000/44100) = 2048 * 1.02 * 1.088 = 2274
+        // The previous implementation computed the input count itself (count * rate *
+        // sourceRate/targetRate). That figure ignores the WDL filter's priming latency, so the
+        // resampler was perpetually under-fed by a frame or two and emitted fewer samples than
+        // requested - padded with silence. At rate ~1.0 it fired on nearly every callback,
+        // surfacing as audible stutter on revealing external DACs.
         //
-        // Without this, downsampling (source > target) would starve the resampler,
-        // causing it to produce fewer output samples and resulting in silence gaps.
-        var sampleRateRatio = (double)_source.WaveFormat.SampleRate / _targetSampleRate;
-        var inputSamplesNeeded = (int)Math.Ceiling(count * currentRate * sampleRateRatio);
+        // We intentionally do NOT bypass the resampler at rate 1.0: the WDL filter carries
+        // state across calls, and dropping out of the path disrupts it and causes pops.
+        var framesNeeded = _resampler.ResamplePrepare(outputFrames, channels, out var inBuffer, out var inBufferOffset);
+        var framesRead = _source.Read(inBuffer, inBufferOffset, framesNeeded * channels) / channels;
 
-        // Ensure source buffer is large enough.
-        // This should rarely happen with proper pre-allocation, but handle it as a safety net.
-        if (_sourceBuffer.Length < inputSamplesNeeded)
+        if (framesRead == 0)
         {
-            _logger?.LogWarning(
-                "Audio thread buffer reallocation triggered: needed {Needed}, had {Had}. " +
-                "Consider increasing MaxExpectedOutputRequest.",
-                inputSamplesNeeded,
-                _sourceBuffer.Length);
-            _sourceBuffer = new float[inputSamplesNeeded * 2];
-        }
-
-        // Read from source
-        var inputRead = _source.Read(_sourceBuffer, 0, inputSamplesNeeded);
-
-        if (inputRead == 0)
-        {
-            // Source is empty - fill with silence and track underrun
+            // Source genuinely empty - fill with silence and track the underrun.
             Interlocked.Increment(ref _sourceEmptyCount);
             LogUnderrunIfNeeded("source empty");
             Array.Fill(buffer, 0f, offset, count);
             return count;
         }
 
-        // Resample
-        var outputGenerated = Resample(_sourceBuffer, inputRead, buffer, offset, count);
+        var framesGenerated = _resampler.ResampleOut(buffer, offset, framesRead, outputFrames, channels);
+        var samplesGenerated = framesGenerated * channels;
 
-        // If we didn't generate enough output, pad with silence and track underrun
-        if (outputGenerated < count)
+        // A shortfall here now means the source delivered fewer frames than the resampler
+        // asked for (a real upstream/network underrun), not a filter-priming deficit.
+        if (samplesGenerated < count)
         {
             Interlocked.Increment(ref _resamplerShortCount);
-            LogUnderrunIfNeeded($"resampler short: got {outputGenerated}, needed {count}");
-            Array.Fill(buffer, 0f, offset + outputGenerated, count - outputGenerated);
+            LogUnderrunIfNeeded($"resampler short: got {samplesGenerated}, needed {count}");
+            Array.Fill(buffer, 0f, offset + samplesGenerated, count - samplesGenerated);
         }
 
         return count;
-    }
-
-    /// <summary>
-    /// Performs the actual resampling using WDL resampler.
-    /// </summary>
-    private int Resample(float[] input, int inputCount, float[] output, int outputOffset, int outputCount)
-    {
-        var channels = WaveFormat.Channels;
-        var inputFrames = inputCount / channels;
-        var outputFrames = outputCount / channels;
-
-        // Get resampler's input buffer - includes offset parameter for where to write
-        var framesNeeded = _resampler.ResamplePrepare(outputFrames, channels, out var inBuffer, out var inBufferOffset);
-
-        // Copy our input to resampler's buffer at the correct offset
-        var framesToCopy = Math.Min(inputFrames, framesNeeded);
-        var samplesToCopy = framesToCopy * channels;
-        for (var i = 0; i < samplesToCopy; i++)
-        {
-            inBuffer[inBufferOffset + i] = input[i];
-        }
-
-        // Process through resampler directly into output buffer
-        var framesGenerated = _resampler.ResampleOut(output, outputOffset, framesToCopy, outputFrames, channels);
-
-        var samplesGenerated = framesGenerated * channels;
-
-        // Soft clipping disabled - was causing audible "overdrive" artifacts even on normal audio.
-        // The WDL resampler's output is typically within ±1.0 for well-mastered content.
-        // Any occasional overshoots from sinc filter ringing will be handled by the DAC's
-        // built-in clipping, which is less audible than our soft clipper engaging frequently.
-        // ApplySoftClipping(output, outputOffset, samplesGenerated);
-
-        return samplesGenerated;
     }
 
     /// <summary>

--- a/tests/SendspinClient.Services.Tests/Audio/DynamicResamplerSampleProviderTests.cs
+++ b/tests/SendspinClient.Services.Tests/Audio/DynamicResamplerSampleProviderTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="DynamicResamplerSampleProviderTests.cs" company="Sendspin Windows Client">
+// Licensed under the MIT License. See LICENSE file in the project root.
+// </copyright>
+
+using NAudio.Wave;
+using SendspinClient.Services.Audio;
+using Xunit;
+
+namespace SendspinClient.Services.Tests.Audio;
+
+public class DynamicResamplerSampleProviderTests
+{
+    /// <summary>
+    /// A source that always satisfies the full requested count, so any resampler
+    /// shortfall is purely the WDL filter-priming deficit - never a genuine source underrun.
+    /// </summary>
+    private sealed class FullSampleProvider : ISampleProvider
+    {
+        private float _phase = -0.5f;
+
+        public FullSampleProvider(int sampleRate, int channels)
+        {
+            WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
+        }
+
+        public WaveFormat WaveFormat { get; }
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            // Low-amplitude ramp so the output is real audio, not silence.
+            for (var i = 0; i < count; i++)
+            {
+                buffer[offset + i] = _phase;
+                _phase += 0.0001f;
+                if (_phase > 0.5f)
+                {
+                    _phase = -0.5f;
+                }
+            }
+
+            return count;
+        }
+    }
+
+    [Fact]
+    public void IdentityRate_FullSource_NeverPadsSilence()
+    {
+        const int sampleRate = 44100;
+        const int channels = 2;
+
+        var source = new FullSampleProvider(sampleRate, channels);
+
+        // targetSampleRate == source rate => identity resampling (sync-correction only),
+        // playback rate stays 1.0 with no correction provider. This is fletchowns' USB-DAC case.
+        using var resampler = new DynamicResamplerSampleProvider(source, correctionProvider: null, targetSampleRate: sampleRate);
+
+        // 882 interleaved samples == 441 frames == one 10 ms WASAPI period at 44.1 kHz.
+        const int count = 882;
+        var buffer = new float[count];
+
+        // The first callback primes the WDL filter's history; like NAudio's own resampler it may
+        // emit a single short frame here (one ~22 µs frame at stream start - inaudible).
+        resampler.Read(buffer, 0, count);
+        var shortsAfterPriming = resampler.ResamplerShortCount;
+        Assert.True(
+            shortsAfterPriming <= 1,
+            $"startup priming should cost at most one frame, got {shortsAfterPriming}");
+
+        // ~3 seconds of steady-state callbacks. The previous implementation under-fed the WDL
+        // filter by its priming latency and padded silence on essentially every callback
+        // (observed as 861 shorts in 21 s on a USB DAC). Output-driven feeding must accumulate
+        // zero further shorts once primed.
+        for (var i = 0; i < 300; i++)
+        {
+            var read = resampler.Read(buffer, 0, count);
+            Assert.Equal(count, read);
+        }
+
+        Assert.Equal(shortsAfterPriming, resampler.ResamplerShortCount);
+        Assert.Equal(0L, resampler.SourceEmptyCount);
+    }
+}

--- a/tests/SendspinClient.Services.Tests/Audio/DynamicResamplerSampleProviderTests.cs
+++ b/tests/SendspinClient.Services.Tests/Audio/DynamicResamplerSampleProviderTests.cs
@@ -11,72 +11,87 @@ namespace SendspinClient.Services.Tests.Audio;
 public class DynamicResamplerSampleProviderTests
 {
     /// <summary>
-    /// A source that always satisfies the full requested count, so any resampler
-    /// shortfall is purely the WDL filter-priming deficit - never a genuine source underrun.
+    /// A source that always returns the full requested count of a constant DC value. A correct
+    /// resampler passes DC through unchanged, so the only way an output sample can collapse toward
+    /// zero is an injected silence pad - which makes silence-gap concealment directly testable.
     /// </summary>
-    private sealed class FullSampleProvider : ISampleProvider
+    private sealed class ConstantSampleProvider : ISampleProvider
     {
-        private float _phase = -0.5f;
+        private readonly float _value;
 
-        public FullSampleProvider(int sampleRate, int channels)
+        public ConstantSampleProvider(int sampleRate, int channels, float value)
         {
             WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
+            _value = value;
         }
 
         public WaveFormat WaveFormat { get; }
 
         public int Read(float[] buffer, int offset, int count)
         {
-            // Low-amplitude ramp so the output is real audio, not silence.
-            for (var i = 0; i < count; i++)
-            {
-                buffer[offset + i] = _phase;
-                _phase += 0.0001f;
-                if (_phase > 0.5f)
-                {
-                    _phase = -0.5f;
-                }
-            }
-
+            Array.Fill(buffer, _value, offset, count);
             return count;
         }
     }
 
     [Fact]
-    public void IdentityRate_FullSource_NeverPadsSilence()
+    public void RateCorrection_ConcealsShortfalls_WithoutSilenceGaps()
     {
         const int sampleRate = 44100;
         const int channels = 2;
+        const float dc = 0.5f;
 
-        var source = new FullSampleProvider(sampleRate, channels);
+        var source = new ConstantSampleProvider(sampleRate, channels, dc);
 
-        // targetSampleRate == source rate => identity resampling (sync-correction only),
-        // playback rate stays 1.0 with no correction provider. This is fletchowns' USB-DAC case.
+        // targetSampleRate == source rate => identity resampling, sync-correction only.
         using var resampler = new DynamicResamplerSampleProvider(source, correctionProvider: null, targetSampleRate: sampleRate);
 
         // 882 interleaved samples == 441 frames == one 10 ms WASAPI period at 44.1 kHz.
         const int count = 882;
         var buffer = new float[count];
 
-        // The first callback primes the WDL filter's history; like NAudio's own resampler it may
-        // emit a single short frame here (one ~22 µs frame at stream start - inaudible).
-        resampler.Read(buffer, 0, count);
-        var shortsAfterPriming = resampler.ResamplerShortCount;
-        Assert.True(
-            shortsAfterPriming <= 1,
-            $"startup priming should cost at most one frame, got {shortsAfterPriming}");
-
-        // ~3 seconds of steady-state callbacks. The previous implementation under-fed the WDL
-        // filter by its priming latency and padded silence on essentially every callback
-        // (observed as 861 shorts in 21 s on a USB DAC). Output-driven feeding must accumulate
-        // zero further shorts once primed.
-        for (var i = 0; i < 300; i++)
+        // Warm up: the WDL filter's output ramps from 0 to the DC level as its history fills.
+        for (var i = 0; i < 5; i++)
         {
-            var read = resampler.Read(buffer, 0, count);
-            Assert.Equal(count, read);
+            resampler.Read(buffer, 0, count);
         }
 
-        Assert.Equal(shortsAfterPriming, resampler.ResamplerShortCount);
-        Assert.Equal(0L, resampler.SourceEmptyCount);
+        // ~3 s of callbacks under continuous drift correction - the rate is nudged every callback,
+        // the regime where a USB DAC's drift keeps the corrector adjusting and the WDL filter comes
+        // up 1-2 frames short. The previous code padded those shorts with digital silence (an
+        // audible click, 861 events in 21 s observed on a USB DAC); the fix conceals them by holding
+        // the last sample.
+        //
+        // Silence pads are bit-exact 0.0f (Array.Fill); a DC input through the resampler never
+        // produces exact zero, and a held DC frame is ~0.5. So an exact-zero output sample is the
+        // unambiguous signature of a leaked silence pad. (Note: the resampler still has its own
+        // amplitude transient on each rate change - a non-zero dip - which is a separate, pre-
+        // existing matter addressed by the clock/loop architecture work, not by concealment.)
+        var rate = 1.0;
+        var step = 0.00005;
+        var silenceSamples = 0;
+        for (var i = 0; i < 300; i++)
+        {
+            rate += step;
+            if (rate is > 1.002 or < 0.998)
+            {
+                step = -step;
+            }
+
+            resampler.PlaybackRate = rate;
+            resampler.Read(buffer, 0, count);
+
+            foreach (var sample in buffer)
+            {
+                if (sample == 0f)
+                {
+                    silenceSamples++;
+                }
+            }
+        }
+
+        // Guard that the run actually hit the shortfall path, so the concealment was exercised.
+        Assert.True(resampler.ResamplerShortCount > 0, "test did not exercise the resampler-short path");
+        Assert.Equal(0, silenceSamples);
     }
 }


### PR DESCRIPTION
## What this is (and isn''t)

This fixes the **audible** part of the #33 stutter: `DynamicResamplerSampleProvider` was padding momentary resampler shortfalls with **digital silence**, which is a step discontinuity - a broadband click. This is **concealment + fewer shortfalls**, not the root architectural fix (see "Scope" below). The SDK sync corrections were never the cause - fletchowns'' sync-health logs show `drops=0 inserts=0` throughout; the audible artifact is entirely in this provider.

## Two parts

**1. Output-driven feeding (correctness).** The old code computed its own source read size as `count * rate * sourceRate/targetRate`. NAudio''s `WdlResamplingSampleProvider` and the WDL source show the real figure is `ratio*out + filter-priming-margin - already-buffered`, obtained from `ResamplePrepare`. The self-computed figure omits the priming margin, so the filter was under-fed and came up short **whenever the rate sat off 1.0** (under continuous drift correction - not at rate 1.0, which I originally claimed). Now we ask `ResamplePrepare` first and read exactly that into its buffer. Cuts shortfalls ~60% in a rate-varying stress test (88 to 36 per 300 callbacks).

**2. Zero-order-hold concealment (audibility).** Feeding does not eliminate shortfalls - the WDL filter still emits a frame or two short right after a `SetRates`. Conceal the residual by holding the last produced frame instead of silence. Inaudible at 1-2 frames; standard packet-loss concealment. A persisted `_lastFrame` covers the rare callback that produces nothing. The genuine source-empty (sustained stall) path keeps silence deliberately - holding across a long gap would leave a stuck DC offset.

## Verification

- New regression test drives continuous rate correction and asserts no bit-exact-zero sample leaks through concealment while the shortfall path is exercised. **Red on the pre-fix code (174 silence samples), green after.** (The earlier rate=1.0 test was too weak - it passed on the old code too - and has been replaced.)
- Full suite green (87/87), solution builds clean.

## Scope / what this does NOT fix

The shortfalls are a symptom of an over-reactive correction loop: the rate keeps churning because sync is timed against the **wall clock** (MonotonicTimer), not the device clock. Validated against Snapcast (`snd_pcm_avail_delay` -> device clock), shairport-sync (ALSA DAC timing), and the WASAPI docs (`IAudioClock::GetPosition` tracks true DAC drift). The real resolution - implementing the WASAPI audio clock and tightening the correction loop toward ppm-level (Snapcast caps at +/-500ppm; we use +/-2-4%) - is a separate effort being written up. This PR makes the symptom inaudible in the meantime and is worth shipping for the affected USB-DAC user to re-test with verbose logs.