### PR TITLE
fix: reset seek bar on track change and unify progress handling

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -503,6 +503,12 @@ Progress = meta.Progress.IsPresent ? meta.Progress.Value : existing.Progress;
 
 This matches the CLI's `UndefinedField` pattern in Python.
 
+**Corollary the app depends on**: when the progress field is absent, the SDK's
+carry-forward keeps the **same** `PlaybackProgress` instance (verified in 9.1.0's
+`SendspinClientService.HandleServerState`), and deserializes a **new** instance exactly
+when the server sent the field. `TrackProgressTracker` relies on this reference identity
+to distinguish fresh progress from carried-forward stale progress.
+
 ---
 
 ## Testing & Debugging
@@ -561,6 +567,13 @@ Enable verbose logging in appsettings.json:
 The SDK is consumed as a NuGet package. Source and publishing are managed in [Sendspin/sendspin-dotnet](https://github.com/Sendspin/sendspin-dotnet).
 
 To update the SDK version, change the `Version` in the `<PackageReference Include="Sendspin.SDK">` entries in both `Sendspin.Windows.csproj` and `Sendspin.Windows.Services.csproj`.
+
+When bumping the SDK version, also verify that the carry-forward-by-reference behavior
+still holds: `SendspinClientService.HandleServerState` must reuse the **same**
+`PlaybackProgress` instance when the progress field is absent from a message —
+`TrackProgressTracker`'s freshness detection depends on it (see gotcha #7). An upstream
+contract test is being added to sendspin-dotnet; until it exists, this must be checked
+manually against the SDK source.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-17-seek-bar-reset-design.md
+++ b/docs/superpowers/specs/2026-07-17-seek-bar-reset-design.md
@@ -1,0 +1,78 @@
+# Seek Bar Reset on Track Change — Design
+
+**Date**: 2026-07-17
+**Status**: Implemented
+**Bug**: Clicking previous/next at e.g. 120s into a track leaves the seek bar at ~120s; the
+interpolation timer keeps adding wall-clock time against the old duration, so the bar creeps
+and pins near the end until the server happens to send a progress object.
+
+## Root Causes
+
+1. **No local reset on track change.** Neither group-state handler nor the track-change
+   detection in `OnCurrentTrackChanged` resets Position/Duration when the track identity
+   changes without an accompanying progress object.
+2. **Handler drift.** The client-initiated (primary) handler `OnManualClientGroupStateChanged`
+   never got the progress tri-state handling the host-mode handler `OnGroupStateChanged` has —
+   two copies of the same merge logic diverged.
+3. **Explicit-null progress never zeroes Position.** Per the tri-state (present-null = track
+   ended), both handlers at best stopped interpolation but left the stale Position on screen.
+   The Python CLI clears progress *and* duration in this case (`update_metadata` in
+   `sendspin/tui/app.py`).
+
+An SDK-level detail sharpens cause 1: `SendSpinClient.HandleServerState` merges metadata with
+`Optional<T>` semantics and **carries the previous `PlaybackProgress` instance forward** when
+the field is absent. A track change whose `server/state` lacks progress therefore arrives as
+*new identity + the old track's stale progress object*, and the old code re-anchored to that
+stale position. Both connection modes flow through `SendSpinClient` (the host service wraps
+one per incoming connection), so the same semantics apply everywhere.
+
+## Fix
+
+Extract one shared, plain, unit-testable class — `TrackProgressTracker`
+(`src/Sendspin.Windows.Services/Playback/`) — that owns all position/duration/anchor state.
+`MainViewModel` becomes a thin caller: both group-state handlers call `ApplyMetadata`, the
+250 ms UI timer calls `Tick`, next/previous call `ResetForPendingTrackChange`, and the
+pause/stop transition calls `Freeze`. Fresh progress is distinguished from carried-forward
+stale progress by reference: the SDK deserializes a **new** `PlaybackProgress` instance
+exactly when the server sent the field, and carries the **same** instance forward when absent.
+
+## Behavior Matrix
+
+| Scenario | Old behavior | New behavior |
+|---|---|---|
+| Same-track update with fresh progress | Adopt position/duration, re-anchor | Same |
+| Same-track update, progress absent (carried ref) | Re-anchored to stale server position (bar rewound) | Keep current interpolated position untouched |
+| Track change **with** fresh progress | Adopt (worked) | Reset, then adopt (same result) |
+| Track change **without** progress (carried stale ref or null) | Kept old position; timer crept vs old duration (**the bug**) | Position 0, Duration 0, frozen until first fresh progress |
+| Explicit-null progress, same track (track ended) | Host: kept final position; manual: kept anchor | Position 0, Duration 0, frozen (matches CLI clearing) |
+| Previous/Next clicked | Nothing until server progress | Optimistic: Position 0 immediately, frozen; next fresh progress re-anchors (covers server restarting the *same* track at 0) |
+| Pause → resume without fresh progress | Frozen at last position | Same (`Freeze` clears the anchor) |
+| Metadata null (track cleared) | Zeroed | Same, via tracker |
+| Paused progress with `playback_speed` 0 | n/a | Anchored but frozen (speed scales extrapolation) |
+
+Preserved quirk: extrapolation still only advances when duration > 0 (same gate as the old
+timer tick), so duration-less streams keep today's static display.
+
+## Extrapolation Formula (spec adoption — full branch)
+
+The SDK 9.1.0 surface exposes everything the spec formula needs, so it is implemented
+app-side with no SDK changes:
+
+- `PlaybackProgress.PlaybackSpeed` (double?, 1000 = 1.0x) — scales elapsed time; 0 freezes.
+- `TrackMetadata.Timestamp` (long?, server-domain µs) — when the progress was measured.
+- `IClockSynchronizer.ServerToClientTime` / `IsConverged` — server→client conversion.
+
+On fresh progress the anchor is `ServerToClientTime(metadata.Timestamp)` (network-delay
+compensation per spec), displayed position = anchor position + elapsed × speed, clamped to
+[0, duration]. Fallback to receipt-time anchoring when: no timestamp, clock not converged,
+converted time implausibly old (> 5 s before receipt — guards against a stale carried-forward
+timestamp merged next to fresh progress), or converted time in the future. Speed defaults to
+1.0 when absent.
+
+## Out of Scope / Deferred
+
+- The SDK never clears `GroupState.Metadata` on group switch (the CLI does). A group switch
+  to a group playing an identically-titled track could briefly show stale progress; fixing
+  that needs an SDK change (e.g. surfacing group identity with metadata resets).
+- Advancing the position label for duration-less streams (radio) — behavior intentionally
+  unchanged.

--- a/docs/superpowers/specs/2026-07-17-seek-bar-reset-design.md
+++ b/docs/superpowers/specs/2026-07-17-seek-bar-reset-design.md
@@ -32,7 +32,11 @@ Extract one shared, plain, unit-testable class — `TrackProgressTracker`
 (`src/Sendspin.Windows.Services/Playback/`) — that owns all position/duration/anchor state.
 `MainViewModel` becomes a thin caller: both group-state handlers call `ApplyMetadata`, the
 250 ms UI timer calls `Tick`, next/previous call `ResetForPendingTrackChange`, and the
-pause/stop transition calls `Freeze`. Fresh progress is distinguished from carried-forward
+pause/stop transition calls `Freeze`. `ApplyMetadata` also receives the playback state from
+the **same group update** (not the VM property): fresh progress arriving while the group is
+not playing anchors with effective speed 0, so a pause update cannot silently un-freeze the
+bar and the handlers' assignment order (`PlaybackState` before/after progress) stops
+mattering. Fresh progress is distinguished from carried-forward
 stale progress by reference: the SDK deserializes a **new** `PlaybackProgress` instance
 exactly when the server sent the field, and carries the **same** instance forward when absent.
 
@@ -46,9 +50,10 @@ exactly when the server sent the field, and carries the **same** instance forwar
 | Track change **without** progress (carried stale ref or null) | Kept old position; timer crept vs old duration (**the bug**) | Position 0, Duration 0, frozen until first fresh progress |
 | Explicit-null progress, same track (track ended) | Host: kept final position; manual: kept anchor | Position 0, Duration 0, frozen (matches CLI clearing) |
 | Previous/Next clicked | Nothing until server progress | Optimistic: Position 0 immediately, frozen; next fresh progress re-anchors (covers server restarting the *same* track at 0) |
-| Pause → resume without fresh progress | Frozen at last position | Same (`Freeze` clears the anchor) |
+| Pause update **with** fresh progress (speed absent or explicit) | (initial tracker implementation) anchor re-armed at the progress speed (default 1.0), undoing `Freeze`; a later resume without fresh progress jumped the bar by the whole pause duration | Anchored at the paused position with effective speed 0 — the update's playback state overrides the progress speed |
+| Pause → resume without fresh progress | Frozen at last position | Frozen at the paused position until fresh progress re-anchors (`Freeze` clears the anchor; not-playing updates anchor at speed 0) |
 | Metadata null (track cleared) | Zeroed | Same, via tracker |
-| Paused progress with `playback_speed` 0 | n/a | Anchored but frozen (speed scales extrapolation) |
+| Paused progress with `playback_speed` 0 | n/a | Anchored but frozen (state and speed agree) |
 
 Preserved quirk: extrapolation still only advances when duration > 0 (same gate as the old
 timer tick), so duration-less streams keep today's static display.
@@ -67,7 +72,8 @@ compensation per spec), displayed position = anchor position + elapsed × speed,
 [0, duration]. Fallback to receipt-time anchoring when: no timestamp, clock not converged,
 converted time implausibly old (> 5 s before receipt — guards against a stale carried-forward
 timestamp merged next to fresh progress), or converted time in the future. Speed defaults to
-1.0 when absent.
+1.0 when absent, but the update's playback state overrides it: any not-playing state anchors
+with effective speed 0.
 
 ## Out of Scope / Deferred
 

--- a/docs/superpowers/specs/2026-07-17-seek-bar-reset-design.md
+++ b/docs/superpowers/specs/2026-07-17-seek-bar-reset-design.md
@@ -19,12 +19,13 @@ and pins near the end until the server happens to send a progress object.
    The Python CLI clears progress *and* duration in this case (`update_metadata` in
    `sendspin/tui/app.py`).
 
-An SDK-level detail sharpens cause 1: `SendSpinClient.HandleServerState` merges metadata with
+An SDK-level detail sharpens cause 1: `SendspinClientService.HandleServerState` (declared in
+`SendSpinClient.cs`) merges metadata with
 `Optional<T>` semantics and **carries the previous `PlaybackProgress` instance forward** when
 the field is absent. A track change whose `server/state` lacks progress therefore arrives as
 *new identity + the old track's stale progress object*, and the old code re-anchored to that
-stale position. Both connection modes flow through `SendSpinClient` (the host service wraps
-one per incoming connection), so the same semantics apply everywhere.
+stale position. Both connection modes flow through `SendspinClientService` (the host service
+wraps one per incoming connection), so the same semantics apply everywhere.
 
 ## Fix
 

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -27,10 +27,14 @@ namespace Sendspin.Windows.Services.Playback;
 /// <para>
 /// Extrapolation follows the spec formula: displayed position is the anchored
 /// <c>track_progress</c> plus elapsed time scaled by <c>playback_speed</c> (0 freezes the
-/// position), clamped to <c>[0, duration]</c>. When the clock synchronizer has converged
-/// and the metadata carries a plausible server timestamp, the anchor is that timestamp
-/// converted to client time (compensating network delay); otherwise the anchor falls back
-/// to the receipt time.
+/// position), clamped to <c>[0, duration]</c>. The playback state carried by the same
+/// update overrides the progress object's speed: whenever the group is not playing, fresh
+/// progress anchors with an effective speed of 0, so a pause update cannot silently
+/// un-freeze the bar and a later resume without fresh progress stays at the paused
+/// position instead of jumping forward by the pause duration. When the clock synchronizer
+/// has converged and the metadata carries a plausible server timestamp, the anchor is that
+/// timestamp converted to client time (compensating network delay); otherwise the anchor
+/// falls back to the receipt time.
 /// </para>
 /// <para>
 /// All times are client-domain microseconds from <see cref="IHighPrecisionTimer"/>.
@@ -81,8 +85,11 @@ public sealed class TrackProgressTracker
     /// Applies a merged metadata snapshot from a group state update.
     /// </summary>
     /// <param name="metadata">The merged track metadata, or null when no track is active.</param>
+    /// <param name="playbackState">The group playback state carried by the same update.
+    /// When not <see cref="PlaybackState.Playing"/>, fresh progress anchors with an
+    /// effective speed of 0 regardless of the progress object's <c>playback_speed</c>.</param>
     /// <param name="nowMicroseconds">Current client time in microseconds.</param>
-    public void ApplyMetadata(TrackMetadata? metadata, long nowMicroseconds)
+    public void ApplyMetadata(TrackMetadata? metadata, PlaybackState playbackState, long nowMicroseconds)
     {
         if (metadata is null)
         {
@@ -132,7 +139,15 @@ public sealed class TrackProgressTracker
         if (progress.TrackProgress.HasValue)
         {
             _anchorPositionSeconds = Math.Max(0, progress.TrackProgress.Value / 1000.0);
-            _speedFactor = Math.Max(0, (progress.PlaybackSpeed ?? 1000.0) / 1000.0);
+
+            // The update's playback state overrides the progress object's speed: while not
+            // playing the effective speed is 0, so a pause update carrying fresh progress
+            // (with or without playback_speed) anchors frozen, and a later resume without
+            // fresh progress stays at the paused position instead of jumping forward by
+            // the pause duration.
+            _speedFactor = playbackState == PlaybackState.Playing
+                ? Math.Max(0, (progress.PlaybackSpeed ?? 1000.0) / 1000.0)
+                : 0;
             _anchorMicroseconds = ResolveAnchor(metadata.Timestamp, nowMicroseconds);
             _hasAnchor = true;
             PositionSeconds = ExtrapolateAt(nowMicroseconds);

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -55,10 +55,7 @@ public sealed class TrackProgressTracker
 
     private string? _trackIdentity;
     private PlaybackProgress? _lastProgress;
-    private double _anchorPositionSeconds;
-    private long _anchorMicroseconds;
-    private double _speedFactor = 1.0;
-    private bool _hasAnchor;
+    private Anchor? _anchor;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrackProgressTracker"/> class.
@@ -138,19 +135,19 @@ public sealed class TrackProgressTracker
 
         if (progress.TrackProgress.HasValue)
         {
-            _anchorPositionSeconds = Math.Max(0, progress.TrackProgress.Value / 1000.0);
-
             // The update's playback state overrides the progress object's speed: while not
             // playing the effective speed is 0, so a pause update carrying fresh progress
             // (with or without playback_speed) anchors frozen, and a later resume without
             // fresh progress stays at the paused position instead of jumping forward by
             // the pause duration.
-            _speedFactor = playbackState == PlaybackState.Playing
+            var speedFactor = playbackState == PlaybackState.Playing
                 ? Math.Max(0, (progress.PlaybackSpeed ?? 1000.0) / 1000.0)
                 : 0;
-            _anchorMicroseconds = ResolveAnchor(metadata.Timestamp, nowMicroseconds);
-            _hasAnchor = true;
-            PositionSeconds = ExtrapolateAt(nowMicroseconds);
+            _anchor = new Anchor(
+                ResolveAnchor(metadata.Timestamp, nowMicroseconds),
+                Math.Max(0, progress.TrackProgress.Value / 1000.0),
+                speedFactor);
+            PositionSeconds = ExtrapolateAt(_anchor.Value, nowMicroseconds);
         }
     }
 
@@ -164,7 +161,7 @@ public sealed class TrackProgressTracker
     public void ResetForPendingTrackChange()
     {
         PositionSeconds = 0;
-        _hasAnchor = false;
+        _anchor = null;
 
         // _lastProgress is intentionally kept: a group/update echoing the pre-change
         // state carries the same stale progress instance and must not look fresh.
@@ -177,7 +174,7 @@ public sealed class TrackProgressTracker
     /// </summary>
     public void Freeze()
     {
-        _hasAnchor = false;
+        _anchor = null;
     }
 
     /// <summary>
@@ -188,12 +185,12 @@ public sealed class TrackProgressTracker
     /// (no anchor, or the duration is unknown).</returns>
     public double? Tick(long nowMicroseconds)
     {
-        if (!_hasAnchor || DurationSeconds <= 0)
+        if (_anchor is not { } anchor || DurationSeconds <= 0)
         {
             return null;
         }
 
-        PositionSeconds = ExtrapolateAt(nowMicroseconds);
+        PositionSeconds = ExtrapolateAt(anchor, nowMicroseconds);
         return PositionSeconds;
     }
 
@@ -201,14 +198,13 @@ public sealed class TrackProgressTracker
     {
         PositionSeconds = 0;
         DurationSeconds = 0;
-        _speedFactor = 1.0;
-        _hasAnchor = false;
+        _anchor = null;
     }
 
-    private double ExtrapolateAt(long nowMicroseconds)
+    private double ExtrapolateAt(Anchor anchor, long nowMicroseconds)
     {
-        var elapsedSeconds = Math.Max(0, nowMicroseconds - _anchorMicroseconds) / 1_000_000.0;
-        var position = _anchorPositionSeconds + (elapsedSeconds * _speedFactor);
+        var elapsedSeconds = Math.Max(0, nowMicroseconds - anchor.AtMicroseconds) / 1_000_000.0;
+        var position = anchor.PositionSeconds + (elapsedSeconds * anchor.SpeedFactor);
         return DurationSeconds > 0 ? Math.Clamp(position, 0, DurationSeconds) : Math.Max(0, position);
     }
 
@@ -226,4 +222,11 @@ public sealed class TrackProgressTracker
 
         return nowMicroseconds;
     }
+
+    /// <summary>
+    /// Extrapolation anchor captured from fresh progress: the track position at a
+    /// client-domain instant, plus the effective speed. Null whenever extrapolation
+    /// is stopped (no fresh progress yet, frozen, or reset).
+    /// </summary>
+    private readonly record struct Anchor(long AtMicroseconds, double PositionSeconds, double SpeedFactor);
 }

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -28,7 +28,8 @@ namespace Sendspin.Windows.Services.Playback;
 /// <para>
 /// Extrapolation follows the spec formula: displayed position is the anchored
 /// <c>track_progress</c> plus elapsed time scaled by <c>playback_speed</c> (0 freezes the
-/// position), clamped to <c>[0, duration]</c>. The playback state carried by the same
+/// position), clamped to <c>[0, duration]</c> when the duration is known. The playback
+/// state carried by the same
 /// update overrides the progress object's speed: whenever the group is not playing, fresh
 /// progress anchors with an effective speed of 0, so a pause update cannot silently
 /// un-freeze the bar and a later resume without fresh progress stays at the paused
@@ -38,7 +39,9 @@ namespace Sendspin.Windows.Services.Playback;
 /// falls back to the receipt time.
 /// </para>
 /// <para>
-/// All times are client-domain microseconds from <see cref="IHighPrecisionTimer"/>.
+/// The <c>nowMicroseconds</c> parameters are client-domain microseconds from
+/// <see cref="IHighPrecisionTimer"/>; <see cref="TrackMetadata.Timestamp"/> is
+/// server-domain and converted internally.
 /// The class is not thread-safe; callers are expected to invoke it from the UI dispatcher.
 /// </para>
 /// </remarks>
@@ -177,8 +180,10 @@ public sealed class TrackProgressTracker
         PositionSeconds = 0;
         _anchor = null;
 
-        // _lastProgress is intentionally kept: a group/update echoing the pre-change
-        // state carries the same stale progress instance and must not look fresh.
+        // _lastProgress is intentionally kept: any group-state event echoing the
+        // pre-change merged state carries the same stale progress instance and must
+        // not look fresh (metadata travels in server/state; group/update only carries
+        // playback state and group identity, but both re-emit the merged snapshot).
     }
 
     /// <summary>

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using Sendspin.SDK.Models;
 using Sendspin.SDK.Protocol.Messages;
 using Sendspin.SDK.Synchronization;
@@ -52,6 +54,7 @@ public sealed class TrackProgressTracker
     private const long MaxAnchorAgeMicroseconds = 5_000_000;
 
     private readonly IClockSynchronizer? _clockSynchronizer;
+    private readonly ILogger<TrackProgressTracker> _logger;
 
     private string? _trackIdentity;
     private PlaybackProgress? _lastProgress;
@@ -63,9 +66,12 @@ public sealed class TrackProgressTracker
     /// <param name="clockSynchronizer">Optional clock synchronizer used to anchor fresh
     /// progress at its server timestamp. When null or not converged, anchors fall back to
     /// the receipt time.</param>
-    public TrackProgressTracker(IClockSynchronizer? clockSynchronizer)
+    /// <param name="logger">Logger for anchor and reset diagnostics (Debug level; these
+    /// fire on every progress update).</param>
+    public TrackProgressTracker(IClockSynchronizer? clockSynchronizer, ILogger<TrackProgressTracker> logger)
     {
         _clockSynchronizer = clockSynchronizer;
+        _logger = logger;
     }
 
     /// <summary>
@@ -100,6 +106,7 @@ public sealed class TrackProgressTracker
         // has no track id/URI, so title+artist+album is the best available identity.
         var identity = $"{metadata.Title}|{metadata.Artist}|{metadata.Album}";
         var identityChanged = identity != _trackIdentity;
+        var previousIdentity = _trackIdentity;
         _trackIdentity = identity;
 
         var progress = metadata.Progress;
@@ -109,6 +116,10 @@ public sealed class TrackProgressTracker
         if (identityChanged)
         {
             // New track: never trust position state that belonged to the previous track.
+            _logger.LogDebug(
+                "Track identity changed ({PreviousIdentity} -> {Identity}); resetting seek bar position",
+                previousIdentity ?? "(none)",
+                identity);
             ResetPosition();
         }
 
@@ -116,6 +127,7 @@ public sealed class TrackProgressTracker
         {
             // Explicit-null progress (track ended) or no progress yet: clear position and
             // duration, matching the CLI's update_metadata handling.
+            _logger.LogDebug("Progress is null (track ended or none yet); clearing position and duration");
             ResetPosition();
             return;
         }
@@ -160,6 +172,9 @@ public sealed class TrackProgressTracker
     /// </summary>
     public void ResetForPendingTrackChange()
     {
+        _logger.LogDebug(
+            "Optimistic seek bar reset pending track change (position was {PositionSeconds}s)",
+            PositionSeconds);
         PositionSeconds = 0;
         _anchor = null;
 
@@ -210,17 +225,30 @@ public sealed class TrackProgressTracker
 
     private long ResolveAnchor(long? serverTimestampMicroseconds, long nowMicroseconds)
     {
-        if (serverTimestampMicroseconds.HasValue && _clockSynchronizer?.IsConverged == true)
+        if (!serverTimestampMicroseconds.HasValue)
         {
-            var converted = _clockSynchronizer.ServerToClientTime(serverTimestampMicroseconds.Value);
-            var age = nowMicroseconds - converted;
-            if (age >= 0 && age <= MaxAnchorAgeMicroseconds)
-            {
-                return converted;
-            }
+            _logger.LogDebug("Anchor fell back to receipt time: metadata carries no server timestamp");
+            return nowMicroseconds;
         }
 
-        return nowMicroseconds;
+        if (_clockSynchronizer?.IsConverged != true)
+        {
+            _logger.LogDebug("Anchor fell back to receipt time: clock synchronizer not converged");
+            return nowMicroseconds;
+        }
+
+        var converted = _clockSynchronizer.ServerToClientTime(serverTimestampMicroseconds.Value);
+        var age = nowMicroseconds - converted;
+        if (age < 0 || age > MaxAnchorAgeMicroseconds)
+        {
+            _logger.LogDebug(
+                "Anchor fell back to receipt time: converted timestamp age {AgeMicroseconds}µs outside [0, {MaxAgeMicroseconds}µs]",
+                age,
+                MaxAnchorAgeMicroseconds);
+            return nowMicroseconds;
+        }
+
+        return converted;
     }
 
     /// <summary>
@@ -228,5 +256,9 @@ public sealed class TrackProgressTracker
     /// client-domain instant, plus the effective speed. Null whenever extrapolation
     /// is stopped (no fresh progress yet, frozen, or reset).
     /// </summary>
+    [SuppressMessage(
+        "StyleCop.CSharp.NamingRules",
+        "SA1313:Parameter names should begin with lower-case letter",
+        Justification = "Positional record parameters become properties and follow property naming.")]
     private readonly record struct Anchor(long AtMicroseconds, double PositionSeconds, double SpeedFactor);
 }

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Sendspin.SDK.Models;
 using Sendspin.SDK.Protocol.Messages;
@@ -256,9 +255,18 @@ public sealed class TrackProgressTracker
     /// client-domain instant, plus the effective speed. Null whenever extrapolation
     /// is stopped (no fresh progress yet, frozen, or reset).
     /// </summary>
-    [SuppressMessage(
-        "StyleCop.CSharp.NamingRules",
-        "SA1313:Parameter names should begin with lower-case letter",
-        Justification = "Positional record parameters become properties and follow property naming.")]
-    private readonly record struct Anchor(long AtMicroseconds, double PositionSeconds, double SpeedFactor);
+    /// <remarks>
+    /// A plain readonly struct rather than the equivalent positional record struct:
+    /// the StyleCop version in use crashes on record struct declarations (AD0001 from
+    /// SA1201) and flags positional parameters as SA1313, which would push the build's
+    /// warning count above its baseline. Value equality is not needed here.
+    /// </remarks>
+    private readonly struct Anchor(long atMicroseconds, double positionSeconds, double speedFactor)
+    {
+        public long AtMicroseconds { get; } = atMicroseconds;
+
+        public double PositionSeconds { get; } = positionSeconds;
+
+        public double SpeedFactor { get; } = speedFactor;
+    }
 }

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -1,0 +1,214 @@
+// <copyright file="TrackProgressTracker.cs" company="Sendspin Windows Client">
+// Licensed under the MIT License. See LICENSE file in the project root.
+// </copyright>
+
+using Sendspin.SDK.Models;
+using Sendspin.SDK.Protocol.Messages;
+using Sendspin.SDK.Synchronization;
+
+namespace Sendspin.Windows.Services.Playback;
+
+/// <summary>
+/// Tracks the displayed playback position and duration for the seek bar. Owns the anchor
+/// state used to extrapolate the position between server progress updates and implements
+/// the Sendspin spec's progress semantics on top of the SDK's merged
+/// <see cref="GroupState"/> metadata snapshots.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The SDK merges <c>server/state</c> metadata with <c>Optional&lt;T&gt;</c> semantics and
+/// carries the previous <see cref="PlaybackProgress"/> instance forward when the field is
+/// absent from a message. This class therefore distinguishes <em>fresh</em> progress (a new
+/// instance, meaning the server actually sent the field) from <em>carried-forward</em>
+/// progress by reference. Carried progress never re-anchors the position: on the same track
+/// it leaves the extrapolation undisturbed, and on a track-identity change it is treated as
+/// no progress at all — the position resets to zero until the first fresh progress arrives.
+/// </para>
+/// <para>
+/// Extrapolation follows the spec formula: displayed position is the anchored
+/// <c>track_progress</c> plus elapsed time scaled by <c>playback_speed</c> (0 freezes the
+/// position), clamped to <c>[0, duration]</c>. When the clock synchronizer has converged
+/// and the metadata carries a plausible server timestamp, the anchor is that timestamp
+/// converted to client time (compensating network delay); otherwise the anchor falls back
+/// to the receipt time.
+/// </para>
+/// <para>
+/// All times are client-domain microseconds from <see cref="IHighPrecisionTimer"/>.
+/// The class is not thread-safe; callers are expected to invoke it from the UI dispatcher.
+/// </para>
+/// </remarks>
+public sealed class TrackProgressTracker
+{
+    /// <summary>
+    /// Maximum age of a converted metadata timestamp before it is considered implausible
+    /// and the anchor falls back to receipt time. Guards against a stale carried-forward
+    /// timestamp arriving next to fresh progress (the SDK merges metadata fields
+    /// independently).
+    /// </summary>
+    private const long MaxAnchorAgeMicroseconds = 5_000_000;
+
+    private readonly IClockSynchronizer? _clockSynchronizer;
+
+    private string? _trackIdentity;
+    private PlaybackProgress? _lastProgress;
+    private double _anchorPositionSeconds;
+    private long _anchorMicroseconds;
+    private double _speedFactor = 1.0;
+    private bool _hasAnchor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TrackProgressTracker"/> class.
+    /// </summary>
+    /// <param name="clockSynchronizer">Optional clock synchronizer used to anchor fresh
+    /// progress at its server timestamp. When null or not converged, anchors fall back to
+    /// the receipt time.</param>
+    public TrackProgressTracker(IClockSynchronizer? clockSynchronizer)
+    {
+        _clockSynchronizer = clockSynchronizer;
+    }
+
+    /// <summary>
+    /// Gets the current displayed position in seconds.
+    /// </summary>
+    public double PositionSeconds { get; private set; }
+
+    /// <summary>
+    /// Gets the current track duration in seconds (0 when unknown).
+    /// </summary>
+    public double DurationSeconds { get; private set; }
+
+    /// <summary>
+    /// Applies a merged metadata snapshot from a group state update.
+    /// </summary>
+    /// <param name="metadata">The merged track metadata, or null when no track is active.</param>
+    /// <param name="nowMicroseconds">Current client time in microseconds.</param>
+    public void ApplyMetadata(TrackMetadata? metadata, long nowMicroseconds)
+    {
+        if (metadata is null)
+        {
+            _trackIdentity = null;
+            _lastProgress = null;
+            ResetPosition();
+            return;
+        }
+
+        // Same identity convention as the track-change notification logic: TrackMetadata
+        // has no track id/URI, so title+artist+album is the best available identity.
+        var identity = $"{metadata.Title}|{metadata.Artist}|{metadata.Album}";
+        var identityChanged = identity != _trackIdentity;
+        _trackIdentity = identity;
+
+        var progress = metadata.Progress;
+        var isFresh = progress is not null && !ReferenceEquals(progress, _lastProgress);
+        _lastProgress = progress;
+
+        if (identityChanged)
+        {
+            // New track: never trust position state that belonged to the previous track.
+            ResetPosition();
+        }
+
+        if (progress is null)
+        {
+            // Explicit-null progress (track ended) or no progress yet: clear position and
+            // duration, matching the CLI's update_metadata handling.
+            ResetPosition();
+            return;
+        }
+
+        if (!isFresh)
+        {
+            // Carried-forward instance: the server did not send progress in this message.
+            // Same track: leave the running extrapolation undisturbed (prevents rewinding
+            // to a stale position). New track: stay at the reset applied above.
+            return;
+        }
+
+        if (progress.TrackDuration.HasValue)
+        {
+            DurationSeconds = Math.Max(0, progress.TrackDuration.Value / 1000.0);
+        }
+
+        if (progress.TrackProgress.HasValue)
+        {
+            _anchorPositionSeconds = Math.Max(0, progress.TrackProgress.Value / 1000.0);
+            _speedFactor = Math.Max(0, (progress.PlaybackSpeed ?? 1000.0) / 1000.0);
+            _anchorMicroseconds = ResolveAnchor(metadata.Timestamp, nowMicroseconds);
+            _hasAnchor = true;
+            PositionSeconds = ExtrapolateAt(nowMicroseconds);
+        }
+    }
+
+    /// <summary>
+    /// Optimistically resets the position to zero when the user requests a track change
+    /// (next/previous), pending server confirmation. Extrapolation stops until the next
+    /// fresh progress re-anchors it; the known duration is kept for display. This also
+    /// covers the server restarting the <em>same</em> track at zero on "previous", where
+    /// the track identity never changes.
+    /// </summary>
+    public void ResetForPendingTrackChange()
+    {
+        PositionSeconds = 0;
+        _hasAnchor = false;
+
+        // _lastProgress is intentionally kept: a group/update echoing the pre-change
+        // state carries the same stale progress instance and must not look fresh.
+    }
+
+    /// <summary>
+    /// Stops extrapolation when playback leaves the playing state, keeping the last
+    /// displayed position. Resuming without fresh progress stays frozen rather than
+    /// jumping forward by the paused duration.
+    /// </summary>
+    public void Freeze()
+    {
+        _hasAnchor = false;
+    }
+
+    /// <summary>
+    /// Recomputes the extrapolated position. Call periodically while playing.
+    /// </summary>
+    /// <param name="nowMicroseconds">Current client time in microseconds.</param>
+    /// <returns>The updated position in seconds, or null when there is nothing to advance
+    /// (no anchor, or the duration is unknown).</returns>
+    public double? Tick(long nowMicroseconds)
+    {
+        if (!_hasAnchor || DurationSeconds <= 0)
+        {
+            return null;
+        }
+
+        PositionSeconds = ExtrapolateAt(nowMicroseconds);
+        return PositionSeconds;
+    }
+
+    private void ResetPosition()
+    {
+        PositionSeconds = 0;
+        DurationSeconds = 0;
+        _speedFactor = 1.0;
+        _hasAnchor = false;
+    }
+
+    private double ExtrapolateAt(long nowMicroseconds)
+    {
+        var elapsedSeconds = Math.Max(0, nowMicroseconds - _anchorMicroseconds) / 1_000_000.0;
+        var position = _anchorPositionSeconds + (elapsedSeconds * _speedFactor);
+        return DurationSeconds > 0 ? Math.Clamp(position, 0, DurationSeconds) : Math.Max(0, position);
+    }
+
+    private long ResolveAnchor(long? serverTimestampMicroseconds, long nowMicroseconds)
+    {
+        if (serverTimestampMicroseconds.HasValue && _clockSynchronizer?.IsConverged == true)
+        {
+            var converted = _clockSynchronizer.ServerToClientTime(serverTimestampMicroseconds.Value);
+            var age = nowMicroseconds - converted;
+            if (age >= 0 && age <= MaxAnchorAgeMicroseconds)
+            {
+                return converted;
+            }
+        }
+
+        return nowMicroseconds;
+    }
+}

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -588,7 +588,8 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private void OnPositionTimerTick(object? sender, EventArgs e)
     {
-        // Only interpolate while playing; the tracker returns null when it has no anchor.
+        // Only interpolate while playing; the tracker returns null when it has no
+        // anchor or no known duration.
         if (PlaybackState != PlaybackState.Playing)
         {
             return;

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -604,11 +604,13 @@ public partial class MainViewModel : ViewModelBase
     /// Routes a merged metadata snapshot through the progress tracker and reflects the
     /// resulting position/duration in the UI. Shared by both connection-mode handlers so
     /// the progress tri-state (value / explicit null / absent) and track-change resets
-    /// behave identically in client-initiated and server-initiated modes.
+    /// behave identically in client-initiated and server-initiated modes. The playback
+    /// state comes from the same group update (not the VM property) so the tracker sees
+    /// a consistent snapshot regardless of handler assignment order.
     /// </summary>
-    private void ApplyTrackProgress(TrackMetadata? metadata)
+    private void ApplyTrackProgress(TrackMetadata? metadata, PlaybackState playbackState)
     {
-        _progressTracker.ApplyMetadata(metadata, HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds());
+        _progressTracker.ApplyMetadata(metadata, playbackState, HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds());
         Duration = _progressTracker.DurationSeconds;
         Position = _progressTracker.PositionSeconds;
     }
@@ -1136,7 +1138,7 @@ public partial class MainViewModel : ViewModelBase
                 RepeatMode = group.Repeat ?? "off";
 
                 // Position/duration: tri-state progress handling and track-change resets
-                ApplyTrackProgress(group.Metadata);
+                ApplyTrackProgress(group.Metadata, group.PlaybackState);
 
                 if (CurrentTrack != null)
                 {
@@ -1325,7 +1327,7 @@ public partial class MainViewModel : ViewModelBase
                 RepeatMode = group.Repeat ?? "off";
 
                 // Position/duration: tri-state progress handling and track-change resets
-                ApplyTrackProgress(group.Metadata);
+                ApplyTrackProgress(group.Metadata, group.PlaybackState);
 
                 // Update status with now playing info
                 if (CurrentTrack != null)
@@ -1765,11 +1767,12 @@ public partial class MainViewModel : ViewModelBase
         }
         else if (value == null)
         {
-            // Track cleared - reset artwork and progress
+            // Track cleared - reset artwork and progress. Null metadata resets the
+            // tracker unconditionally, so the playback state is incidental here.
             AlbumArtwork = null;
             _lastArtworkUrl = null;
             _previousTrackId = null;
-            ApplyTrackProgress(null);
+            ApplyTrackProgress(null, PlaybackState);
 
             // Clear Discord presence when track is cleared
             _discordService.ClearPresence();

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -24,6 +24,7 @@ using Sendspin.Windows.Services.Diagnostics;
 using Sendspin.Windows.Services.Discord;
 using Sendspin.Windows.Services.MediaControls;
 using Sendspin.Windows.Services.Notifications;
+using Sendspin.Windows.Services.Playback;
 using Sendspin.Windows.Views;
 
 namespace Sendspin.Windows.ViewModels;
@@ -118,16 +119,10 @@ public partial class MainViewModel : ViewModelBase
     private readonly DispatcherTimer _positionTimer;
 
     /// <summary>
-    /// The last position value received from the server.
-    /// Used as anchor point for local interpolation.
+    /// Owns the seek bar position/duration state: progress tri-state handling,
+    /// track-change resets, and extrapolation between server updates.
     /// </summary>
-    private double _lastServerPosition;
-
-    /// <summary>
-    /// Timestamp when we received the last server position update.
-    /// Used to calculate elapsed time for interpolation.
-    /// </summary>
-    private DateTime _lastServerPositionUpdate = DateTime.MinValue;
+    private readonly TrackProgressTracker _progressTracker;
 
     /// <summary>
     /// Gets the application version string for display in the UI.
@@ -540,6 +535,7 @@ public partial class MainViewModel : ViewModelBase
         _ambient = ambient;
         _settingsService = settingsService;
         _syncHealthMonitor = syncHealthMonitor;
+        _progressTracker = new TrackProgressTracker(clockSynchronizer);
 
         _mediaControlsService.PlayPauseRequested += (_, _) =>
             App.Current.Dispatcher.InvokeAsync(() =>
@@ -586,27 +582,35 @@ public partial class MainViewModel : ViewModelBase
 
     /// <summary>
     /// Timer tick handler for smooth position interpolation.
-    /// Calculates current position based on last server update + elapsed time.
+    /// Asks the progress tracker to extrapolate from the last server anchor.
     /// </summary>
     private void OnPositionTimerTick(object? sender, EventArgs e)
     {
-        // Only interpolate when playing and we have valid anchor data
-        if (PlaybackState != PlaybackState.Playing ||
-            _lastServerPositionUpdate == DateTime.MinValue ||
-            Duration <= 0)
+        // Only interpolate while playing; the tracker returns null when it has no anchor.
+        if (PlaybackState != PlaybackState.Playing)
         {
             return;
         }
 
-        // Calculate interpolated position
-        var elapsed = (DateTime.UtcNow - _lastServerPositionUpdate).TotalSeconds;
-        var interpolatedPosition = _lastServerPosition + elapsed;
+        var position = _progressTracker.Tick(HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds());
+        if (position.HasValue)
+        {
+            // Update position (this triggers OnPositionChanged which updates UI bindings)
+            Position = position.Value;
+        }
+    }
 
-        // Clamp to valid range (don't exceed duration)
-        interpolatedPosition = Math.Min(interpolatedPosition, Duration);
-
-        // Update position (this triggers OnPositionChanged which updates UI bindings)
-        Position = interpolatedPosition;
+    /// <summary>
+    /// Routes a merged metadata snapshot through the progress tracker and reflects the
+    /// resulting position/duration in the UI. Shared by both connection-mode handlers so
+    /// the progress tri-state (value / explicit null / absent) and track-change resets
+    /// behave identically in client-initiated and server-initiated modes.
+    /// </summary>
+    private void ApplyTrackProgress(TrackMetadata? metadata)
+    {
+        _progressTracker.ApplyMetadata(metadata, HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds());
+        Duration = _progressTracker.DurationSeconds;
+        Position = _progressTracker.PositionSeconds;
     }
 
     public async Task InitializeAsync()
@@ -687,6 +691,11 @@ public partial class MainViewModel : ViewModelBase
     {
         if (!IsConnected) return;
 
+        // Optimistic reset: snap the seek bar to zero now; the next fresh server
+        // progress re-anchors it authoritatively.
+        _progressTracker.ResetForPendingTrackChange();
+        Position = 0;
+
         try
         {
             await SendCommandToActiveClientAsync(Commands.Next);
@@ -701,6 +710,12 @@ public partial class MainViewModel : ViewModelBase
     private async Task PreviousTrackAsync()
     {
         if (!IsConnected) return;
+
+        // Optimistic reset: snap the seek bar to zero now; the next fresh server
+        // progress re-anchors it. Covers the server restarting the SAME track at zero,
+        // where no track-identity change would ever reset the bar.
+        _progressTracker.ResetForPendingTrackChange();
+        Position = 0;
 
         try
         {
@@ -1120,18 +1135,8 @@ public partial class MainViewModel : ViewModelBase
                 IsShuffleEnabled = group.Shuffle;
                 RepeatMode = group.Repeat ?? "off";
 
-                if (group.Metadata?.Duration.HasValue == true)
-                {
-                    Duration = group.Metadata.Duration.Value;
-                }
-
-                // Update position from server and set anchor for interpolation
-                if (group.Metadata?.Position.HasValue == true)
-                {
-                    _lastServerPosition = group.Metadata.Position.Value;
-                    _lastServerPositionUpdate = DateTime.UtcNow;
-                    Position = _lastServerPosition;
-                }
+                // Position/duration: tri-state progress handling and track-change resets
+                ApplyTrackProgress(group.Metadata);
 
                 if (CurrentTrack != null)
                 {
@@ -1319,32 +1324,8 @@ public partial class MainViewModel : ViewModelBase
                 IsShuffleEnabled = group.Shuffle;
                 RepeatMode = group.Repeat ?? "off";
 
-                // Handle progress updates OR clearing
-                // Progress can be:
-                //   - Non-null: update position/duration and enable interpolation
-                //   - Null: track ended - stop interpolation but keep final position visible
-                if (group.Metadata?.Progress is not null)
-                {
-                    // Progress exists - update position/duration
-                    if (group.Metadata.Duration.HasValue)
-                    {
-                        Duration = group.Metadata.Duration.Value;
-                    }
-
-                    if (group.Metadata.Position.HasValue)
-                    {
-                        _lastServerPosition = group.Metadata.Position.Value;
-                        _lastServerPositionUpdate = DateTime.UtcNow;
-                        Position = _lastServerPosition;
-                    }
-                }
-                else if (group.Metadata is not null)
-                {
-                    // Progress explicitly cleared (track ended)
-                    // Keep final position visible, but stop interpolation timer
-                    // The PlaybackState change (via group/update) handles the play/pause button
-                    _lastServerPositionUpdate = DateTime.MinValue;
-                }
+                // Position/duration: tri-state progress handling and track-change resets
+                ApplyTrackProgress(group.Metadata);
 
                 // Update status with now playing info
                 if (CurrentTrack != null)
@@ -1713,10 +1694,10 @@ public partial class MainViewModel : ViewModelBase
 
         _mediaControlsService.UpdateState(value);
 
-        // Reset position interpolation anchor when playback stops
+        // Stop position extrapolation when playback stops; the bar keeps its last value
         if (value != PlaybackState.Playing)
         {
-            _lastServerPositionUpdate = DateTime.MinValue;
+            _progressTracker.Freeze();
         }
     }
 
@@ -1788,9 +1769,7 @@ public partial class MainViewModel : ViewModelBase
             AlbumArtwork = null;
             _lastArtworkUrl = null;
             _previousTrackId = null;
-            Position = 0;
-            Duration = 0;
-            _lastServerPositionUpdate = DateTime.MinValue;
+            ApplyTrackProgress(null);
 
             // Clear Discord presence when track is cleared
             _discordService.ClearPresence();

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -535,7 +535,9 @@ public partial class MainViewModel : ViewModelBase
         _ambient = ambient;
         _settingsService = settingsService;
         _syncHealthMonitor = syncHealthMonitor;
-        _progressTracker = new TrackProgressTracker(clockSynchronizer);
+        _progressTracker = new TrackProgressTracker(
+            clockSynchronizer,
+            loggerFactory.CreateLogger<TrackProgressTracker>());
 
         _mediaControlsService.PlayPauseRequested += (_, _) =>
             App.Current.Dispatcher.InvokeAsync(() =>
@@ -704,7 +706,7 @@ public partial class MainViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send next command");
+            _logger.LogError(ex, "Failed to send next command; seek bar was already optimistically reset to zero");
         }
     }
 
@@ -725,7 +727,7 @@ public partial class MainViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send previous command");
+            _logger.LogError(ex, "Failed to send previous command; seek bar was already optimistically reset to zero");
         }
     }
 

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Sendspin.SDK.Models;
 using Sendspin.SDK.Protocol.Messages;
 using Sendspin.SDK.Synchronization;
@@ -18,7 +19,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void NoMetadataYet_DefaultsToZero()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
 
         Assert.Equal(0.0, tracker.PositionSeconds);
         Assert.Equal(0.0, tracker.DurationSeconds);
@@ -28,7 +29,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void FreshProgress_AdoptsPositionAndDuration()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
@@ -39,7 +40,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void Tick_AdvancesWithElapsedTime()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         var position = tracker.Tick(T0 + (2 * Second));
@@ -51,7 +52,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void Tick_ClampsToDuration()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(299_000, 300_000)), PlaybackState.Playing, T0);
 
         var position = tracker.Tick(T0 + (5 * Second));
@@ -63,7 +64,7 @@ public class TrackProgressTrackerTests
     public void Tick_WithoutDuration_DoesNotAdvance()
     {
         // Preserved behavior: duration-less streams show a static server position.
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 0)), PlaybackState.Playing, T0);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
@@ -76,7 +77,7 @@ public class TrackProgressTrackerTests
     {
         // The SDK's Optional merge carries the same PlaybackProgress instance forward
         // when a message omits the progress field.
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         var progress = Progress(120_000, 300_000);
         tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0);
         tracker.Tick(T0 + (2 * Second)); // interpolated to 122
@@ -94,7 +95,7 @@ public class TrackProgressTrackerTests
     {
         // The reported bug: track changes but the merged metadata still carries the OLD
         // track's progress instance (server sent no progress field for the new track).
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         var stale = Progress(120_000, 300_000);
         tracker.ApplyMetadata(Track("A", stale), PlaybackState.Playing, T0);
 
@@ -108,7 +109,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void TrackChange_WithFreshProgress_AdoptsNewTrackPosition()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ApplyMetadata(Track("B", Progress(0, 200_000)), PlaybackState.Playing, T0 + Second);
@@ -122,7 +123,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void TrackChange_WithNullProgress_ResetsToZero()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ApplyMetadata(Track("B", progress: null), PlaybackState.Playing, T0 + Second);
@@ -136,7 +137,7 @@ public class TrackProgressTrackerTests
     public void ExplicitNullProgress_SameTrack_ClearsPosition()
     {
         // Matches the CLI's update_metadata: explicit null clears progress AND duration.
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(295_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ApplyMetadata(Track("A", progress: null), PlaybackState.Playing, T0 + (5 * Second));
@@ -149,7 +150,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void NullMetadata_ClearsEverything()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ApplyMetadata(null, PlaybackState.Playing, T0 + Second);
@@ -162,7 +163,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void ResetForPendingTrackChange_ZeroesPositionAndStopsExtrapolation()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ResetForPendingTrackChange();
@@ -177,7 +178,7 @@ public class TrackProgressTrackerTests
     {
         // After the optimistic reset, a group/update echoing the pre-change merged state
         // (same identity, same stale progress instance) must not resurrect the old anchor.
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         var progress = Progress(120_000, 300_000);
         tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0);
 
@@ -193,7 +194,7 @@ public class TrackProgressTrackerTests
     {
         // "Previous" can legitimately restart the SAME track at 0 — identity unchanged,
         // so only fresh progress can re-anchor after the optimistic reset.
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ResetForPendingTrackChange();
@@ -207,7 +208,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void Freeze_StopsExtrapolation_KeepsLastPosition()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
         tracker.Tick(T0 + (2 * Second));
 
@@ -220,7 +221,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void PlaybackSpeed_ScalesExtrapolation()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 500)), PlaybackState.Playing, T0);
 
         var position = tracker.Tick(T0 + (2 * Second));
@@ -231,7 +232,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void PlaybackSpeedZero_FreezesAtServerPosition()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 0)), PlaybackState.Playing, T0);
 
         var position = tracker.Tick(T0 + (30 * Second));
@@ -244,7 +245,7 @@ public class TrackProgressTrackerTests
     {
         // A pause update often carries fresh progress WITHOUT playback_speed. The paused
         // state must override the speed default (1.0): the bar stays at the paused position.
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Paused, T0 + Second);
@@ -259,7 +260,7 @@ public class TrackProgressTrackerTests
     {
         // Resume often arrives with the carried-forward progress instance only. The bar
         // must stay at the paused position instead of jumping by the pause duration.
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
         var pausedProgress = Progress(120_000, 300_000);
         tracker.ApplyMetadata(Track("A", pausedProgress), PlaybackState.Paused, T0 + Second);
@@ -274,7 +275,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void ResumeWithFreshProgress_Reanchors()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Paused, T0 + Second);
 
@@ -290,7 +291,7 @@ public class TrackProgressTrackerTests
     {
         // Even when the paused progress carries an explicit playback_speed of 1000, the
         // not-playing state wins: anchoring uses effective speed 0.
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 1000)), PlaybackState.Paused, T0);
 
@@ -302,7 +303,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void Freeze_ThenFreshProgress_ResumesExtrapolation()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
         tracker.Tick(T0 + (2 * Second)); // 122
 
@@ -320,7 +321,7 @@ public class TrackProgressTrackerTests
         // Progress was measured 200 ms (server time) before we received it; the displayed
         // position starts 200 ms ahead of track_progress (network-delay compensation).
         var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true };
-        var tracker = new TrackProgressTracker(sync);
+        var tracker = CreateTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - 200_000);
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
@@ -334,7 +335,7 @@ public class TrackProgressTrackerTests
     public void UnconvergedClock_FallsBackToReceiptAnchor()
     {
         var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = false };
-        var tracker = new TrackProgressTracker(sync);
+        var tracker = CreateTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - 200_000);
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
@@ -348,7 +349,7 @@ public class TrackProgressTrackerTests
         // The SDK merges metadata fields independently, so fresh progress can arrive next
         // to a stale carried-forward timestamp. Distrust anything older than a few seconds.
         var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true };
-        var tracker = new TrackProgressTracker(sync);
+        var tracker = CreateTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - (10 * Second));
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
@@ -362,7 +363,7 @@ public class TrackProgressTrackerTests
     public void FutureTimestamp_FallsBackToReceiptAnchor()
     {
         var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true };
-        var tracker = new TrackProgressTracker(sync);
+        var tracker = CreateTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 + (3 * Second));
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
@@ -375,7 +376,7 @@ public class TrackProgressTrackerTests
     [Fact]
     public void FreshProgressWithoutTrackProgress_UpdatesDurationOnly()
     {
-        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
         tracker.Tick(T0 + (2 * Second)); // 122
 
@@ -386,6 +387,9 @@ public class TrackProgressTrackerTests
         var position = tracker.Tick(T0 + (4 * Second));
         Assert.Equal(124.0, position!.Value, 3); // anchor undisturbed
     }
+
+    private static TrackProgressTracker CreateTracker(IClockSynchronizer? clockSynchronizer = null) =>
+        new TrackProgressTracker(clockSynchronizer, NullLogger<TrackProgressTracker>.Instance);
 
     private static TrackMetadata Track(string title, PlaybackProgress? progress, long? timestamp = null) => new TrackMetadata
     {

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -82,7 +82,8 @@ public class TrackProgressTrackerTests
         tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0);
         tracker.Tick(T0 + (2 * Second)); // interpolated to 122
 
-        // A group/update re-emits the merged state: same identity, same progress instance.
+        // A group-state event re-emits the merged state: same identity, same progress
+        // instance (metadata travels in server/state; group/update carries none).
         tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0 + (2 * Second));
 
         Assert.Equal(122.0, tracker.PositionSeconds, 3);
@@ -176,8 +177,9 @@ public class TrackProgressTrackerTests
     [Fact]
     public void ResetForPendingTrackChange_CarriedProgressEcho_StaysAtZero()
     {
-        // After the optimistic reset, a group/update echoing the pre-change merged state
-        // (same identity, same stale progress instance) must not resurrect the old anchor.
+        // After the optimistic reset, a group-state event echoing the pre-change merged
+        // state (same identity, same stale progress instance) must not resurrect the
+        // old anchor.
         var tracker = CreateTracker();
         var progress = Progress(120_000, 300_000);
         tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0);

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -30,7 +30,7 @@ public class TrackProgressTrackerTests
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
 
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
         Assert.Equal(300.0, tracker.DurationSeconds, 3);
@@ -40,7 +40,7 @@ public class TrackProgressTrackerTests
     public void Tick_AdvancesWithElapsedTime()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         var position = tracker.Tick(T0 + (2 * Second));
 
@@ -52,7 +52,7 @@ public class TrackProgressTrackerTests
     public void Tick_ClampsToDuration()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(299_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(299_000, 300_000)), PlaybackState.Playing, T0);
 
         var position = tracker.Tick(T0 + (5 * Second));
 
@@ -64,7 +64,7 @@ public class TrackProgressTrackerTests
     {
         // Preserved behavior: duration-less streams show a static server position.
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 0)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 0)), PlaybackState.Playing, T0);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
         Assert.Null(tracker.Tick(T0 + (2 * Second)));
@@ -78,11 +78,11 @@ public class TrackProgressTrackerTests
         // when a message omits the progress field.
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
         var progress = Progress(120_000, 300_000);
-        tracker.ApplyMetadata(Track("A", progress), T0);
+        tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0);
         tracker.Tick(T0 + (2 * Second)); // interpolated to 122
 
         // A group/update re-emits the merged state: same identity, same progress instance.
-        tracker.ApplyMetadata(Track("A", progress), T0 + (2 * Second));
+        tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0 + (2 * Second));
 
         Assert.Equal(122.0, tracker.PositionSeconds, 3);
         var position = tracker.Tick(T0 + (4 * Second));
@@ -96,9 +96,9 @@ public class TrackProgressTrackerTests
         // track's progress instance (server sent no progress field for the new track).
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
         var stale = Progress(120_000, 300_000);
-        tracker.ApplyMetadata(Track("A", stale), T0);
+        tracker.ApplyMetadata(Track("A", stale), PlaybackState.Playing, T0);
 
-        tracker.ApplyMetadata(Track("B", stale), T0 + Second);
+        tracker.ApplyMetadata(Track("B", stale), PlaybackState.Playing, T0 + Second);
 
         Assert.Equal(0.0, tracker.PositionSeconds);
         Assert.Equal(0.0, tracker.DurationSeconds);
@@ -109,9 +109,9 @@ public class TrackProgressTrackerTests
     public void TrackChange_WithFreshProgress_AdoptsNewTrackPosition()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
-        tracker.ApplyMetadata(Track("B", Progress(0, 200_000)), T0 + Second);
+        tracker.ApplyMetadata(Track("B", Progress(0, 200_000)), PlaybackState.Playing, T0 + Second);
 
         Assert.Equal(0.0, tracker.PositionSeconds, 3);
         Assert.Equal(200.0, tracker.DurationSeconds, 3);
@@ -123,9 +123,9 @@ public class TrackProgressTrackerTests
     public void TrackChange_WithNullProgress_ResetsToZero()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
-        tracker.ApplyMetadata(Track("B", progress: null), T0 + Second);
+        tracker.ApplyMetadata(Track("B", progress: null), PlaybackState.Playing, T0 + Second);
 
         Assert.Equal(0.0, tracker.PositionSeconds);
         Assert.Equal(0.0, tracker.DurationSeconds);
@@ -137,9 +137,9 @@ public class TrackProgressTrackerTests
     {
         // Matches the CLI's update_metadata: explicit null clears progress AND duration.
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(295_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(295_000, 300_000)), PlaybackState.Playing, T0);
 
-        tracker.ApplyMetadata(Track("A", progress: null), T0 + (5 * Second));
+        tracker.ApplyMetadata(Track("A", progress: null), PlaybackState.Playing, T0 + (5 * Second));
 
         Assert.Equal(0.0, tracker.PositionSeconds);
         Assert.Equal(0.0, tracker.DurationSeconds);
@@ -150,9 +150,9 @@ public class TrackProgressTrackerTests
     public void NullMetadata_ClearsEverything()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
-        tracker.ApplyMetadata(null, T0 + Second);
+        tracker.ApplyMetadata(null, PlaybackState.Playing, T0 + Second);
 
         Assert.Equal(0.0, tracker.PositionSeconds);
         Assert.Equal(0.0, tracker.DurationSeconds);
@@ -163,7 +163,7 @@ public class TrackProgressTrackerTests
     public void ResetForPendingTrackChange_ZeroesPositionAndStopsExtrapolation()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ResetForPendingTrackChange();
 
@@ -179,10 +179,10 @@ public class TrackProgressTrackerTests
         // (same identity, same stale progress instance) must not resurrect the old anchor.
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
         var progress = Progress(120_000, 300_000);
-        tracker.ApplyMetadata(Track("A", progress), T0);
+        tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0);
 
         tracker.ResetForPendingTrackChange();
-        tracker.ApplyMetadata(Track("A", progress), T0 + Second);
+        tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0 + Second);
 
         Assert.Equal(0.0, tracker.PositionSeconds);
         Assert.Null(tracker.Tick(T0 + (2 * Second)));
@@ -194,10 +194,10 @@ public class TrackProgressTrackerTests
         // "Previous" can legitimately restart the SAME track at 0 — identity unchanged,
         // so only fresh progress can re-anchor after the optimistic reset.
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
         tracker.ResetForPendingTrackChange();
-        tracker.ApplyMetadata(Track("A", Progress(500, 300_000)), T0 + Second);
+        tracker.ApplyMetadata(Track("A", Progress(500, 300_000)), PlaybackState.Playing, T0 + Second);
 
         Assert.Equal(0.5, tracker.PositionSeconds, 3);
         var position = tracker.Tick(T0 + (2 * Second));
@@ -208,7 +208,7 @@ public class TrackProgressTrackerTests
     public void Freeze_StopsExtrapolation_KeepsLastPosition()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
         tracker.Tick(T0 + (2 * Second));
 
         tracker.Freeze();
@@ -221,7 +221,7 @@ public class TrackProgressTrackerTests
     public void PlaybackSpeed_ScalesExtrapolation()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 500)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 500)), PlaybackState.Playing, T0);
 
         var position = tracker.Tick(T0 + (2 * Second));
 
@@ -232,11 +232,86 @@ public class TrackProgressTrackerTests
     public void PlaybackSpeedZero_FreezesAtServerPosition()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 0)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 0)), PlaybackState.Playing, T0);
 
         var position = tracker.Tick(T0 + (30 * Second));
 
         Assert.Equal(120.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void PauseWithFreshProgress_OmittingSpeed_StaysFrozen()
+    {
+        // A pause update often carries fresh progress WITHOUT playback_speed. The paused
+        // state must override the speed default (1.0): the bar stays at the paused position.
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Paused, T0 + Second);
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (60 * Second));
+        Assert.Equal(120.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void ResumeWithoutFreshProgress_StaysAtPausedPosition()
+    {
+        // Resume often arrives with the carried-forward progress instance only. The bar
+        // must stay at the paused position instead of jumping by the pause duration.
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+        var pausedProgress = Progress(120_000, 300_000);
+        tracker.ApplyMetadata(Track("A", pausedProgress), PlaybackState.Paused, T0 + Second);
+
+        tracker.ApplyMetadata(Track("A", pausedProgress), PlaybackState.Playing, T0 + (30 * Second));
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (32 * Second));
+        Assert.Equal(120.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void ResumeWithFreshProgress_Reanchors()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Paused, T0 + Second);
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0 + (30 * Second));
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (32 * Second));
+        Assert.Equal(122.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void PauseWithFreshProgress_ExplicitNormalSpeed_StaysFrozen()
+    {
+        // Even when the paused progress carries an explicit playback_speed of 1000, the
+        // not-playing state wins: anchoring uses effective speed 0.
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 1000)), PlaybackState.Paused, T0);
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (30 * Second));
+        Assert.Equal(120.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void Freeze_ThenFreshProgress_ResumesExtrapolation()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+        tracker.Tick(T0 + (2 * Second)); // 122
+
+        tracker.Freeze();
+        tracker.ApplyMetadata(Track("A", Progress(130_000, 300_000)), PlaybackState.Playing, T0 + (5 * Second));
+
+        Assert.Equal(130.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (7 * Second));
+        Assert.Equal(132.0, position!.Value, 3);
     }
 
     [Fact]
@@ -248,7 +323,7 @@ public class TrackProgressTrackerTests
         var tracker = new TrackProgressTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - 200_000);
 
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
 
         Assert.Equal(120.2, tracker.PositionSeconds, 3);
         var position = tracker.Tick(T0 + (2 * Second));
@@ -262,7 +337,7 @@ public class TrackProgressTrackerTests
         var tracker = new TrackProgressTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - 200_000);
 
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
     }
@@ -276,7 +351,7 @@ public class TrackProgressTrackerTests
         var tracker = new TrackProgressTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - (10 * Second));
 
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
         var position = tracker.Tick(T0 + (2 * Second));
@@ -290,7 +365,7 @@ public class TrackProgressTrackerTests
         var tracker = new TrackProgressTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 + (3 * Second));
 
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
         var position = tracker.Tick(T0 + (2 * Second));
@@ -301,10 +376,10 @@ public class TrackProgressTrackerTests
     public void FreshProgressWithoutTrackProgress_UpdatesDurationOnly()
     {
         var tracker = new TrackProgressTracker(clockSynchronizer: null);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
         tracker.Tick(T0 + (2 * Second)); // 122
 
-        tracker.ApplyMetadata(Track("A", Progress(null, 310_000)), T0 + (2 * Second));
+        tracker.ApplyMetadata(Track("A", Progress(null, 310_000)), PlaybackState.Playing, T0 + (2 * Second));
 
         Assert.Equal(310.0, tracker.DurationSeconds, 3);
         Assert.Equal(122.0, tracker.PositionSeconds, 3);

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -1,0 +1,358 @@
+// <copyright file="TrackProgressTrackerTests.cs" company="Sendspin Windows Client">
+// Licensed under the MIT License. See LICENSE file in the project root.
+// </copyright>
+
+using Sendspin.SDK.Models;
+using Sendspin.SDK.Protocol.Messages;
+using Sendspin.SDK.Synchronization;
+using Sendspin.Windows.Services.Playback;
+using Xunit;
+
+namespace Sendspin.Windows.Services.Tests.Playback;
+
+public class TrackProgressTrackerTests
+{
+    private const long T0 = 5_000_000_000_000L; // arbitrary client time (microseconds)
+    private const long Second = 1_000_000L;
+
+    [Fact]
+    public void NoMetadataYet_DefaultsToZero()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Null(tracker.Tick(T0));
+    }
+
+    [Fact]
+    public void FreshProgress_AdoptsPositionAndDuration()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        Assert.Equal(300.0, tracker.DurationSeconds, 3);
+    }
+
+    [Fact]
+    public void Tick_AdvancesWithElapsedTime()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+
+        var position = tracker.Tick(T0 + (2 * Second));
+
+        Assert.Equal(122.0, position!.Value, 3);
+        Assert.Equal(122.0, tracker.PositionSeconds, 3);
+    }
+
+    [Fact]
+    public void Tick_ClampsToDuration()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(299_000, 300_000)), T0);
+
+        var position = tracker.Tick(T0 + (5 * Second));
+
+        Assert.Equal(300.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void Tick_WithoutDuration_DoesNotAdvance()
+    {
+        // Preserved behavior: duration-less streams show a static server position.
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 0)), T0);
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        Assert.Null(tracker.Tick(T0 + (2 * Second)));
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+    }
+
+    [Fact]
+    public void SameTrack_CarriedProgress_DoesNotRewindPosition()
+    {
+        // The SDK's Optional merge carries the same PlaybackProgress instance forward
+        // when a message omits the progress field.
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var progress = Progress(120_000, 300_000);
+        tracker.ApplyMetadata(Track("A", progress), T0);
+        tracker.Tick(T0 + (2 * Second)); // interpolated to 122
+
+        // A group/update re-emits the merged state: same identity, same progress instance.
+        tracker.ApplyMetadata(Track("A", progress), T0 + (2 * Second));
+
+        Assert.Equal(122.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (4 * Second));
+        Assert.Equal(124.0, position!.Value, 3); // anchor undisturbed
+    }
+
+    [Fact]
+    public void TrackChange_WithCarriedStaleProgress_ResetsToZero()
+    {
+        // The reported bug: track changes but the merged metadata still carries the OLD
+        // track's progress instance (server sent no progress field for the new track).
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var stale = Progress(120_000, 300_000);
+        tracker.ApplyMetadata(Track("A", stale), T0);
+
+        tracker.ApplyMetadata(Track("B", stale), T0 + Second);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Null(tracker.Tick(T0 + (10 * Second))); // frozen until fresh progress
+    }
+
+    [Fact]
+    public void TrackChange_WithFreshProgress_AdoptsNewTrackPosition()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+
+        tracker.ApplyMetadata(Track("B", Progress(0, 200_000)), T0 + Second);
+
+        Assert.Equal(0.0, tracker.PositionSeconds, 3);
+        Assert.Equal(200.0, tracker.DurationSeconds, 3);
+        var position = tracker.Tick(T0 + (3 * Second));
+        Assert.Equal(2.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void TrackChange_WithNullProgress_ResetsToZero()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+
+        tracker.ApplyMetadata(Track("B", progress: null), T0 + Second);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Null(tracker.Tick(T0 + (10 * Second)));
+    }
+
+    [Fact]
+    public void ExplicitNullProgress_SameTrack_ClearsPosition()
+    {
+        // Matches the CLI's update_metadata: explicit null clears progress AND duration.
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(295_000, 300_000)), T0);
+
+        tracker.ApplyMetadata(Track("A", progress: null), T0 + (5 * Second));
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Null(tracker.Tick(T0 + (10 * Second)));
+    }
+
+    [Fact]
+    public void NullMetadata_ClearsEverything()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+
+        tracker.ApplyMetadata(null, T0 + Second);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Null(tracker.Tick(T0 + (2 * Second)));
+    }
+
+    [Fact]
+    public void ResetForPendingTrackChange_ZeroesPositionAndStopsExtrapolation()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+
+        tracker.ResetForPendingTrackChange();
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Null(tracker.Tick(T0 + (2 * Second)));
+        Assert.Equal(300.0, tracker.DurationSeconds, 3); // duration label persists until new data
+    }
+
+    [Fact]
+    public void ResetForPendingTrackChange_CarriedProgressEcho_StaysAtZero()
+    {
+        // After the optimistic reset, a group/update echoing the pre-change merged state
+        // (same identity, same stale progress instance) must not resurrect the old anchor.
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        var progress = Progress(120_000, 300_000);
+        tracker.ApplyMetadata(Track("A", progress), T0);
+
+        tracker.ResetForPendingTrackChange();
+        tracker.ApplyMetadata(Track("A", progress), T0 + Second);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Null(tracker.Tick(T0 + (2 * Second)));
+    }
+
+    [Fact]
+    public void ResetForPendingTrackChange_FreshProgressReanchors()
+    {
+        // "Previous" can legitimately restart the SAME track at 0 — identity unchanged,
+        // so only fresh progress can re-anchor after the optimistic reset.
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+
+        tracker.ResetForPendingTrackChange();
+        tracker.ApplyMetadata(Track("A", Progress(500, 300_000)), T0 + Second);
+
+        Assert.Equal(0.5, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (2 * Second));
+        Assert.Equal(1.5, position!.Value, 3);
+    }
+
+    [Fact]
+    public void Freeze_StopsExtrapolation_KeepsLastPosition()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.Tick(T0 + (2 * Second));
+
+        tracker.Freeze();
+
+        Assert.Null(tracker.Tick(T0 + (60 * Second)));
+        Assert.Equal(122.0, tracker.PositionSeconds, 3); // no jump on later resume
+    }
+
+    [Fact]
+    public void PlaybackSpeed_ScalesExtrapolation()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 500)), T0);
+
+        var position = tracker.Tick(T0 + (2 * Second));
+
+        Assert.Equal(121.0, position!.Value, 3); // 2 s wall x 0.5
+    }
+
+    [Fact]
+    public void PlaybackSpeedZero_FreezesAtServerPosition()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 0)), T0);
+
+        var position = tracker.Tick(T0 + (30 * Second));
+
+        Assert.Equal(120.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void ConvergedClock_AnchorsAtServerTimestamp()
+    {
+        // Progress was measured 200 ms (server time) before we received it; the displayed
+        // position starts 200 ms ahead of track_progress (network-delay compensation).
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true };
+        var tracker = new TrackProgressTracker(sync);
+        var measuredAt = sync.ClientToServerTime(T0 - 200_000);
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), T0);
+
+        Assert.Equal(120.2, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (2 * Second));
+        Assert.Equal(122.2, position!.Value, 3);
+    }
+
+    [Fact]
+    public void UnconvergedClock_FallsBackToReceiptAnchor()
+    {
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = false };
+        var tracker = new TrackProgressTracker(sync);
+        var measuredAt = sync.ClientToServerTime(T0 - 200_000);
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), T0);
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+    }
+
+    [Fact]
+    public void ImplausiblyOldTimestamp_FallsBackToReceiptAnchor()
+    {
+        // The SDK merges metadata fields independently, so fresh progress can arrive next
+        // to a stale carried-forward timestamp. Distrust anything older than a few seconds.
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true };
+        var tracker = new TrackProgressTracker(sync);
+        var measuredAt = sync.ClientToServerTime(T0 - (10 * Second));
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), T0);
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (2 * Second));
+        Assert.Equal(122.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void FutureTimestamp_FallsBackToReceiptAnchor()
+    {
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true };
+        var tracker = new TrackProgressTracker(sync);
+        var measuredAt = sync.ClientToServerTime(T0 + (3 * Second));
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), T0);
+
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (2 * Second));
+        Assert.Equal(122.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void FreshProgressWithoutTrackProgress_UpdatesDurationOnly()
+    {
+        var tracker = new TrackProgressTracker(clockSynchronizer: null);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), T0);
+        tracker.Tick(T0 + (2 * Second)); // 122
+
+        tracker.ApplyMetadata(Track("A", Progress(null, 310_000)), T0 + (2 * Second));
+
+        Assert.Equal(310.0, tracker.DurationSeconds, 3);
+        Assert.Equal(122.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (4 * Second));
+        Assert.Equal(124.0, position!.Value, 3); // anchor undisturbed
+    }
+
+    private static TrackMetadata Track(string title, PlaybackProgress? progress, long? timestamp = null) => new TrackMetadata
+    {
+        Title = title,
+        Artist = "Artist",
+        Album = "Album",
+        Progress = progress,
+        Timestamp = timestamp,
+    };
+
+    private static PlaybackProgress Progress(double? progressMs, double? durationMs, double? speed = null) => new PlaybackProgress
+    {
+        TrackProgress = progressMs,
+        TrackDuration = durationMs,
+        PlaybackSpeed = speed,
+    };
+
+    /// <summary>
+    /// Minimal clock synchronizer with a fixed offset: server = client + offset.
+    /// </summary>
+    private sealed class FakeClockSynchronizer : IClockSynchronizer
+    {
+        public long OffsetMicroseconds { get; set; }
+
+        public bool IsConverged { get; set; }
+
+        public bool HasMinimalSync => IsConverged;
+
+        public double StaticDelayMs { get; set; }
+
+        public long ClientToServerTime(long clientTime) => clientTime + OffsetMicroseconds;
+
+        public long ServerToClientTime(long serverTime) => serverTime - OffsetMicroseconds;
+
+        public void ProcessMeasurement(long t1, long t2, long t3, long t4)
+        {
+        }
+
+        public void Reset()
+        {
+        }
+
+        public ClockSyncStatus GetStatus() => new ClockSyncStatus();
+    }
+}

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -388,6 +388,51 @@ public class TrackProgressTrackerTests
         Assert.Equal(124.0, position!.Value, 3); // anchor undisturbed
     }
 
+    [Fact]
+    public void FreshProgress_NullDuration_KeepsPreviousDuration()
+    {
+        // Duration tri-state: the SDK models unknown duration as null, so fresh progress
+        // with TrackDuration = null keeps the previously known duration.
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+
+        tracker.ApplyMetadata(Track("A", Progress(130_000, durationMs: null)), PlaybackState.Playing, T0 + Second);
+
+        Assert.Equal(300.0, tracker.DurationSeconds, 3);
+        Assert.Equal(130.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (3 * Second));
+        Assert.Equal(132.0, position!.Value, 3); // re-anchored and still advancing
+    }
+
+    [Fact]
+    public void FreshProgress_ZeroDuration_SetsDurationToZero()
+    {
+        // Unlike null (unknown), an explicit 0 is a value and must be adopted.
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+
+        tracker.ApplyMetadata(Track("A", Progress(130_000, 0)), PlaybackState.Playing, T0 + Second);
+
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Equal(130.0, tracker.PositionSeconds, 3);
+        Assert.Null(tracker.Tick(T0 + (3 * Second))); // no extrapolation without a duration
+    }
+
+    [Fact]
+    public void NullDurationFromTrackStart_ShowsStaticPosition()
+    {
+        // Radio case: the track never reports a duration. Same static display as an
+        // explicit 0 duration — position shows the server value and does not advance.
+        var tracker = CreateTracker();
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, durationMs: null)), PlaybackState.Playing, T0);
+
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        Assert.Null(tracker.Tick(T0 + (2 * Second)));
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+    }
+
     private static TrackProgressTracker CreateTracker(IClockSynchronizer? clockSynchronizer = null) =>
         new TrackProgressTracker(clockSynchronizer, NullLogger<TrackProgressTracker>.Instance);
 


### PR DESCRIPTION
## Summary

Fixes the seek bar not resetting when clicking previous/next. Three root causes in the ViewModel's progress handling, plus an SDK-interaction subtlety found along the way:

- **No local reset on track change** — new-track metadata never zeroed position/duration, so the bar kept extrapolating against the old track's duration and crept toward the end.
- **Handler drift** — the client-initiated (primary) path never got the `Optional<Progress>` tri-state handling the host path had.
- **Explicit-null progress** (track ended) left the stale position on the bar.
- **Carried-forward progress** — the SDK 9.1.0 state merge reuses the same `PlaybackProgress` instance when a group update omits progress, so a track change without fresh progress arrived as *new identity + stale progress* and the old code actively re-anchored to it; same-track updates also visibly rewound the bar on every group update.

## Changes

- New `TrackProgressTracker` (`Sendspin.Windows.Services/Playback/`) owns all position/anchor logic; both connection-mode handlers in `MainViewModel` now share it, eliminating the drift.
- Track-identity changes reset the bar; carried-forward progress is recognized by object reference and never re-anchors.
- Explicit-null progress zeroes position and duration (matches the Python CLI's `update_metadata` semantics).
- Optimistic reset to 0:00 on previous/next click, with extrapolation frozen until fresh server progress arrives — covers the server restarting the *same* track at 0:00.
- Spec-accurate extrapolation: fresh progress anchors at the Kalman-converted server timestamp, elapsed scales by `playback_speed` (0 = paused/frozen), clamped to the track; falls back to receipt-time anchoring when sync isn't converged or a timestamp is implausible. App-only — no SDK changes.
- Design note: `docs/superpowers/specs/2026-07-17-seek-bar-reset-design.md`.

## Testing

- 22 new unit tests (`TrackProgressTrackerTests`) covering the behavior matrix — same-track update, track change with/without progress, explicit-null, previous/next reset, pause, clamping. All pass.
- Full suite: 119/121. The 2 failures (`MultiRoomSyncAlignmentTests.StartupPrefill_Uncompensated_DriftsOffSchedule`, `DynamicResamplerSampleProviderTests.RateCorrection_ConcealsShortfalls_WithoutSilenceGaps`) fail identically on untouched master — pre-existing and unrelated (resampler area).
- Release build clean: 0 errors, warning count unchanged from master.

## Manual test plan

1. ~2 min into a track, click Previous to a different track → bar snaps to 0:00 immediately, no creep, then tracks server progress.
2. Past ~30 s, click Previous once (same-track restart) → bar snaps to 0:00 even though the title never changed.
3. Play ~2 min untouched → smooth advance, no jumps on artwork/metadata refreshes; pause ~30 s and resume → no forward leap.