### PR TITLE
chore: bump Sendspin.SDK to 9.0.4

### DIFF
--- a/src/SendspinClient.Services/SendspinClient.Services.csproj
+++ b/src/SendspinClient.Services/SendspinClient.Services.csproj
@@ -23,7 +23,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.0.3" />
+    <PackageReference Include="Sendspin.SDK" Version="9.0.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />

--- a/src/SendspinClient/SendspinClient.csproj
+++ b/src/SendspinClient/SendspinClient.csproj
@@ -63,7 +63,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.0.3" />
+    <PackageReference Include="Sendspin.SDK" Version="9.0.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />


### PR DESCRIPTION
Bumps `Sendspin.SDK` 9.0.3 → 9.0.4 in both project files.

## Why

9.0.4 fixes the **stuck "connected" state after a Music Assistant restart/update** (issue #1, coastercog's report). The reconnect machinery only ran when `ReceiveAsync` threw or a send failed; two ways a server can vanish produced neither signal:

- **Half-open socket** (frozen peer / network drop, no TCP FIN) — `ReceiveAsync` blocked forever. 9.0.4 enables the .NET 9+ PING/PONG keep-alive (`KeepAliveTimeout`) so a dead peer aborts the read.
- **Graceful close frame** (restart/update) — the receive loop `return`ed silently. 9.0.4 routes it through `HandleConnectionLostAsync` instead.

## How it composes with this app

The manual client is created with `AutoReconnect = false` and reconnects via **mDNS rediscovery on the `Disconnected` event**. The old behavior was stuck because those two cases never produced a `Disconnected` event, so rediscovery never started. 9.0.4 makes the event fire for both, so the existing app path recovers the player automatically — **within ~30s** (new 15s interval + 15s PONG timeout), no manual restart.

No app code change required: the app only overrides `AutoReconnect`, so the new `KeepAliveIntervalMs`/`KeepAliveTimeoutMs` defaults are inherited, and the app targets net10.0 so the PING/PONG path is active.

## Verification

- `dotnet restore` resolves 9.0.4 from NuGet; Release build green.
- Merging publishes a `Dev Build <sha>` prerelease for coastercog to confirm the auto-recovery on their MA restart scenario.

Refs #1.