### PR TITLE
fix: advance position and show LIVE for unknown-duration streams

### DIFF
--- a/docs/superpowers/specs/2026-07-20-radio-unknown-duration-design.md
+++ b/docs/superpowers/specs/2026-07-20-radio-unknown-duration-design.md
@@ -1,0 +1,66 @@
+# Radio / unknown-duration progress — design note
+
+Date: 2026-07-20
+Branch: `fix/radio-unknown-duration` (stacks on `fix/seek-bar-freeze`)
+
+## Symptom
+
+Playing a live radio stream, the seek bar row rendered `0:00 ──────────── 0:00` with a
+permanently empty bar, and the elapsed time never moved.
+
+## Spec ground truth
+
+Validated against [Sendspin/spec](https://github.com/Sendspin/spec) @ `3632c68`.
+
+- README:1447 — `track_duration`: "total track length in milliseconds, **0 for
+  unlimited/unknown duration (e.g., live radio streams)**".
+- README:1454-1461 — the canonical progress formula:
+
+  ```python
+  calculated_progress = metadata.progress.track_progress + (current_time - metadata.timestamp) * metadata.progress.playback_speed / 1000000
+  if metadata.progress.track_duration != 0:
+      current_track_progress_ms = max(min(calculated_progress, metadata.progress.track_duration), 0)
+  else:
+      current_track_progress_ms = max(calculated_progress, 0)
+  ```
+
+The `else` branch is decisive: with an unknown duration the position **must still
+advance**; only the upper clamp is skipped. Cross-checked against aiosendspin
+(`server/roles/metadata/group.py`, `_get_current_track_progress`) and SendspinDroid, whose
+protocol layer carries an explicit `unknownDuration_notClampedAbove` test. Our freeze was
+the outlier.
+
+## Two independent defects
+
+**A — position never advanced (spec violation).**
+`src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs`, `Tick()` bailed out on
+`DurationSeconds <= 0`. That condition has no basis in the spec. `ExtrapolateAt` was
+already correct (`DurationSeconds > 0 ? Math.Clamp(...) : Math.Max(0, position)`), but its
+zero-duration branch was dead code on the periodic path — reachable only from the one-shot
+call in `ApplyMetadata`, so a live stream's position jumped on each fresh progress message
+and froze in between. Fix: drop the duration condition; extrapolate whenever an anchor
+exists and let `ExtrapolateAt` decide about clamping.
+
+Note the SDK models unknown duration as **null** as well as 0 (`PlaybackProgress.TrackDuration`
+is `double?`); the tracker already collapses both to `DurationSeconds == 0`, so one fix
+covers both.
+
+**B — the row rendered wrong.** `MainViewModel.ProgressPercent` returned 0 for an unknown
+duration and `DurationFormatted` formatted 0 as `"0:00"`. The progress row's visibility
+binds to `CurrentTrack` being non-null (MainWindow.xaml), so radio always showed the row —
+with a dead bar and a bogus `0:00` total.
+
+## UI decision (product choice, not spec-mandated)
+
+The spec says nothing about presentation. The chosen default treatment for an unbounded
+stream:
+
+- elapsed time ticks and is shown normally;
+- the duration label reads **"LIVE"** instead of `0:00`;
+- the progress bar is **collapsed** — a percentage of an unknown total is meaningless, and
+  a permanently empty track reads as a bug.
+
+Implementation keeps this cleanly swappable: a single `MainViewModel.HasKnownDuration`
+(`Duration > 0`) is the source of truth for both the label and the bar's `Visibility`
+(existing `BoolToVisibilityConverter`). `ProgressPercent` still returns 0 in this mode; it
+is simply unused. Known-duration tracks are untouched.

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -284,11 +284,17 @@ public sealed class TrackProgressTracker
     /// Recomputes the extrapolated position. Call periodically while playing.
     /// </summary>
     /// <param name="nowMicroseconds">Current client time in microseconds.</param>
-    /// <returns>The updated position in seconds, or null when there is nothing to advance
-    /// (no anchor, or the duration is unknown).</returns>
+    /// <returns>The updated position in seconds, or null when there is no anchor to
+    /// extrapolate from.</returns>
+    /// <remarks>
+    /// An unknown duration (spec: <c>track_duration</c> = 0 for live/unbounded streams,
+    /// which the SDK also models as null) does not stop extrapolation — per the spec
+    /// formula it only skips the upper clamp, which <see cref="ExtrapolateAt"/> already
+    /// handles.
+    /// </remarks>
     public double? Tick(long nowMicroseconds)
     {
-        if (_anchor is not { } anchor || DurationSeconds <= 0)
+        if (_anchor is not { } anchor)
         {
             return null;
         }

--- a/src/Sendspin.Windows/MainWindow.xaml
+++ b/src/Sendspin.Windows/MainWindow.xaml
@@ -515,6 +515,9 @@
                                    Foreground="{StaticResource TextSecondaryBrush}"
                                    VerticalAlignment="Center"/>
 
+                        <!-- Hidden for unbounded streams (live radio): a percentage of an
+                             unknown duration is meaningless, so only the elapsed time and
+                             the "LIVE" label remain. -->
                         <ProgressBar Grid.Column="1"
                                      Margin="12,0"
                                      Value="{Binding ProgressPercent, Mode=OneWay}"
@@ -522,7 +525,8 @@
                                      Height="4"
                                      VerticalAlignment="Center"
                                      Foreground="{StaticResource TextPrimaryBrush}"
-                                     Background="#40FFFFFF"/>
+                                     Background="#40FFFFFF"
+                                     Visibility="{Binding HasKnownDuration, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
                         <TextBlock Grid.Column="2"
                                    Text="{Binding DurationFormatted}"

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -480,14 +480,25 @@ public partial class MainViewModel : ViewModelBase
     public string PositionFormatted => FormatTime(Position);
 
     /// <summary>
-    /// Gets the total duration formatted as a time string (e.g., "3:45" or "1:23:45").
+    /// Gets a value indicating whether the current track has a known, bounded duration.
+    /// Per the Sendspin spec a <c>track_duration</c> of 0 means unlimited/unknown (live
+    /// radio); the tracker maps the SDK's null duration to the same 0. Single source of
+    /// truth for the unbounded-stream presentation in the progress row.
     /// </summary>
-    public string DurationFormatted => FormatTime(Duration);
+    public bool HasKnownDuration => Duration > 0;
 
     /// <summary>
-    /// Gets the progress percentage (0-100) for progress bar display.
+    /// Gets the total duration formatted as a time string (e.g., "3:45" or "1:23:45"),
+    /// or "LIVE" for an unbounded stream. The "LIVE" label is a product choice, not a
+    /// spec requirement.
     /// </summary>
-    public double ProgressPercent => Duration > 0 ? (Position / Duration) * 100 : 0;
+    public string DurationFormatted => HasKnownDuration ? FormatTime(Duration) : "LIVE";
+
+    /// <summary>
+    /// Gets the progress percentage (0-100) for progress bar display. Always 0 for an
+    /// unbounded stream, where the bar is hidden and the value is unused.
+    /// </summary>
+    public double ProgressPercent => HasKnownDuration ? (Position / Duration) * 100 : 0;
 
     /// <summary>
     /// Formats seconds as a time string (M:SS or H:MM:SS for long tracks).
@@ -1727,6 +1738,7 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     partial void OnDurationChanged(double value)
     {
+        OnPropertyChanged(nameof(HasKnownDuration));
         OnPropertyChanged(nameof(DurationFormatted));
         OnPropertyChanged(nameof(ProgressPercent));
     }

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -61,15 +61,66 @@ public class TrackProgressTrackerTests
     }
 
     [Fact]
-    public void Tick_WithoutDuration_DoesNotAdvance()
+    public void Tick_ZeroDuration_AdvancesUnclamped()
     {
-        // Preserved behavior: duration-less streams show a static server position.
+        // Spec (README:1447, 1454-1461): track_duration = 0 means unlimited/unknown (live
+        // radio). The position MUST still advance; only the upper clamp is skipped.
         var tracker = CreateTracker();
         tracker.ApplyMetadata(Track("A", Progress(120_000, 0)), PlaybackState.Playing, T0);
 
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
-        Assert.Null(tracker.Tick(T0 + (2 * Second)));
-        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (5 * Second));
+
+        Assert.Equal(125.0, position!.Value, 3);
+        var later = tracker.Tick(T0 + (10 * Second));
+        Assert.Equal(130.0, later!.Value, 3);
+    }
+
+    [Fact]
+    public void Tick_NullDuration_AdvancesUnclamped()
+    {
+        // The SDK models unknown duration as null as well as 0; both must advance.
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, durationMs: null)), PlaybackState.Playing, T0);
+
+        Assert.Equal(0.0, tracker.DurationSeconds);
+        var position = tracker.Tick(T0 + (5 * Second));
+
+        Assert.Equal(125.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void Tick_UnknownDuration_GrowsWithoutBound()
+    {
+        // No plausible track length caps a live stream: two hours in, still counting.
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(0, 0)), PlaybackState.Playing, T0);
+
+        var position = tracker.Tick(T0 + (7200 * Second));
+
+        Assert.Equal(7200.0, position!.Value, 3);
+    }
+
+    [Fact]
+    public void Tick_UnknownDuration_ScalesWithPlaybackSpeed()
+    {
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 0, speed: 500)), PlaybackState.Playing, T0);
+
+        var position = tracker.Tick(T0 + (2 * Second));
+
+        Assert.Equal(121.0, position!.Value, 3); // 2 s wall x 0.5
+    }
+
+    [Fact]
+    public void Tick_UnknownDuration_SpeedZeroStaysFrozen()
+    {
+        var tracker = CreateTracker();
+        tracker.ApplyMetadata(Track("A", Progress(120_000, 0, speed: 0)), PlaybackState.Playing, T0);
+
+        var position = tracker.Tick(T0 + (30 * Second));
+
+        Assert.Equal(120.0, position!.Value, 3);
     }
 
     [Fact]
@@ -421,22 +472,23 @@ public class TrackProgressTrackerTests
 
         Assert.Equal(0.0, tracker.DurationSeconds);
         Assert.Equal(130.0, tracker.PositionSeconds, 3);
-        Assert.Null(tracker.Tick(T0 + (3 * Second))); // no extrapolation without a duration
+        var position = tracker.Tick(T0 + (3 * Second));
+        Assert.Equal(132.0, position!.Value, 3); // unbounded from here on
     }
 
     [Fact]
-    public void NullDurationFromTrackStart_ShowsStaticPosition()
+    public void NullDurationFromTrackStart_AdvancesFromServerPosition()
     {
-        // Radio case: the track never reports a duration. Same static display as an
-        // explicit 0 duration — position shows the server value and does not advance.
+        // Radio case: the track never reports a duration. The position still advances,
+        // and the duration stays 0 so the UI can render it as unbounded.
         var tracker = CreateTracker();
 
         tracker.ApplyMetadata(Track("A", Progress(120_000, durationMs: null)), PlaybackState.Playing, T0);
 
         Assert.Equal(0.0, tracker.DurationSeconds);
         Assert.Equal(120.0, tracker.PositionSeconds, 3);
-        Assert.Null(tracker.Tick(T0 + (2 * Second)));
-        Assert.Equal(120.0, tracker.PositionSeconds, 3);
+        var position = tracker.Tick(T0 + (2 * Second));
+        Assert.Equal(122.0, position!.Value, 3);
     }
 
     [Fact]
@@ -515,7 +567,11 @@ public class TrackProgressTrackerTests
 
         Assert.Equal(0.0, tracker.PositionSeconds);
         Assert.Equal(0.0, tracker.DurationSeconds);
-        Assert.Null(tracker.Tick(T0 + (2 * Second)));
+
+        // A non-positive duration is indistinguishable from "unknown", so the position
+        // advances from the clamped zero rather than freezing.
+        var position = tracker.Tick(T0 + (2 * Second));
+        Assert.Equal(2.0, position!.Value, 3);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Live radio / unknown-duration streams showed `0:00 ──────────── 0:00` with a permanently empty bar and an elapsed time that never moved. Two independent defects stacked — fixing either alone still leaves radio looking broken.

**1. Position never advanced (spec violation).** `Tick()` bailed out on `DurationSeconds <= 0`, a condition with no basis in the spec. `ExtrapolateAt` was already correct — its unknown-duration branch was simply dead code on the periodic path, so a live stream's position only jumped when a fresh progress message happened to arrive.

**2. The display was wrong.** `ProgressPercent` returned 0 and the duration label rendered `FormatTime(0)` → `0:00`, while the progress row stayed visible because its visibility binds to `CurrentTrack`.

## Spec basis

Validated against [Sendspin/spec](https://github.com/Sendspin/spec) @ `3632c68`:

- README:1447 — `track_duration`: "total track length in milliseconds, **0 for unlimited/unknown duration (e.g., live radio streams)**"
- README:1454-1461 — the canonical formula's `else` branch is `max(calculated_progress, 0)`, so position **must still advance** when duration is 0; only the upper clamp is skipped.

Cross-checked against the references: aiosendspin advances (`_get_current_track_progress`), and SendspinDroid's protocol layer advances with an explicit test named `unknownDuration_notClampedAbove`. Our freeze was the outlier.

## Changes

- `Tick()` now runs whenever an anchor exists; `ExtrapolateAt` (unchanged) applies clamp-or-not correctly. The SDK models unknown duration as both `0` and `null`; both are handled.
- New `MainViewModel.HasKnownDuration` is the single source of truth for the UI: `DurationFormatted` shows `LIVE` instead of `0:00`, and the ProgressBar's `Visibility` binds through the existing `BoolToVisibilityConverter` (no new converter). The layout column stays `Width="*"`, so collapsing the bar keeps elapsed left-aligned and `LIVE` right-aligned.
- Known-duration playback is unchanged in every respect.
- Design note: `docs/superpowers/specs/2026-07-20-radio-unknown-duration-design.md`, which flags the LIVE / hidden-bar treatment as a **product choice**, not spec-mandated — easy to swap for an indeterminate bar if preferred.

## Tests

4 net new cases: unclamped advance on zero duration and on null duration, unbounded growth (+2 h with no clamp), speed scaling at unknown duration, and speed 0 still freezing. Red-first confirmed (`Failed: 7, Passed: 40`) before implementation.

**Tracker suite 47/47.** Full suite 144/146 — the 2 failures are the known pre-existing resampler ones. Release rebuild clean at the 553-warning baseline.

Three existing tests encoded the old frozen behavior as if it were intended (one literally commented "Preserved behavior: duration-less streams show a static server position") and were rewritten to the spec-correct expectation.

One knock-on worth noting: `NegativeProgressAndDuration_ClampToZero` now expects the position to advance, because a negative duration clamped to 0 is indistinguishable from "unknown". Negative durations are non-conformant regardless, and the spec's `!= 0` predicate has the same property.

## Manual verification

1. **Radio** — elapsed counts up smoothly and indefinitely; right label reads `LIVE`; no bar track drawn.
2. **Normal track** — visually unchanged: filling bar, real duration, clamps at 100%.
3. **Switch radio → track → radio** — bar appears/disappears, label alternates, no stale `0:00`. This is the only path exercising the new `HasKnownDuration` change notification and has no automated guard.
4. **Pause on radio** — elapsed stops and resumes in place.