### PR TITLE
Click-to-seek sliders + UI tweaks

### DIFF
--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -727,6 +727,7 @@
                                             Minimum="0" Maximum="2"
                                             TickFrequency="0.25" IsSnapToTickEnabled="False"
                                             Value="{Binding SettingsAmbientBackdropIntensity, Mode=TwoWay}"
+                                            IsMoveToPointEnabled="True"
                                             VerticalAlignment="Center"/>
                                     <TextBlock Grid.Column="1"
                                                Text="{Binding SettingsAmbientBackdropIntensity, StringFormat={}{0:P0}}"
@@ -1330,6 +1331,7 @@
                         <Slider Grid.Column="1"
                                 Minimum="0" Maximum="100"
                                 Value="{Binding Volume}"
+                                IsMoveToPointEnabled="True"
                                 VerticalAlignment="Center"
                                 Margin="8,0"/>
 

--- a/src/SendspinClient/MainWindow.xaml
+++ b/src/SendspinClient/MainWindow.xaml
@@ -776,6 +776,24 @@
                                           VerticalAlignment="Center"/>
                             </Grid>
 
+                            <Grid Margin="0,0,0,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0">
+                                    <TextBlock Text="Show Switch Group Button" Style="{StaticResource BodyText}"/>
+                                    <TextBlock Text="Show the group-switching button in the volume bar (turn off for single-room setups)"
+                                               Style="{StaticResource CaptionText}"
+                                               Foreground="{StaticResource TextMutedBrush}"
+                                               Margin="0,2,0,0"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <CheckBox Grid.Column="1"
+                                          IsChecked="{Binding SettingsShowSwitchGroupButton}"
+                                          VerticalAlignment="Center"/>
+                            </Grid>
+
                             <!-- Player Name -->
                             <StackPanel Margin="0,0,0,16">
                                 <TextBlock Text="Player Name" Style="{StaticResource BodyText}"/>
@@ -1348,7 +1366,8 @@
                                 ToolTip="{Binding CurrentGroupTooltip}"
                                 Foreground="{StaticResource TextSecondaryBrush}"
                                 Width="32" Height="32"
-                                Margin="4,0,0,0">
+                                Margin="4,0,0,0"
+                                Visibility="{Binding SettingsShowSwitchGroupButton, Converter={StaticResource BoolToVisibilityConverter}}">
                             <Path Width="18" Height="18" Stretch="Uniform"
                                   StrokeThickness="1.7" StrokeLineJoin="Round"
                                   Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -338,6 +338,13 @@ public partial class MainViewModel : ViewModelBase
     private bool _settingsStartMinimized = true;
 
     /// <summary>
+    /// Gets or sets whether the Switch Group button is shown in the volume bar.
+    /// On by default; hidden when disabled (useful for single-group/single-room setups).
+    /// </summary>
+    [ObservableProperty]
+    private bool _settingsShowSwitchGroupButton = true;
+
+    /// <summary>
     /// Gets or sets the player name shown to servers.
     /// Defaults to the computer name.
     /// </summary>
@@ -2336,6 +2343,7 @@ public partial class MainViewModel : ViewModelBase
         _mediaControlsService.IsEnabled = SettingsEnableMediaKeys;
 
         SettingsStartMinimized = _configuration.GetValue<bool>("App:StartMinimized", true);
+        SettingsShowSwitchGroupButton = _configuration.GetValue<bool>("App:ShowSwitchGroupButton", true);
 
         // Load player name (default to computer name)
         SettingsPlayerName = _configuration.GetValue<string>("Player:Name", Environment.MachineName) ?? Environment.MachineName;
@@ -2591,6 +2599,7 @@ public partial class MainViewModel : ViewModelBase
 
             var appSection = root["App"]?.AsObject() ?? new JsonObject();
             appSection["StartMinimized"] = SettingsStartMinimized;
+            appSection["ShowSwitchGroupButton"] = SettingsShowSwitchGroupButton;
             root["App"] = appSection;
 
             // Update player section

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -207,8 +207,8 @@ public partial class MainViewModel : ViewModelBase
     /// Gets the tooltip text for the Switch Group button.
     /// </summary>
     public string CurrentGroupTooltip => string.IsNullOrEmpty(CurrentGroupName)
-        ? "Switch Group"
-        : $"Current: {CurrentGroupName}\nClick to switch";
+        ? "Click to switch to the next group"
+        : $"{CurrentGroupName} · {PlaybackState}\nClick to switch to the next group";
 
     /// <summary>
     /// Gets or sets whether shuffle is enabled for the current group.
@@ -1686,6 +1686,7 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsPlaying));
         OnPropertyChanged(nameof(DisplayTitle));
         OnPropertyChanged(nameof(DisplayArtist));
+        OnPropertyChanged(nameof(CurrentGroupTooltip));
         UpdateTrayToolTip();
 
         // Show playback state notification (if enabled in settings)

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -169,7 +169,7 @@ public partial class MainViewModel : ViewModelBase
     /// Changes are debounced and sent to the server.
     /// </summary>
     [ObservableProperty]
-    private int _volume = 100;
+    private int _volume = 50;
 
     /// <summary>
     /// Gets or sets whether audio output is muted.
@@ -2297,8 +2297,9 @@ public partial class MainViewModel : ViewModelBase
         // Load audio settings
         SettingsStaticDelayMs = Math.Max(0, _configuration.GetValue<double>("Audio:StaticDelayMs", 0));
 
-        // Load persisted player volume/mute (these get applied via OnVolumeChanged/OnIsMutedChanged)
-        Volume = _configuration.GetValue<int>("Audio:PlayerVolume", 100);
+        // Load persisted player volume/mute (these get applied via OnVolumeChanged/OnIsMutedChanged).
+        // 50% is the default when nothing has been saved/overridden yet.
+        Volume = _configuration.GetValue<int>("Audio:PlayerVolume", 50);
         IsMuted = _configuration.GetValue<bool>("Audio:PlayerMuted", false);
 
         // Load audio stream type preference


### PR DESCRIPTION
## Summary
A batch of small UX/quality-of-life tweaks to the player.

- **Click-to-seek sliders** — clicking anywhere on the **volume** or **backdrop-intensity** track jumps the thumb to that point (then drag continues), instead of stepping toward it (`IsMoveToPointEnabled`). Static Delay intentionally keeps default stepping for precision.
- **Default launch volume = 50%** — changed the `Audio:PlayerVolume` load fallback from 100 to 50. Only affects fresh installs / configs with no saved volume; existing saved volumes still take precedence.
- **Richer Switch Group tooltip** — now shows `Group · State` over `Click to switch to the next group` (falls back to the action line when no group name is known). The destination can't be named — the protocol only exposes the current group.
- **Show Switch Group Button setting** — new toggle in Settings → General (on by default, persisted to `App:ShowSwitchGroupButton`) to hide the button for single-room setups.

All changes build clean and follow existing patterns (settings declare/load/save, computed-property notify wiring).