### PR TITLE
feat: time sync against the WASAPI device clock (issue #33)

### DIFF
--- a/docs/sync-clock-architecture-plan.md
+++ b/docs/sync-clock-architecture-plan.md
@@ -50,6 +50,39 @@ shortfalls would largely disappear at the source.
 
 ## Part A — Implement the WASAPI audio clock (app side)
 
+> **Status: implemented (Phase 0 probe + Phase 1 wiring).** The probe confirmed `IAudioClock`
+> reads sane, monotonically-advancing values at ratio ~1.0000 in shared mode over ~100 s on a
+> wired desktop — refuting the interface comment's "shared mode → null" assumption. Phase 1 wires
+> it in as the live sync-timing source.
+>
+> Because the app moved sync correction **app-side**, the real integration point is **not** the
+> SDK's `GetAudioClockMicroseconds()` (the SDK only calls that once, at pipeline setup). It is the
+> `GetSyncTimeMicroseconds` delegate that `WasapiAudioPlayer` passes to `SyncCorrectedSampleSource`
+> — invoked per render read, which is the actual playback-sync timing path. That delegate now reads
+> `IAudioClock` and returns it via [`DeviceClockAnchor`](../src/SendspinClient.Services/Audio/DeviceClockAnchor.cs).
+>
+> **Anchoring.** The device position starts near 0; the wall clock is a huge epoch value. We capture
+> `offset = wall − device` once, then return `device + offset`. The offset cancels in the buffer's
+> `elapsed = now − start`, so downstream sees true device-paced elapsed while the absolute value
+> rides the wall-clock timeline — making device↔wall transitions a continuous hand-off, not a cliff.
+>
+> **Escape hatch + auto-fallback.** `Audio:SyncCorrection:UseDeviceClock` (default `true`) disables
+> it entirely; at runtime, a read failure falls back to the wall clock and a large mid-stream
+> backward jump abandons the device clock for that stream. So bad hardware degrades to today's
+> behavior instead of breaking.
+>
+> **Documented hardware hiccups** (full detail in `DeviceClockAnchor`'s XML docs):
+> - Device clock not ready for the first few ms after `Start()` → wall clock until it anchors.
+> - Drivers that don't support / throw on `IAudioClock` → null read → wall clock, no exception escapes.
+> - Mid-stream position reset/glitch (backward jump > 50 ms) → abandon device clock for the stream.
+> - Stream restart / device switch zeroes the position → `Reset()` re-anchors (`SetState`→Playing and
+>   `SwitchDeviceAsync`) so the zero is a fresh anchor, not mistaken for a glitch.
+> - Ratio ~1.0000 on a machine whose system clock already agrees with its DAC means **no change** —
+>   the win is only where the two clocks genuinely diverge (e.g. fletchowns' USB DAC). **The decisive
+>   validation is still a verbose re-test on that USB DAC.**
+> - A subtly-wrong device clock (wrong rate, or silently slaved to the system clock) isn't caught by
+>   the guards; it just yields neutral-to-slightly-worse sync. Only per-device validation finds that.
+
 ### Goal
 
 Provide the SDK with the device playback position so it times sync against the DAC clock,

--- a/src/SendspinClient.Services/Audio/DeviceClockAnchor.cs
+++ b/src/SendspinClient.Services/Audio/DeviceClockAnchor.cs
@@ -1,0 +1,147 @@
+// <copyright file="DeviceClockAnchor.cs" company="Sendspin Windows Client">
+// Licensed under the MIT License. See LICENSE file in the project root.
+// </copyright>
+
+namespace SendspinClient.Services.Audio;
+
+/// <summary>
+/// Anchors the WASAPI device clock (IAudioClock) onto the wall-clock timeline so it can replace
+/// the wall clock as the sync-timing source without a discontinuity, and degrades gracefully when
+/// the device clock is unavailable or misbehaves.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why anchor.</b> The wall clock (<c>HighPrecisionTimer</c>) returns a large Unix-epoch-based
+/// value; the device clock position starts near 0 at stream start. The downstream buffer measures
+/// <c>elapsed = now - startAnchor</c>. Mixing the two scales (start captured on one, <c>now</c> on
+/// the other) yields a multi-billion-microsecond jump that trips the buffer's re-anchor threshold.
+/// We capture <c>offset = wall - device</c> once, then return <c>device + offset</c>. The offset
+/// cancels in <c>now - start</c>, so the buffer sees true device-paced elapsed time, while the
+/// absolute value stays on the wall-clock timeline. A device&#8596;wall transition is then a
+/// continuous hand-off, not a cliff.
+/// </para>
+/// <para>
+/// <b>Hardware hiccups this guards against (issue #33 follow-up):</b>
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <b>Device clock not ready at the first reads.</b> <c>IAudioClock</c> may return null for a
+///     few milliseconds after <c>Start()</c>. While null, <see cref="Resolve"/> returns the wall
+///     clock and anchors later; because the offset makes the device value continuous with the wall
+///     clock, the switchover is seamless.
+///   </item>
+///   <item>
+///     <b>Unsupported / throwing IAudioClock on some drivers.</b> The caller passes null on a read
+///     failure; this anchor then simply stays on the wall clock. No exception escapes the timing
+///     path.
+///   </item>
+///   <item>
+///     <b>Driver resets the position mid-stream</b> (e.g. <c>AUDCLNT</c> reset / format change that
+///     escapes the device-switch path). A backward jump beyond <see cref="DisableThresholdMicros"/>
+///     is treated as untrustworthy: the device clock is abandoned for the rest of the stream and we
+///     fall back to the wall clock. Sub-millisecond backward jitter is tolerated via a high-water
+///     mark so a benign blip does not disable a healthy clock.
+///   </item>
+///   <item>
+///     <b>Stream restart / device switch.</b> A new <c>WasapiOut</c> zeroes the position, which
+///     would look like a giant backward jump. The owner calls <see cref="Reset"/> at those known
+///     re-anchor points so a fresh anchor is taken instead of mistaking the reset for a glitch.
+///   </item>
+/// </list>
+/// <para>
+/// <b>What this does NOT fix.</b> A device whose clock is subtly wrong (advances at the wrong rate,
+/// or is silently slaved to the system clock and so offers no drift benefit) will simply yield
+/// neutral-to-slightly-worse sync; only per-device validation catches that. A machine whose system
+/// clock already agrees with its DAC (ratio ~1.0000, as on a wired desktop) sees no change &#8212;
+/// the win is on hardware where the two clocks genuinely diverge (e.g. a USB DAC on its own
+/// crystal).
+/// </para>
+/// </remarks>
+public sealed class DeviceClockAnchor
+{
+    /// <summary>
+    /// A mid-stream backward jump larger than this (50 ms) is treated as a driver reset/glitch and
+    /// the device clock is abandoned for the rest of the stream. A legitimate reset zeroes the
+    /// position (backward by the whole elapsed time), so it is caught with wide margin; genuine
+    /// monotonic clocks never step back this far.
+    /// </summary>
+    private const long DisableThresholdMicros = 50_000;
+
+    private long _offsetMicros;
+    private long _highWaterDeviceMicros;
+    private bool _anchored;
+    private bool _disabled;
+
+    /// <summary>Gets a value indicating whether the most recent <see cref="Resolve"/> call anchored
+    /// for the first time (one-shot edge flag, for logging).</summary>
+    public bool JustEngaged { get; private set; }
+
+    /// <summary>Gets a value indicating whether the most recent <see cref="Resolve"/> call abandoned
+    /// the device clock due to a backward jump (one-shot edge flag, for logging).</summary>
+    public bool JustDisabled { get; private set; }
+
+    /// <summary>Gets a value indicating whether the device clock is currently the active source.</summary>
+    public bool IsActive => _anchored && !_disabled;
+
+    /// <summary>
+    /// Maps a device-clock reading (or null when unavailable) onto the wall-clock timeline.
+    /// </summary>
+    /// <param name="deviceMicros">The device clock position in microseconds, or null if it could
+    /// not be read this call.</param>
+    /// <param name="wallMicros">The current wall-clock time in microseconds (the fallback).</param>
+    /// <returns>The sync time in microseconds on the wall-clock timeline.</returns>
+    public long Resolve(long? deviceMicros, long wallMicros)
+    {
+        JustEngaged = false;
+        JustDisabled = false;
+
+        if (_disabled || deviceMicros is null)
+        {
+            return wallMicros;
+        }
+
+        var device = deviceMicros.Value;
+
+        if (!_anchored)
+        {
+            // Capture the offset so device+offset == wall right now: continuous with whatever the
+            // buffer already anchored on (it may have started on the wall clock while the device
+            // clock was still warming up).
+            _offsetMicros = wallMicros - device;
+            _highWaterDeviceMicros = device;
+            _anchored = true;
+            JustEngaged = true;
+            return wallMicros;
+        }
+
+        if (device < _highWaterDeviceMicros - DisableThresholdMicros)
+        {
+            // Large backward jump => driver reset/glitch we did not expect. Abandon for this stream.
+            _disabled = true;
+            JustDisabled = true;
+            return wallMicros;
+        }
+
+        if (device > _highWaterDeviceMicros)
+        {
+            _highWaterDeviceMicros = device;
+        }
+
+        return device + _offsetMicros;
+    }
+
+    /// <summary>
+    /// Clears all anchor state. Call at known re-anchor points (stream start, device switch) where
+    /// the device clock position legitimately resets to zero, so the reset is not mistaken for a
+    /// backward-jump glitch.
+    /// </summary>
+    public void Reset()
+    {
+        _offsetMicros = 0;
+        _highWaterDeviceMicros = 0;
+        _anchored = false;
+        _disabled = false;
+        JustEngaged = false;
+        JustDisabled = false;
+    }
+}

--- a/src/SendspinClient.Services/Audio/WasapiAudioPlayer.cs
+++ b/src/SendspinClient.Services/Audio/WasapiAudioPlayer.cs
@@ -65,10 +65,13 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
     private int _outputLatencyMs;
     private int _deviceNativeSampleRate = 48000;
 
-    // Audio-clock probe (issue #33). The SDK assumes WASAPI shared mode cannot supply a
-    // hardware clock and falls back to the wall clock; this gathers evidence to test that.
+    // WASAPI device clock as the sync-timing source (issue #33). The SDK assumes shared mode cannot
+    // supply a hardware clock and times sync against the wall clock; the probe confirmed IAudioClock
+    // is readable and tracks real time in shared mode, so we drive sync off it via _deviceClockAnchor
+    // (with automatic wall-clock fallback). _useDeviceClock is the escape hatch for bad hardware.
+    private readonly bool _useDeviceClock;
+    private readonly DeviceClockAnchor _deviceClockAnchor = new();
     private AudioClockClient? _audioClockClient;
-    private bool _audioClockProbeFailed;
     private long _lastClockProbeLogTicks;
     private long _probeLastClockMicros;
     private long _probeLastWallMicros;
@@ -173,16 +176,24 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
     /// WDL uses sinc interpolation, SoundTouch uses WSOLA algorithm.
     /// Ignored when strategy is DropInsertOnly.
     /// </param>
+    /// <param name="useDeviceClock">
+    /// When true (default), sync is timed against the WASAPI device clock (IAudioClock) instead of
+    /// the wall clock, with automatic fallback to the wall clock when the device clock is
+    /// unavailable or misbehaves. Set false to force wall-clock timing on hardware where the device
+    /// clock proves unreliable. See <see cref="DeviceClockAnchor"/>.
+    /// </param>
     public WasapiAudioPlayer(
         ILogger<WasapiAudioPlayer> logger,
         string? deviceId = null,
         SyncCorrectionStrategy syncStrategy = SyncCorrectionStrategy.Combined,
-        ResamplerType resamplerType = ResamplerType.Wdl)
+        ResamplerType resamplerType = ResamplerType.Wdl,
+        bool useDeviceClock = true)
     {
         _logger = logger;
         _deviceId = deviceId;
         _syncStrategy = syncStrategy;
         _resamplerType = resamplerType;
+        _useDeviceClock = useDeviceClock;
     }
 
     /// <summary>
@@ -311,7 +322,7 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
             _correctedSource = new SyncCorrectedSampleSource(
                 _buffer,
                 _correctionProvider,
-                () => HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds(),
+                GetSyncTimeMicroseconds,
                 _logger);
 
             effectiveSource = _correctedSource;
@@ -474,6 +485,16 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
                         _wasapiOut.Dispose();
                         _wasapiOut = null;
                     }
+
+                    // The cached IAudioClock belongs to the disposed device; drop it and re-anchor so
+                    // the new device's clock baseline is picked up cleanly (handled again on Playing,
+                    // but cleared here too in case the switch happens while stopped). Also clear the
+                    // diagnostic baseline so the first [AudioClock] log after the switch doesn't
+                    // compute a bogus delta against the old device's (much larger) position.
+                    _audioClockClient = null;
+                    _deviceClockAnchor.Reset();
+                    _probeLastClockMicros = 0;
+                    _probeLastWallMicros = 0;
 
                     // Update device ID
                     _deviceId = deviceId;
@@ -742,19 +763,47 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
     }
 
     /// <summary>
-    /// Audio-clock probe for issue #33. Reads the WASAPI device clock (IAudioClock) and logs it
-    /// against wall time to determine empirically whether it is usable in shared mode - the SDK's
-    /// IAudioPlayer contract assumes it is not. Returns <c>null</c> so the SDK keeps its current
-    /// wall-clock timing; this only gathers evidence. Wiring the device clock in as the sync
-    /// timing source is a follow-up once the probe confirms it tracks real time.
+    /// Sync time source for <see cref="SyncCorrectedSampleSource"/> - the app's actual playback
+    /// timing path (the SDK's GetAudioClockMicroseconds/GetCurrentLocalTime path is bypassed here,
+    /// since correction was moved app-side). This delegate IS invoked per render read during
+    /// playback, so it reads the WASAPI device clock (IAudioClock) and returns it anchored onto the
+    /// wall-clock timeline via <see cref="DeviceClockAnchor"/> - timing sync against the DAC's own
+    /// crystal instead of the system clock (issue #33). Falls back to the wall clock when the device
+    /// clock is unavailable, when it misbehaves, or when <see cref="_useDeviceClock"/> is false.
     /// </summary>
-    public long? GetAudioClockMicroseconds()
+    private long GetSyncTimeMicroseconds()
     {
-        LogAudioClockProbeIfDue();
-        return null;
+        var wallMicros = HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds();
+
+        if (!_useDeviceClock)
+        {
+            return wallMicros;
+        }
+
+        // One hardware read per call, reused for both the returned sync time and the diagnostics log.
+        var deviceMicros = TryReadAudioClockMicroseconds();
+        var syncMicros = _deviceClockAnchor.Resolve(deviceMicros, wallMicros);
+
+        if (_deviceClockAnchor.JustEngaged)
+        {
+            _logger.LogInformation("[Timing] Device audio clock engaged as the sync-timing source (IAudioClock, shared mode)");
+        }
+        else if (_deviceClockAnchor.JustDisabled)
+        {
+            _logger.LogWarning("[Timing] Device audio clock went non-monotonic; reverted to wall-clock timing for this stream");
+        }
+
+        LogAudioClockDiagnosticsIfDue(deviceMicros, wallMicros);
+        return syncMicros;
     }
 
-    private void LogAudioClockProbeIfDue()
+    /// <summary>
+    /// Periodically logs the device-clock-vs-wall-clock advance ratio (issue #33 diagnostics). Uses
+    /// the reading already taken in <see cref="GetSyncTimeMicroseconds"/> - it does not re-read
+    /// hardware. A ratio &gt; 1.0 means the DAC is running faster than the system clock (the drift
+    /// the device clock now corrects for); ~1.0000 means the two clocks already agree on this box.
+    /// </summary>
+    private void LogAudioClockDiagnosticsIfDue(long? clockMicros, long wallMicros)
     {
         var nowTicks = DateTime.UtcNow.Ticks;
         var last = Interlocked.Read(ref _lastClockProbeLogTicks);
@@ -768,21 +817,19 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
             return;
         }
 
-        var clockMicros = TryReadAudioClockMicroseconds();
         if (clockMicros == null)
         {
-            _logger.LogInformation("[AudioClockProbe] IAudioClock unavailable in shared mode - SDK wall-clock fallback in effect");
+            _logger.LogInformation("[AudioClock] not readable yet (awaiting playback / IAudioClock not ready) - on wall-clock fallback");
             return;
         }
 
-        var wallMicros = nowTicks / 10; // 100ns ticks -> microseconds
         if (_probeLastWallMicros != 0)
         {
             var clockDeltaMs = (clockMicros.Value - _probeLastClockMicros) / 1000.0;
             var wallDeltaMs = (wallMicros - _probeLastWallMicros) / 1000.0;
             var ratio = wallDeltaMs > 0 ? clockDeltaMs / wallDeltaMs : 0;
             _logger.LogInformation(
-                "[AudioClockProbe] pos={PosMs:F1}ms; advanced {ClockDeltaMs:F0}ms over wall {WallDeltaMs:F0}ms (ratio {Ratio:F4} - ~1.0 = tracks real time)",
+                "[AudioClock] pos={PosMs:F1}ms; advanced {ClockDeltaMs:F0}ms over wall {WallDeltaMs:F0}ms (ratio {Ratio:F4}; >1 = DAC faster than system clock)",
                 clockMicros.Value / 1000.0,
                 clockDeltaMs,
                 wallDeltaMs,
@@ -791,7 +838,7 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
         else
         {
             _logger.LogInformation(
-                "[AudioClockProbe] IAudioClock readable in shared mode: pos={PosMs:F1}ms (first reading)",
+                "[AudioClock] IAudioClock readable in shared mode: pos={PosMs:F1}ms (first reading)",
                 clockMicros.Value / 1000.0);
         }
 
@@ -805,7 +852,11 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
     /// </summary>
     private long? TryReadAudioClockMicroseconds()
     {
-        if (_audioClockProbeFailed)
+        // Only query once playback is running: Play() has called the audio client's Init()+Start(),
+        // so IAudioClock is valid. Querying earlier (the SDK's one-time timing-source check at
+        // pipeline setup, before WasapiOut.Init()) throws AUDCLNT_E_NOT_INITIALIZED. We must NOT
+        // permanently disable on that, or a pre-playback failure masks a clock that works in play.
+        if (State != AudioPlayerState.Playing)
         {
             return null;
         }
@@ -829,8 +880,9 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
         }
         catch (Exception ex)
         {
-            _audioClockProbeFailed = true;
-            _logger.LogWarning(ex, "[AudioClockProbe] IAudioClock read failed - this supports the SDK's shared-mode fallback assumption");
+            // Drop the cached client and retry on the next probe (also handles device-switch staleness).
+            _audioClockClient = null;
+            _logger.LogDebug(ex, "[AudioClockProbe] IAudioClock read threw; will retry");
             return null;
         }
     }
@@ -867,6 +919,13 @@ public sealed class WasapiAudioPlayer : IAudioPlayer
     {
         if (State != newState)
         {
+            // Entering Playing means a (re)started WASAPI stream whose device-clock position zeroes;
+            // re-anchor so the reset is taken as a fresh anchor, not mistaken for a backward glitch.
+            if (newState == AudioPlayerState.Playing && State != AudioPlayerState.Playing)
+            {
+                _deviceClockAnchor.Reset();
+            }
+
             _logger.LogDebug("Player state: {OldState} -> {NewState}", State, newState);
             State = newState;
             StateChanged?.Invoke(this, newState);

--- a/src/SendspinClient/App.xaml.cs
+++ b/src/SendspinClient/App.xaml.cs
@@ -310,11 +310,15 @@ public partial class App : Application
             ? ResamplerType.SoundTouch
             : ResamplerType.Wdl;
 
+        // Time sync against the WASAPI device clock (DAC crystal) rather than the wall clock. Escape
+        // hatch for hardware whose IAudioClock misbehaves; the player also auto-falls-back at runtime.
+        var useDeviceClock = _configuration!.GetValue("Audio:SyncCorrection:UseDeviceClock", true);
+
         services.AddTransient<IAudioPlayer>(sp =>
         {
             var logger = sp.GetRequiredService<ILogger<WasapiAudioPlayer>>();
             var currentDeviceId = _configuration!.GetValue<string?>("Audio:DeviceId");
-            return new WasapiAudioPlayer(logger, currentDeviceId, syncStrategy, resamplerType);
+            return new WasapiAudioPlayer(logger, currentDeviceId, syncStrategy, resamplerType, useDeviceClock);
         });
 
         // Audio pipeline - orchestrates decoder, buffer, and player

--- a/tests/SendspinClient.Services.Tests/Audio/DeviceClockAnchorTests.cs
+++ b/tests/SendspinClient.Services.Tests/Audio/DeviceClockAnchorTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="DeviceClockAnchorTests.cs" company="Sendspin Windows Client">
+// Licensed under the MIT License. See LICENSE file in the project root.
+// </copyright>
+
+using SendspinClient.Services.Audio;
+using Xunit;
+
+namespace SendspinClient.Services.Tests.Audio;
+
+public class DeviceClockAnchorTests
+{
+    [Fact]
+    public void UnavailableDeviceClock_ReturnsWallClock()
+    {
+        var anchor = new DeviceClockAnchor();
+
+        Assert.Equal(5_000_000_000L, anchor.Resolve(deviceMicros: null, wallMicros: 5_000_000_000L));
+        Assert.False(anchor.IsActive);
+        Assert.False(anchor.JustEngaged);
+    }
+
+    [Fact]
+    public void FirstAnchor_IsContinuousWithWallClock()
+    {
+        var anchor = new DeviceClockAnchor();
+
+        // Device position starts near zero; wall clock is a huge epoch value. The first reading must
+        // hand off continuously - returning the wall value, not the tiny device value.
+        var result = anchor.Resolve(deviceMicros: 1_000_000L, wallMicros: 5_000_000_000L);
+
+        Assert.Equal(5_000_000_000L, result);
+        Assert.True(anchor.JustEngaged);
+        Assert.True(anchor.IsActive);
+    }
+
+    [Fact]
+    public void AfterAnchor_ElapsedTracksDeviceClock_NotWallClock()
+    {
+        var anchor = new DeviceClockAnchor();
+
+        // Anchor: device pos 1.0s, wall 5000.0s.
+        var start = anchor.Resolve(deviceMicros: 1_000_000L, wallMicros: 5_000_000_000L);
+
+        // DAC runs faster than the system clock: device advanced 1.0s while wall advanced only 0.5s.
+        var now = anchor.Resolve(deviceMicros: 2_000_000L, wallMicros: 5_000_500_000L);
+
+        // The whole point of the anchor: elapsed reflects the DEVICE's pacing (1.0s), so downstream
+        // sync sees the real drift instead of wall-clock jitter.
+        Assert.Equal(1_000_000L, now - start);
+    }
+
+    [Fact]
+    public void LateAnchor_AfterWallClockStart_HandsOffContinuously()
+    {
+        var anchor = new DeviceClockAnchor();
+
+        // First reads: device clock not ready yet -> wall clock.
+        var t0 = anchor.Resolve(deviceMicros: null, wallMicros: 5_000_000_000L);
+        Assert.Equal(5_000_000_000L, t0);
+        Assert.False(anchor.IsActive);
+
+        // Device becomes available a bit later. The hand-off returns the wall value (continuous),
+        // so there is no jump on the timeline the buffer already started measuring against.
+        var t1 = anchor.Resolve(deviceMicros: 40_000L, wallMicros: 5_000_050_000L);
+        Assert.Equal(5_000_050_000L, t1);
+        Assert.True(anchor.JustEngaged);
+
+        // From here it tracks the device clock.
+        var t2 = anchor.Resolve(deviceMicros: 1_040_000L, wallMicros: 5_001_060_000L);
+        Assert.Equal(1_000_000L, t2 - t1); // device advanced exactly 1.0s
+    }
+
+    [Fact]
+    public void LargeBackwardJump_DisablesDeviceClockForStream()
+    {
+        var anchor = new DeviceClockAnchor();
+
+        anchor.Resolve(deviceMicros: 1_000_000L, wallMicros: 5_000_000_000L);
+        anchor.Resolve(deviceMicros: 2_000_000L, wallMicros: 5_001_000_000L);
+
+        // Driver reset the position (back to ~0): far beyond the 50 ms tolerance -> abandon.
+        var afterReset = anchor.Resolve(deviceMicros: 0L, wallMicros: 5_001_500_000L);
+
+        Assert.Equal(5_001_500_000L, afterReset); // fell back to wall clock
+        Assert.True(anchor.JustDisabled);
+        Assert.False(anchor.IsActive);
+
+        // Stays on the wall clock for the rest of the stream, even though the device clock recovers.
+        var later = anchor.Resolve(deviceMicros: 3_000_000L, wallMicros: 5_002_000_000L);
+        Assert.Equal(5_002_000_000L, later);
+        Assert.False(anchor.JustDisabled); // edge flag is one-shot
+        Assert.False(anchor.IsActive);
+    }
+
+    [Fact]
+    public void SmallBackwardJitter_IsTolerated()
+    {
+        var anchor = new DeviceClockAnchor();
+
+        anchor.Resolve(deviceMicros: 1_000_000L, wallMicros: 5_000_000_000L);
+        anchor.Resolve(deviceMicros: 2_000_000L, wallMicros: 5_001_000_000L);
+
+        // 10 ms backward blip (< 50 ms tolerance): keep tracking the device clock, do not disable.
+        var jittered = anchor.Resolve(deviceMicros: 1_990_000L, wallMicros: 5_001_010_000L);
+
+        Assert.False(anchor.JustDisabled);
+        Assert.True(anchor.IsActive);
+        Assert.Equal(1_990_000L + (5_000_000_000L - 1_000_000L), jittered); // device + original offset
+    }
+
+    [Fact]
+    public void Reset_TakesAFreshAnchorAgainstNewBaseline()
+    {
+        var anchor = new DeviceClockAnchor();
+
+        anchor.Resolve(deviceMicros: 1_000_000L, wallMicros: 5_000_000_000L);
+        anchor.Resolve(deviceMicros: 2_000_000L, wallMicros: 5_001_000_000L);
+
+        // Stream restart / device switch: new WasapiOut zeroes the position. Reset() so the zero is a
+        // fresh anchor rather than a backward-jump glitch.
+        anchor.Reset();
+        Assert.False(anchor.IsActive);
+
+        var reanchored = anchor.Resolve(deviceMicros: 0L, wallMicros: 6_000_000_000L);
+        Assert.Equal(6_000_000_000L, reanchored); // continuous with the new wall value
+        Assert.True(anchor.JustEngaged);
+        Assert.True(anchor.IsActive);
+    }
+}


### PR DESCRIPTION
## Summary

Times audio sync against the **WASAPI device clock** (`IAudioClock`) instead of the wall clock — the architectural root cause behind the issue #33 stutter. Wall-clock jitter churned the playback rate, which produced the resampler shortfalls #46 conceals; this removes the churn at the source.

Builds on the #47 probe, which confirmed `IAudioClock` is readable and tracks real time (ratio `1.0000`, monotonic) in WASAPI **shared mode** — refuting the SDK's "shared mode → null" assumption.

## What changed

- **New `DeviceClockAnchor`** (isolated, unit-tested): anchors the device clock onto the wall-clock timeline (`offset = wall − device`, captured once) so swapping the timing source is a continuous hand-off, not a cliff — and degrades to the wall clock when the device clock is unavailable or misbehaves.
- **`WasapiAudioPlayer.GetSyncTimeMicroseconds`** — the per-render delegate `SyncCorrectedSampleSource` actually uses — now returns the anchored device clock.
- **Escape hatch** `Audio:SyncCorrection:UseDeviceClock` (default `true`) plus automatic runtime fallback.
- Re-anchors on stream start and device switch; clears the diagnostic baseline on switch so the cross-device `[AudioClock]` log no longer reports a bogus delta.

## Hardware caveats (documented in `DeviceClockAnchor`)

- Startup window before the clock is ready → wall clock until it anchors.
- Drivers that don't support `IAudioClock` → null read → wall clock (no exception escapes).
- Mid-stream reset/glitch (backward jump > 50 ms) → abandon the device clock for that stream.
- Ratio `~1.0000` on a box whose system clock already agrees with its DAC means **no change** — the win is only where the clocks diverge (e.g. a USB DAC on its own crystal).
- A subtly-wrong device clock isn't caught by the guards; only per-device validation finds that.

## Validation

- 7 unit tests for the anchor; full Services suite green (94/94).
- Local **wired** session: device clock engaged at ratio `1.0000`, monotonic, **zero fallbacks**, across 3 device switches; no regression to dead-on wired sync.
- ⏳ **Still needs USB-DAC validation** — the divergent-clock case from issue #33 is the decisive test.

Refs #33.