### PR TITLE
fix: seek bar follow-ups from the PR #59 review

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -113,7 +113,7 @@ Offset:       can be billions of microseconds - THIS IS NORMAL
 ```
 
 The `IClockSynchronizer` interface provides:
-- `ServerToLocalTime(serverTimestamp)` - Convert server time to local playback time
+- `ServerToClientTime(serverTimestamp)` - Convert server time to local playback time (subtracts the configured static delay — audio scheduling semantics)
 - `GetStatus()` - Current offset, drift rate, and convergence status
 
 **Kalman Configuration** (via appsettings.json):
@@ -267,7 +267,8 @@ server/time         - Clock sync response with 4 timestamps
 stream/start        - New audio stream beginning
 stream/end          - Audio stream ended
 stream/clear        - Clear buffer (track change)
-group/update        - Playback state change (play/pause/stop, metadata)
+group/update        - Group playback state and identity (playback state, group id/name)
+server/state        - Delta-merged server state (metadata/progress, volume, mute)
 client/command      - Client sends command (play, pause, volume, etc.)
 ```
 
@@ -637,7 +638,7 @@ SDK classes (in NuGet package — source at [sendspin-dotnet](https://github.com
 - `TimedAudioBuffer` — Sync-aware sample buffer
 - `KalmanClockSynchronizer` — Clock sync algorithm
 - `HighPrecisionTimer` — Microsecond-precision timing
-- `SendSpinHostService` / `SendSpinClient` — Connection modes
+- `SendspinHostService` / `SendspinClientService` — Connection modes (declared in `SendSpinHostService.cs` / `SendSpinClient.cs`)
 - `SyncCorrectionOptions` — Configurable sync correction parameters
 - `Optional<T>` — JSON absent vs null distinction
 

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -58,7 +58,7 @@ public sealed class TrackProgressTracker
     private readonly IClockSynchronizer? _clockSynchronizer;
     private readonly ILogger<TrackProgressTracker> _logger;
 
-    private string? _trackIdentity;
+    private (string? Title, string? Artist, string? Album)? _trackIdentity;
     private PlaybackProgress? _lastProgress;
     private Anchor? _anchor;
 
@@ -104,9 +104,10 @@ public sealed class TrackProgressTracker
             return;
         }
 
-        // Same identity convention as the track-change notification logic: TrackMetadata
-        // has no track id/URI, so title+artist+album is the best available identity.
-        var identity = $"{metadata.Title}|{metadata.Artist}|{metadata.Album}";
+        // Same identity fields as the track-change notification logic: TrackMetadata has
+        // no track id/URI, so title+artist+album is the best available identity. A tuple
+        // avoids the delimiter collisions a joined string would have.
+        var identity = (metadata.Title, metadata.Artist, metadata.Album);
         var identityChanged = identity != _trackIdentity;
         var previousIdentity = _trackIdentity;
         _trackIdentity = identity;
@@ -120,8 +121,17 @@ public sealed class TrackProgressTracker
             // New track: never trust position state that belonged to the previous track.
             _logger.LogDebug(
                 "Track identity changed ({PreviousIdentity} -> {Identity}); resetting seek bar position",
-                previousIdentity ?? "(none)",
-                identity);
+                previousIdentity?.ToString() ?? "(none)",
+                identity.ToString());
+            if (string.IsNullOrEmpty(metadata.Title)
+                && string.IsNullOrEmpty(metadata.Artist)
+                && string.IsNullOrEmpty(metadata.Album))
+            {
+                // Untagged content collapses to one identity, so consecutive such tracks
+                // cannot trigger this reset; only fresh progress re-anchors them.
+                _logger.LogDebug("New track has no title/artist/album; identity-based resets cannot distinguish consecutive untagged tracks");
+            }
+
             ResetPosition();
         }
 
@@ -241,7 +251,13 @@ public sealed class TrackProgressTracker
             return nowMicroseconds;
         }
 
-        var converted = _clockSynchronizer.ServerToClientTime(serverTimestampMicroseconds.Value);
+        // ServerToClientTime targets audio scheduling and subtracts the configured static
+        // delay (hardware compensation); add it back so the display anchor reflects the
+        // measurement time. Without this, a positive delay runs the bar ahead by the delay
+        // and a negative delay pushes every conversion into the future, permanently
+        // tripping the plausibility guard below.
+        var converted = _clockSynchronizer.ServerToClientTime(serverTimestampMicroseconds.Value)
+            + (long)(_clockSynchronizer.StaticDelayMs * 1000);
         var age = nowMicroseconds - converted;
         if (age < 0 || age > MaxAnchorAgeMicroseconds)
         {

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -435,14 +435,93 @@ public class TrackProgressTrackerTests
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
     }
 
+    [Fact]
+    public void StaticDelay_DoesNotShiftDisplayAnchor()
+    {
+        // ServerToClientTime targets audio scheduling and subtracts the configured static
+        // delay; the display anchor adds it back so the seek bar reflects measurement time.
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true, StaticDelayMs = 400 };
+        var tracker = CreateTracker(sync);
+        var measuredAt = sync.ClientToServerTime(T0 - 200_000);
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
+
+        Assert.Equal(120.2, tracker.PositionSeconds, 3); // identical to the zero-delay case
+    }
+
+    [Fact]
+    public void NegativeStaticDelay_StillUsesServerAnchor()
+    {
+        // A negative delay used to push every converted anchor into the future, tripping
+        // the plausibility guard so the spec-anchor path silently never engaged.
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true, StaticDelayMs = -400 };
+        var tracker = CreateTracker(sync);
+        var measuredAt = sync.ClientToServerTime(T0 - 200_000);
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
+
+        Assert.Equal(120.2, tracker.PositionSeconds, 3);
+    }
+
+    [Fact]
+    public void IdentityCollision_DelimiterAmbiguity_TreatedAsDifferentTracks()
+    {
+        // "A|B" + "C" and "A" + "B|C" collided under a joined-string identity; the tuple
+        // identity must treat them as different tracks and reset the stale position.
+        var tracker = CreateTracker();
+        var stale = Progress(120_000, 300_000);
+        tracker.ApplyMetadata(Track("A|B", stale, artist: "C"), PlaybackState.Playing, T0);
+
+        tracker.ApplyMetadata(Track("A", stale, artist: "B|C"), PlaybackState.Playing, T0 + Second);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Null(tracker.Tick(T0 + (2 * Second)));
+    }
+
+    [Fact]
+    public void AnchorAge_ExactlyAtBoundary_UsesServerAnchor()
+    {
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true };
+        var tracker = CreateTracker(sync);
+        var measuredAt = sync.ClientToServerTime(T0 - (5 * Second));
+
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000), timestamp: measuredAt), PlaybackState.Playing, T0);
+
+        Assert.Equal(125.0, tracker.PositionSeconds, 3); // 5 s of network-delay compensation
+    }
+
+    [Fact]
+    public void NegativePlaybackSpeed_ClampsToZero()
+    {
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: -500)), PlaybackState.Playing, T0);
+
+        var position = tracker.Tick(T0 + (30 * Second));
+
+        Assert.Equal(120.0, position!.Value, 3); // the bar never runs backwards
+    }
+
+    [Fact]
+    public void NegativeProgressAndDuration_ClampToZero()
+    {
+        var tracker = CreateTracker();
+
+        tracker.ApplyMetadata(Track("A", Progress(-5_000, -10_000)), PlaybackState.Playing, T0);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Null(tracker.Tick(T0 + (2 * Second)));
+    }
+
     private static TrackProgressTracker CreateTracker(IClockSynchronizer? clockSynchronizer = null) =>
         new TrackProgressTracker(clockSynchronizer, NullLogger<TrackProgressTracker>.Instance);
 
-    private static TrackMetadata Track(string title, PlaybackProgress? progress, long? timestamp = null) => new TrackMetadata
+    private static TrackMetadata Track(string title, PlaybackProgress? progress, long? timestamp = null, string? artist = "Artist", string? album = "Album") => new TrackMetadata
     {
         Title = title,
-        Artist = "Artist",
-        Album = "Album",
+        Artist = artist,
+        Album = album,
         Progress = progress,
         Timestamp = timestamp,
     };
@@ -456,6 +535,10 @@ public class TrackProgressTrackerTests
 
     /// <summary>
     /// Minimal clock synchronizer with a fixed offset: server = client + offset.
+    /// Mirrors the real Kalman contract where <see cref="ServerToClientTime"/> also
+    /// subtracts the configured static delay (audio-scheduling compensation), while
+    /// <see cref="ClientToServerTime"/> is the pure domain shift used to fabricate
+    /// server-side measurement timestamps.
     /// </summary>
     private sealed class FakeClockSynchronizer : IClockSynchronizer
     {
@@ -469,7 +552,7 @@ public class TrackProgressTrackerTests
 
         public long ClientToServerTime(long clientTime) => clientTime + OffsetMicroseconds;
 
-        public long ServerToClientTime(long serverTime) => serverTime - OffsetMicroseconds;
+        public long ServerToClientTime(long serverTime) => serverTime - OffsetMicroseconds - (long)(StaticDelayMs * 1000);
 
         public void ProcessMeasurement(long t1, long t2, long t3, long t4)
         {


### PR DESCRIPTION
## Summary

Closes out the remaining suggestion-level findings from the PR #59 review.

- **Static-delay-free display anchor**: `IClockSynchronizer.ServerToClientTime` subtracts the configured static delay (audio-scheduling semantics). The seek bar anchor now adds it back so the displayed position reflects measurement time — a positive delay no longer runs the bar ahead, and a negative delay no longer pushes every conversion into the future, which permanently tripped the plausibility guard so the server-timestamp anchoring path silently never engaged.
- **Collision-proof track identity**: identity is now a `(title, artist, album)` tuple instead of a `|`-joined string, eliminating delimiter collisions; a Debug log flags degenerate (fully untagged) identities where identity-based resets cannot distinguish consecutive tracks.
- **Boundary pins (test-only)**: exact 5 s anchor-age boundary, negative `playback_speed` clamped to 0 (bar never runs backwards), negative progress/duration clamped to 0.
- **claude.md drift fixes** (pre-existing staleness): protocol table now describes `group/update` accurately and gains the missing `server/state` row; `ServerToLocalTime` → `ServerToClientTime`; `SendSpinHostService`/`SendSpinClient` → actual class names `SendspinHostService`/`SendspinClientService`.

## Testing

- TDD: the static-delay and identity-collision tests were written first and confirmed failing against the previous behavior (bar at 120.6 s instead of 120.2 s with a 400 ms delay; colliding identities skipping the reset).
- Tracker suite: 36/36 pass (30 existing + 6 new). Full suite: 133/135 — the 2 failures are the known pre-existing resampler-area ones, unchanged.
- Release rebuild: 0 errors, warning count exactly at the 553 baseline.