### PR TITLE
fix: re-anchor instead of Clear on static-delay change (kills offset-tuning silence)

### DIFF
--- a/src/SendspinClient.Services/SendspinClient.Services.csproj
+++ b/src/SendspinClient.Services/SendspinClient.Services.csproj
@@ -23,7 +23,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.0.4" />
+    <PackageReference Include="Sendspin.SDK" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />

--- a/src/SendspinClient/SendspinClient.csproj
+++ b/src/SendspinClient/SendspinClient.csproj
@@ -63,7 +63,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.0.4" />
+    <PackageReference Include="Sendspin.SDK" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />

--- a/src/SendspinClient/ViewModels/MainViewModel.cs
+++ b/src/SendspinClient/ViewModels/MainViewModel.cs
@@ -1825,7 +1825,10 @@ public partial class MainViewModel : ViewModelBase
         // Apply delay value immediately (this is cheap)
         _clockSynchronizer.StaticDelayMs = value;
 
-        // Debounce buffer clear - only clear after user stops adjusting the slider
+        // Debounce the re-anchor - only apply after the user stops adjusting the slider.
+        // Re-anchor (not Clear): applies the new delay to the already-buffered audio in place.
+        // Clear() would dump the buffer and, with a server that transmits far ahead of playback,
+        // stall for the full transmit-ahead window (tens of seconds of silence) while it refills.
         _staticDelayClearCts?.Cancel();
         _staticDelayClearCts?.Dispose();
         _staticDelayClearCts = new CancellationTokenSource();
@@ -1838,8 +1841,8 @@ public partial class MainViewModel : ViewModelBase
                 await Task.Delay(StaticDelayClearDebounceMs, clearCts.Token);
                 if (!clearCts.Token.IsCancellationRequested)
                 {
-                    _audioPipeline.Clear();
-                    _logger.LogDebug("Static delay changed to {DelayMs}ms, audio buffer cleared", value);
+                    _audioPipeline.ReanchorTiming();
+                    _logger.LogDebug("Static delay changed to {DelayMs}ms, sync timing re-anchored (buffer preserved)", value);
                 }
             }
             catch (OperationCanceledException)

--- a/tests/SendspinClient.Services.Tests/Audio/StaticDelayReanchorTests.cs
+++ b/tests/SendspinClient.Services.Tests/Audio/StaticDelayReanchorTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="StaticDelayReanchorTests.cs" company="Sendspin Windows Client">
+// Licensed under the MIT License. See LICENSE file in the project root.
+// </copyright>
+
+using System.Linq;
+using Sendspin.SDK.Audio;
+using Sendspin.SDK.Models;
+using Sendspin.SDK.Synchronization;
+using Xunit;
+
+namespace SendspinClient.Services.Tests.Audio;
+
+/// <summary>
+/// Guards the static-delay-change fix: re-anchoring timing must preserve buffered audio so a delay
+/// tweak applies in place, instead of dumping the buffer (which, with a server that transmits far
+/// ahead of playback, stalls for the whole transmit-ahead window — the 30-second silence).
+/// </summary>
+/// <remarks>
+/// The app's <c>OnSettingsStaticDelayMsChanged</c> previously called <c>IAudioPipeline.Clear()</c>;
+/// it now calls <c>ReanchorTiming()</c>, which forwards to <see cref="TimedAudioBuffer.ResetSyncTracking"/>.
+/// These tests exercise that buffer primitive directly (the property the pipeline passthrough relies on).
+/// </remarks>
+public class StaticDelayReanchorTests
+{
+    private const int Rate = 48000;
+    private const int Ch = 2;
+    private const int ChunkFrames = 480;
+    private const int ChunkSamples = ChunkFrames * Ch;
+    private const double UsPerFrame = 1_000_000.0 / Rate;
+    private const long Start = 1_000_000_000L;
+
+    private sealed class FixedClock : IClockSynchronizer
+    {
+        private readonly long _offset;
+
+        public FixedClock(long offset) => _offset = offset;
+
+        public double StaticDelayMs { get; set; }
+
+        public long ServerToClientTime(long t) => t + _offset - (long)(StaticDelayMs * 1000);
+
+        public long ClientToServerTime(long t) => t - _offset + (long)(StaticDelayMs * 1000);
+
+        public bool IsConverged => true;
+
+        public bool HasMinimalSync => true;
+
+        public void ProcessMeasurement(long t1, long t2, long t3, long t4)
+        {
+        }
+
+        public void Reset()
+        {
+        }
+
+        public ClockSyncStatus GetStatus() => new() { IsConverged = true, IsDriftReliable = true };
+    }
+
+    /// <summary>
+    /// Builds a buffer pre-filled with ~2s of audio (a deep buffer, as a far-ahead server produces)
+    /// and reads a few chunks so playback is established.
+    /// </summary>
+    private static (TimedAudioBuffer Buffer, FixedClock Clock) SetupPlaying()
+    {
+        var format = new AudioFormat { Codec = "pcm", SampleRate = Rate, Channels = Ch, BitDepth = 32 };
+        var clock = new FixedClock(Start);
+        var buffer = new TimedAudioBuffer(format, clock, bufferCapacityMs: 4000, SyncCorrectionOptions.Default);
+
+        var data = new float[ChunkSamples];
+        Array.Fill(data, 0.25f);
+
+        long frames = 0;
+        for (var k = 0; k < 200; k++) // 200 × 10ms = 2000ms buffered
+        {
+            buffer.Write(data, (long)(frames * UsPerFrame));
+            frames += ChunkFrames;
+        }
+
+        var outBuf = new float[ChunkSamples];
+        for (var i = 0; i < 10; i++) // establish playback, consume ~100ms
+        {
+            buffer.ReadRaw(outBuf, Start + (long)((long)i * ChunkFrames * UsPerFrame));
+        }
+
+        return (buffer, clock);
+    }
+
+    [Fact]
+    public void ReanchorViaResetSyncTracking_PreservesBufferedAudio_NoSilenceGap()
+    {
+        var (buffer, clock) = SetupPlaying();
+        Assert.True(buffer.BufferedMilliseconds > 1000, "precondition: a deep buffer is present");
+
+        // Apply a static-delay change the way the fixed app does: shift the clock, then re-anchor
+        // (instead of Clear). This is what runs when the user moves the offset slider.
+        clock.StaticDelayMs = 200;
+        buffer.ResetSyncTracking();
+
+        // The whole point of the fix: the buffered audio survives, so there is nothing to re-fetch
+        // and therefore no transmit-ahead wait.
+        Assert.True(
+            buffer.BufferedMilliseconds > 1000,
+            $"re-anchor must preserve buffered audio, but only {buffer.BufferedMilliseconds:F0}ms remained");
+
+        // And audio keeps flowing immediately on the next read — no silence.
+        var outBuf = new float[ChunkSamples];
+        var read = buffer.ReadRaw(outBuf, Start + (long)(10L * ChunkFrames * UsPerFrame));
+        Assert.True(read > 0 && outBuf.Any(s => s != 0f), "audio should keep flowing right after re-anchor");
+    }
+
+    [Fact]
+    public void Clear_EmptiesBuffer_ProducesSilence_TheOldBehavior()
+    {
+        var (buffer, _) = SetupPlaying();
+        Assert.True(buffer.BufferedMilliseconds > 1000);
+
+        // The old static-delay path. Clear dumps everything; with a far-ahead server the only audio
+        // that refills is future-timestamped, so playback waits the transmit-ahead window in silence.
+        buffer.Clear();
+
+        Assert.True(
+            buffer.BufferedMilliseconds < 1,
+            $"Clear should empty the buffer, but {buffer.BufferedMilliseconds:F0}ms remained");
+
+        var outBuf = new float[ChunkSamples];
+        buffer.ReadRaw(outBuf, Start + (long)(10L * ChunkFrames * UsPerFrame));
+        Assert.True(outBuf.All(s => s == 0f), "an emptied buffer outputs silence");
+    }
+}


### PR DESCRIPTION
## Problem

Adjusting the static-delay slider blanked the audio for **tens of seconds** on every nudge — making the offset impossible to tune by ear.

`OnSettingsStaticDelayMsChanged` called `_audioPipeline.Clear()`, which dumps the entire buffer. With a server that transmits far ahead of playback (30–44s observed), the only audio that refills is future-timestamped, so the buffer waits that whole transmit-ahead window in silence before playing again.

## Fix

Swap `Clear()` for the new **`IAudioPipeline.ReanchorTiming()`** (Sendspin.SDK 9.0.5, #57 upstream), which forwards to the device-switch-proven `TimedAudioBuffer.ResetSyncTracking()`. It re-anchors timing — so the next callback re-derives the scheduled start with the new `StaticDelayMs` — while **preserving the buffered audio**. The delay applies in place, no refill, no silence.

Bumps `Sendspin.SDK` 9.0.4 → 9.0.5.

## Tests

`StaticDelayReanchorTests` exercises the buffer primitive directly:
- `ResetSyncTracking` → buffer preserved (`>1000ms` retained), audio flows on the next read.
- `Clear` → buffer emptied (`<1ms`), output silence — the old behavior.

Build green, full suite 96/96.

## Verify

Merging publishes a dev build: move the offset slider mid-playback — the change should apply immediately with no audio dropout.