### PR TITLE
fix: un-freeze the seek bar after a stream restart or state round-trip

### DIFF
--- a/docs/superpowers/specs/2026-07-20-seek-bar-freeze-design.md
+++ b/docs/superpowers/specs/2026-07-20-seek-bar-freeze-design.md
@@ -1,0 +1,120 @@
+# Seek bar freeze — design note
+
+Follow-up to `2026-07-17-seek-bar-reset-design.md`. That work made the bar stop at the
+right moments; this one makes it start again.
+
+## Symptom
+
+The playback progress/seek bar stops advancing and never recovers for the rest of the
+track, even though audio keeps playing. Reconnecting or skipping to the next track clears
+it.
+
+## Root cause
+
+Four app-side pieces combined so that nothing could rebuild the extrapolation anchor:
+
+| Piece | Old behavior |
+|---|---|
+| `TrackProgressTracker.ApplyMetadata` | The group `playback_state` overrode the progress object's `playback_speed`: any non-`Playing` state anchored at effective speed 0. |
+| `TrackProgressTracker.Freeze()` | Nulls `_anchor`. |
+| `MainViewModel.OnPlaybackStateChanged` | Called `Freeze()` on every transition away from `Playing`, with no counterpart on the way back. |
+| `MainViewModel.OnPositionTimerTick` | Returned early unless `PlaybackState == Playing`. |
+
+Only *fresh* progress — a new `PlaybackProgress` instance, detected by `ReferenceEquals` —
+ever rebuilt the anchor. Two real paths produce a `Playing` transition with no fresh
+progress:
+
+1. **Stream restart.** The SDK synthesizes state transitions the server never sent:
+   `SendSpinClient` forces `PlaybackState.Playing` on `stream/start` and
+   `PlaybackState.Idle` on `stream/end` for servers that do not send `group/update`. A
+   format renegotiation, or a server that implements seek as end + start, produces Idle
+   then Playing, *both* carrying the same carried-forward `PlaybackProgress` instance.
+   `Freeze()` ran on Idle; the Playing event could not re-anchor. Bar dead.
+2. **Non-conformant resume.** A server that signals resume with a `group/update` carrying
+   only `playback_state` — `group/update` has no metadata and no progress.
+
+## Spec ground truth
+
+Validated against [Sendspin/spec](https://github.com/Sendspin/spec) @ `3632c68`.
+
+- **README:681** — `playback_state?`: `'playing' | 'stopped'`. There is **no** `'paused'`
+  state.
+- **README:1448** — `playback_speed`: "0 = paused". This is the protocol's *only* pause
+  signal.
+- **README:1446-1448** — inside the `progress` object, `track_progress`, `track_duration`
+  and `playback_speed` are all **required** (no `?`). A conformant server always sends
+  `playback_speed` whenever it sends progress.
+- **README:1445** — the server must send the `progress` object whenever playback state
+  changes (play, pause, resume, seek, playback speed change). There is **no** guarantee of
+  periodic progress messages, and note that track change is *not* in that list.
+
+The old state-override was therefore modelling a state (`paused`) the protocol does not
+have, using a signal (`playback_state`) that is not the pause signal.
+
+## Fix
+
+1. **Derive advance/freeze from `playback_speed` alone.** `ApplyMetadata` now anchors with
+   `Math.Max(0, (progress.PlaybackSpeed ?? 1000.0) / 1000.0)`, with no state override. Per
+   spec a conformant pause arrives as fresh progress with speed 0 while the group state
+   stays `playing`, so this alone still freezes a real pause. The `playbackState` parameter
+   is kept for a Debug-level diagnostic when the two disagree.
+2. **`Resume(long nowMicroseconds)` makes the anchor lifecycle self-healing.** When there
+   is no anchor, or a speed-0 anchor, it re-anchors at the **currently displayed position**
+   with `now` as the anchor instant and the last known non-zero speed factor (1.0 until the
+   server reports otherwise). Anchoring at `now` is what keeps the paused wall-clock
+   duration out of the position — the bar resumes from where it was rather than jumping
+   forward. This mirrors the SendspinDroid reference ("Re-anchor the interpolation
+   timestamp when transitioning to playing, so `getCurrentPosition()` doesn't include pause
+   duration"). It is a no-op while the position is already advancing (fresh progress owns
+   the anchor) and while no server-confirmed position exists (nothing to resume from,
+   including after `ResetForPendingTrackChange()`).
+3. **`Freeze()` is unchanged and still called on every transition to a non-playing state.**
+   Capturing the last position on a genuine stop was always correct; the bug was only that
+   nothing could un-freeze it.
+4. **`MainViewModel.OnPlaybackStateChanged`**: `Playing` → `Resume(now)`, otherwise
+   `Freeze()`, using `HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds()` like the
+   other tracker call sites.
+5. **Removed the `PlaybackState != Playing` early return in `OnPositionTimerTick`.** The
+   tracker is now authoritative: it returns null with no anchor and holds the position
+   still on a speed-0 anchor, so the gate could only ever suppress updates the tracker had
+   already decided were correct. Worse, it was actively harmful — for a conformant pause
+   the state stays `playing`, so the gate did nothing useful there, while for the
+   SDK-synthesized `Idle` it silently discarded ticks. Keeping it would have re-introduced
+   exactly the state coupling this fix removes.
+
+## Behavior matrix
+
+| Scenario | Group state | Progress | Bar |
+|---|---|---|---|
+| Normal playback | `playing` | fresh, speed 1000 | advances at 1x |
+| Conformant pause (README:681, 1448) | `playing` | fresh, speed 0 | frozen at the reported position |
+| Conformant resume | `playing` | fresh, speed 1000 | re-anchors and advances |
+| Non-conformant resume (`group/update` only) | `stopped` → `playing` | carried forward | `Resume()` re-anchors at the displayed position; advances |
+| Stream restart (SDK-synthesized Idle → Playing) | `idle` → `playing` | carried forward | `Freeze()` then `Resume()`; advances from where it stopped |
+| Genuine stop | `stopped` | any | `Freeze()`; holds the last position |
+| Track change, no fresh progress (README:1445) | any | carried forward | reset to 0, stays put until fresh progress |
+| Half-speed pause then resume | `playing` | speed 500, then speed 0 | resumes at 0.5x, the last known non-zero speed |
+| Live radio (duration 0) | `playing` | fresh | static server position; `Tick` returns null |
+
+## Tests
+
+`tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs`.
+
+New: `StreamRestart_IdleThenPlayingWithCarriedProgress_ResumesFromSamePosition`,
+`ResumeAfterFreeze_WithoutFreshProgress_ResumesFromFrozenPosition`,
+`Resume_WithSpeedZeroAnchor_ResumesAtNormalSpeed`,
+`Resume_WithSpeedZeroAnchor_ResumesAtLastKnownSpeed`,
+`Resume_WhileAlreadyAdvancing_DoesNotReanchor`, `Resume_WithNoPriorProgress_IsNoOp`,
+`Resume_AfterPendingTrackChangeReset_IsNoOp`,
+`FreshProgressWithSpeed_AdvancesRegardlessOfGroupState`.
+
+Rewritten because they encoded the state-override bug:
+`PauseWithFreshProgress_OmittingSpeed_StaysFrozen` →
+`ConformantPause_SpeedZeroWhilePlaying_StaysFrozen` (a spec-conformant pause carries speed
+0, so the test no longer depends on the state to freeze), and
+`PauseWithFreshProgress_ExplicitNormalSpeed_StaysFrozen`, whose entire premise was "the
+not-playing state wins over an explicit speed of 1000" — replaced by
+`FreshProgressWithSpeed_AdvancesRegardlessOfGroupState`, which asserts the opposite and is
+what the spec requires. `ResumeWithoutFreshProgress_StaysAtPausedPosition` and
+`ResumeWithFreshProgress_Reanchors` now express the pause as speed 0 rather than a
+`PlaybackState.Paused` that the protocol never emits.

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -28,15 +28,21 @@ namespace Sendspin.Windows.Services.Playback;
 /// <para>
 /// Extrapolation follows the spec formula: displayed position is the anchored
 /// <c>track_progress</c> plus elapsed time scaled by <c>playback_speed</c> (0 freezes the
-/// position), clamped to <c>[0, duration]</c> when the duration is known. The playback
-/// state carried by the same
-/// update overrides the progress object's speed: whenever the group is not playing, fresh
-/// progress anchors with an effective speed of 0, so a pause update cannot silently
-/// un-freeze the bar and a later resume without fresh progress stays at the paused
-/// position instead of jumping forward by the pause duration. When the clock synchronizer
-/// has converged and the metadata carries a plausible server timestamp, the anchor is that
-/// timestamp converted to client time (compensating network delay); otherwise the anchor
-/// falls back to the receipt time.
+/// position), clamped to <c>[0, duration]</c> when the duration is known. Whether the
+/// position advances is derived from <c>playback_speed</c> alone, never from the group's
+/// playback state: the spec has no 'paused' state and defines <c>playback_speed</c> = 0 as
+/// the only pause signal, and a conformant server always sends <c>playback_speed</c>
+/// whenever it sends progress. When the clock synchronizer has converged and the metadata
+/// carries a plausible server timestamp, the anchor is that timestamp converted to client
+/// time (compensating network delay); otherwise the anchor falls back to the receipt time.
+/// </para>
+/// <para>
+/// The anchor lifecycle is self-healing: <see cref="Freeze"/> drops the anchor when
+/// playback leaves the playing state and <see cref="Resume"/> rebuilds it at the currently
+/// displayed position when playback returns, so a state round-trip carrying no fresh
+/// progress (the SDK synthesizes Playing/Idle transitions around stream start/end) cannot
+/// leave the bar frozen for the rest of the track. Resuming re-anchors at the current
+/// instant, so the paused wall-clock duration is never added to the position.
 /// </para>
 /// <para>
 /// The <c>nowMicroseconds</c> parameters are client-domain microseconds from
@@ -61,6 +67,21 @@ public sealed class TrackProgressTracker
     private (string? Title, string? Artist, string? Album)? _trackIdentity;
     private PlaybackProgress? _lastProgress;
     private Anchor? _anchor;
+
+    /// <summary>
+    /// True once fresh progress has anchored a position that survives a freeze, so
+    /// <see cref="Resume"/> knows it has something real to resume from. Cleared by every
+    /// reset, which deliberately withholds extrapolation until the server confirms a
+    /// position again.
+    /// </summary>
+    private bool _hasKnownPosition;
+
+    /// <summary>
+    /// Last non-zero speed factor seen from a progress update, used by <see cref="Resume"/>
+    /// when the frozen anchor's own speed is 0 (a paused anchor). Normal speed until the
+    /// server reports otherwise.
+    /// </summary>
+    private double _lastNonZeroSpeedFactor = 1.0;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrackProgressTracker"/> class.
@@ -91,8 +112,10 @@ public sealed class TrackProgressTracker
     /// </summary>
     /// <param name="metadata">The merged track metadata, or null when no track is active.</param>
     /// <param name="playbackState">The group playback state carried by the same update.
-    /// When not <see cref="PlaybackState.Playing"/>, fresh progress anchors with an
-    /// effective speed of 0 regardless of the progress object's <c>playback_speed</c>.</param>
+    /// Diagnostic only: whether the position advances comes from the progress object's
+    /// <c>playback_speed</c>, the spec's only pause signal. Freezing and resuming on state
+    /// transitions is the caller's job via <see cref="Freeze"/> and
+    /// <see cref="Resume"/>.</param>
     /// <param name="nowMicroseconds">Current client time in microseconds.</param>
     public void ApplyMetadata(TrackMetadata? metadata, PlaybackState playbackState, long nowMicroseconds)
     {
@@ -159,14 +182,29 @@ public sealed class TrackProgressTracker
 
         if (progress.TrackProgress.HasValue)
         {
-            // The update's playback state overrides the progress object's speed: while not
-            // playing the effective speed is 0, so a pause update carrying fresh progress
-            // (with or without playback_speed) anchors frozen, and a later resume without
-            // fresh progress stays at the paused position instead of jumping forward by
-            // the pause duration.
-            var speedFactor = playbackState == PlaybackState.Playing
-                ? Math.Max(0, (progress.PlaybackSpeed ?? 1000.0) / 1000.0)
-                : 0;
+            // playback_speed alone decides whether the position advances: the spec has no
+            // 'paused' playback_state and defines speed 0 as the only pause signal, and a
+            // conformant server always sends the field alongside progress. Deriving this
+            // from the group state instead would freeze the bar whenever the SDK
+            // synthesizes a non-playing state around a stream restart.
+            var speedFactor = Math.Max(0, (progress.PlaybackSpeed ?? 1000.0) / 1000.0);
+            if (speedFactor > 0)
+            {
+                _lastNonZeroSpeedFactor = speedFactor;
+            }
+
+            if (speedFactor > 0 && playbackState != PlaybackState.Playing)
+            {
+                // Not an error: the SDK synthesizes Idle around stream/end, and the server
+                // may report an advancing position in the same merged snapshot. The speed
+                // wins; this only records the disagreement for diagnostics.
+                _logger.LogDebug(
+                    "Fresh progress reports speed {SpeedFactor} while group state is {PlaybackState}; the speed decides",
+                    speedFactor,
+                    playbackState);
+            }
+
+            _hasKnownPosition = true;
             _anchor = new Anchor(
                 ResolveAnchor(metadata.Timestamp, nowMicroseconds),
                 Math.Max(0, progress.TrackProgress.Value / 1000.0),
@@ -189,6 +227,7 @@ public sealed class TrackProgressTracker
             PositionSeconds);
         PositionSeconds = 0;
         _anchor = null;
+        _hasKnownPosition = false;
 
         // _lastProgress is intentionally kept: any group-state event echoing the
         // pre-change merged state carries the same stale progress instance and must
@@ -198,12 +237,47 @@ public sealed class TrackProgressTracker
 
     /// <summary>
     /// Stops extrapolation when playback leaves the playing state, keeping the last
-    /// displayed position. Resuming without fresh progress stays frozen rather than
-    /// jumping forward by the paused duration.
+    /// displayed position. The frozen position is the resume point: <see cref="Resume"/>
+    /// restarts from it rather than jumping forward by the paused duration.
     /// </summary>
     public void Freeze()
     {
         _anchor = null;
+    }
+
+    /// <summary>
+    /// Restarts extrapolation from the currently displayed position when playback returns
+    /// to the playing state. Call on every transition to playing; the counterpart to
+    /// <see cref="Freeze"/>.
+    /// </summary>
+    /// <param name="nowMicroseconds">Current client time in microseconds. Becomes the new
+    /// anchor instant, so time spent not playing is never added to the position.</param>
+    /// <remarks>
+    /// Without this, only fresh progress could rebuild the anchor <see cref="Freeze"/>
+    /// dropped, and a state round-trip carrying the same carried-forward
+    /// <see cref="PlaybackProgress"/> instance — which the SDK produces on a stream restart
+    /// — left the bar frozen for the rest of the track. A no-op while the position is
+    /// already advancing (fresh progress owns the anchor then) and while no position is
+    /// known (nothing to resume from).
+    /// </remarks>
+    public void Resume(long nowMicroseconds)
+    {
+        if (_anchor is { SpeedFactor: > 0 })
+        {
+            return;
+        }
+
+        if (!_hasKnownPosition)
+        {
+            _logger.LogDebug("Resume ignored: no server-confirmed position to resume from");
+            return;
+        }
+
+        _logger.LogDebug(
+            "Resuming seek bar extrapolation at {PositionSeconds}s (speed {SpeedFactor})",
+            PositionSeconds,
+            _lastNonZeroSpeedFactor);
+        _anchor = new Anchor(nowMicroseconds, PositionSeconds, _lastNonZeroSpeedFactor);
     }
 
     /// <summary>
@@ -228,6 +302,7 @@ public sealed class TrackProgressTracker
         PositionSeconds = 0;
         DurationSeconds = 0;
         _anchor = null;
+        _hasKnownPosition = false;
     }
 
     private double ExtrapolateAt(Anchor anchor, long nowMicroseconds)

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -588,13 +588,10 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private void OnPositionTimerTick(object? sender, EventArgs e)
     {
-        // Only interpolate while playing; the tracker returns null when it has no
-        // anchor or no known duration.
-        if (PlaybackState != PlaybackState.Playing)
-        {
-            return;
-        }
-
+        // The tracker is authoritative for whether the position advances: it returns null
+        // when it has no anchor (frozen/reset) or no known duration, and holds the position
+        // still on a speed-0 anchor. Gating on PlaybackState here would be redundant and
+        // would re-introduce the state coupling that froze the bar.
         var position = _progressTracker.Tick(HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds());
         if (position.HasValue)
         {
@@ -1699,8 +1696,16 @@ public partial class MainViewModel : ViewModelBase
 
         _mediaControlsService.UpdateState(value);
 
-        // Stop position extrapolation when playback stops; the bar keeps its last value
-        if (value != PlaybackState.Playing)
+        // Stop position extrapolation when playback stops (the bar keeps its last value)
+        // and restart it from that value when playback returns. Resuming here is what makes
+        // the bar survive a state round-trip that carries no fresh progress — the SDK
+        // synthesizes Idle/Playing around stream/end and stream/start, so a stream restart
+        // would otherwise leave the bar frozen for the rest of the track.
+        if (value == PlaybackState.Playing)
+        {
+            _progressTracker.Resume(HighPrecisionTimer.Shared.GetCurrentTimeMicroseconds());
+        }
+        else
         {
             _progressTracker.Freeze();
         }

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -243,14 +243,15 @@ public class TrackProgressTrackerTests
     }
 
     [Fact]
-    public void PauseWithFreshProgress_OmittingSpeed_StaysFrozen()
+    public void ConformantPause_SpeedZeroWhilePlaying_StaysFrozen()
     {
-        // A pause update often carries fresh progress WITHOUT playback_speed. The paused
-        // state must override the speed default (1.0): the bar stays at the paused position.
+        // Spec: there is no 'paused' playback_state (README:681); playback_speed = 0 is the
+        // protocol's only pause signal (README:1448) and stays inside a 'playing' group.
+        // Deriving the freeze from the speed alone must therefore still freeze a real pause.
         var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
 
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Paused, T0 + Second);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 0)), PlaybackState.Playing, T0 + Second);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
         var position = tracker.Tick(T0 + (60 * Second));
@@ -260,12 +261,12 @@ public class TrackProgressTrackerTests
     [Fact]
     public void ResumeWithoutFreshProgress_StaysAtPausedPosition()
     {
-        // Resume often arrives with the carried-forward progress instance only. The bar
-        // must stay at the paused position instead of jumping by the pause duration.
+        // Resume can arrive with the carried-forward progress instance only. The bar must
+        // stay at the paused position instead of jumping by the pause duration.
         var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
-        var pausedProgress = Progress(120_000, 300_000);
-        tracker.ApplyMetadata(Track("A", pausedProgress), PlaybackState.Paused, T0 + Second);
+        var pausedProgress = Progress(120_000, 300_000, speed: 0);
+        tracker.ApplyMetadata(Track("A", pausedProgress), PlaybackState.Playing, T0 + Second);
 
         tracker.ApplyMetadata(Track("A", pausedProgress), PlaybackState.Playing, T0 + (30 * Second));
 
@@ -279,7 +280,7 @@ public class TrackProgressTrackerTests
     {
         var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Paused, T0 + Second);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 0)), PlaybackState.Playing, T0 + Second);
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0 + (30 * Second));
 
@@ -289,17 +290,20 @@ public class TrackProgressTrackerTests
     }
 
     [Fact]
-    public void PauseWithFreshProgress_ExplicitNormalSpeed_StaysFrozen()
+    public void FreshProgressWithSpeed_AdvancesRegardlessOfGroupState()
     {
-        // Even when the paused progress carries an explicit playback_speed of 1000, the
-        // not-playing state wins: anchoring uses effective speed 0.
+        // The group playback state no longer overrides the progress object's speed: per
+        // spec (README:1446-1448) playback_speed is required whenever progress is sent and
+        // is the authority on whether the position advances. A carried-forward group state
+        // (e.g. the SDK's synthesized Idle on stream/end) must not silently freeze fresh,
+        // explicitly-advancing progress.
         var tracker = CreateTracker();
 
-        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 1000)), PlaybackState.Paused, T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 1000)), PlaybackState.Idle, T0);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
         var position = tracker.Tick(T0 + (30 * Second));
-        Assert.Equal(120.0, position!.Value, 3);
+        Assert.Equal(150.0, position!.Value, 3);
     }
 
     [Fact]
@@ -512,6 +516,110 @@ public class TrackProgressTrackerTests
         Assert.Equal(0.0, tracker.PositionSeconds);
         Assert.Equal(0.0, tracker.DurationSeconds);
         Assert.Null(tracker.Tick(T0 + (2 * Second)));
+    }
+
+    [Fact]
+    public void StreamRestart_IdleThenPlayingWithCarriedProgress_ResumesFromSamePosition()
+    {
+        // The reported freeze: a stream restart (format renegotiation, or a server that
+        // implements seek as stream/end + stream/start) makes the SDK synthesize Idle then
+        // Playing, BOTH carrying the same PlaybackProgress instance. Nothing is fresh, so
+        // only Resume() can rebuild the anchor Freeze() dropped.
+        var tracker = CreateTracker();
+        var progress = Progress(120_000, 300_000, speed: 1000);
+        tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0);
+
+        tracker.Tick(T0 + Second); // the 250 ms UI timer has carried the bar to 121 s
+        tracker.ApplyMetadata(Track("A", progress), PlaybackState.Idle, T0 + Second);
+        tracker.Freeze();
+        tracker.ApplyMetadata(Track("A", progress), PlaybackState.Playing, T0 + (2 * Second));
+        tracker.Resume(T0 + (2 * Second));
+
+        // Resumed from where the bar was (121 s at the freeze), not jumped by the gap.
+        Assert.Equal(121.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (4 * Second));
+        Assert.Equal(123.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void ResumeAfterFreeze_WithoutFreshProgress_ResumesFromFrozenPosition()
+    {
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+        tracker.Freeze();
+
+        tracker.Resume(T0 + (30 * Second));
+
+        // No jump by the 30 s of paused wall time.
+        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (32 * Second));
+        Assert.Equal(122.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void Resume_WithSpeedZeroAnchor_ResumesAtNormalSpeed()
+    {
+        // A speed-0 anchor is frozen but present; Resume must restart it at 1.0 rather
+        // than leaving it stuck at 0.
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 0)), PlaybackState.Playing, T0);
+
+        tracker.Resume(T0 + (30 * Second));
+
+        var position = tracker.Tick(T0 + (32 * Second));
+        Assert.Equal(122.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void Resume_WithSpeedZeroAnchor_ResumesAtLastKnownSpeed()
+    {
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 500)), PlaybackState.Playing, T0);
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000, speed: 0)), PlaybackState.Playing, T0 + Second);
+
+        tracker.Resume(T0 + (30 * Second));
+
+        var position = tracker.Tick(T0 + (32 * Second));
+        Assert.Equal(121.0, position!.Value, 3); // 2 s wall x 0.5
+    }
+
+    [Fact]
+    public void Resume_WhileAlreadyAdvancing_DoesNotReanchor()
+    {
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+
+        tracker.Resume(T0 + (2 * Second));
+
+        var position = tracker.Tick(T0 + (4 * Second));
+        Assert.Equal(124.0, position!.Value, 3); // original anchor kept
+    }
+
+    [Fact]
+    public void Resume_WithNoPriorProgress_IsNoOp()
+    {
+        var tracker = CreateTracker();
+
+        tracker.Resume(T0);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        Assert.Null(tracker.Tick(T0 + (10 * Second)));
+    }
+
+    [Fact]
+    public void Resume_AfterPendingTrackChangeReset_IsNoOp()
+    {
+        // The optimistic reset deliberately stops extrapolation until the server confirms
+        // the new track with fresh progress; Resume must not restart it from zero.
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 300_000)), PlaybackState.Playing, T0);
+        tracker.ResetForPendingTrackChange();
+
+        tracker.Resume(T0 + Second);
+
+        Assert.Equal(0.0, tracker.PositionSeconds);
+        Assert.Null(tracker.Tick(T0 + (3 * Second)));
     }
 
     private static TrackProgressTracker CreateTracker(IClockSynchronizer? clockSynchronizer = null) =>


### PR DESCRIPTION
## Summary

The progress bar could stop advancing **permanently** — audio kept playing while the bar sat still for the rest of the track. Found by comparing our implementation against the protocol spec and the reference implementations, not from logs.

Root cause: the anchor lifecycle was driven by `PlaybackState`, but only *fresh* progress could ever rebuild an anchor. Two real paths reached the dead state:

1. **Stream restart.** The SDK synthesizes state transitions the server never sent — it forces `Playing` on `stream/start` and `Idle` on `stream/end`. A format renegotiation (or a server implementing seek as end+start) emits `Idle` then `Playing`, both carrying the *same carried-forward* `PlaybackProgress` instance. `Freeze()` ran on `Idle`; nothing was fresh, so the `Playing` event could not re-anchor.
2. **Resume from a server that signals via `group/update` only**, which carries just `playback_state`/`group_id`/`group_name` — no progress to re-anchor from.

## Spec basis

Validated against [Sendspin/spec](https://github.com/Sendspin/spec) @ `3632c68`:

- `playback_state` is only `'playing' | 'stopped'` (README:681) — there is no `paused` state, so playback state cannot be the pause signal.
- `playback_speed: 0` means paused (README:1448) — this is the protocol's only pause signal.
- Inside `progress`, `track_progress`/`track_duration`/`playback_speed` are all **required** (README:1446-1448), so a conformant server always sends the speed when it sends progress.
- Progress is mandated only on play/pause/resume/seek/speed-change (README:1445), with no periodic guarantee — so a frozen bar may never self-heal.

## Changes

- Speed factor derives from `playback_speed` alone; the group playback state no longer overrides it.
- New `TrackProgressTracker.Resume(now)` re-anchors at the **current displayed position** with `now` as the anchor time and the last known non-zero speed. Anchoring at `now` is what prevents a jump forward by the paused duration. No-op when already advancing, when no position is known yet, or after a pending track-change reset.
- `MainViewModel.OnPlaybackStateChanged`: Playing → `Resume()`, otherwise `Freeze()`.
- Removed the `PlaybackState != Playing` early return in the position timer. It was wrong in both directions: on a conformant pause the state stays `playing` so it did nothing, and during a synthesized `Idle` it discarded ticks the tracker had already judged correct. The tracker is now authoritative; genuine stops are still covered by `Freeze()` nulling the anchor.
- The retained `playbackState` parameter now emits a Debug log when speed and state disagree — useful signal for diagnosing non-conformant servers.
- Design note: `docs/superpowers/specs/2026-07-20-seek-bar-freeze-design.md`.

## Tests

8 new cases covering both trigger paths, resume-in-place (no pause-duration jump), speed-0 anchors, and the no-op guards. **Tracker suite 43/43.** Full suite 140/142 — the 2 failures are the known pre-existing resampler ones, unchanged. Release build clean at the 553-warning baseline.

Four existing tests were rewritten because they encoded the bug: two asserted that a non-playing state overrides an explicit `playback_speed`, and depended on a `PlaybackState.Paused` the protocol never emits plus a `playback_speed` the spec makes required. They passed only because the test supplied both sides of a boundary that never behaves that way on the wire.

## Manual verification

1. Pause ~20s in, wait ~30s, resume → bar holds while paused, resumes from ~20s (not ~50s, not frozen).
2. Track change from MA and from the client's own transport → resets to 0 and advances.
3. Stream restart (seek in MA, or change output device in Settings) → bar resumes from the correct position. This is the case that killed the bar for the rest of the track before this change.