### PR TITLE
fix: keep the WDL low-pass chain from re-engaging with stale history

### DIFF
--- a/src/Sendspin.Windows.Services/Audio/DynamicResamplerSampleProvider.cs
+++ b/src/Sendspin.Windows.Services/Audio/DynamicResamplerSampleProvider.cs
@@ -166,12 +166,23 @@ public sealed class DynamicResamplerSampleProvider : ISampleProvider, IDisposabl
 
         _lastFrame = new float[WaveFormat.Channels];
 
-        // Initialize WDL resampler
-        // Reduced from 32 to 16 taps - 32-tap was causing audible artifacts during
-        // dynamic rate changes. 16-tap provides good quality with faster adaptation
-        // and less ringing on transients.
+        // Initialize WDL resampler: linear interpolation plus an optional IIR low-pass chain.
+        // (SetMode's second argument is NOT a sinc tap count - with sinc=false it is the
+        // number of biquad passes, and WDL clamps it to 4.)
+        //
+        // The low-pass chain only runs while the resample ratio is off 1.0, and WDL never
+        // clears its filter history. With identity conversion the sync corrector parks the
+        // rate at exactly 1.0 whenever the error is inside the deadband, so every
+        // None -> Resampling flip re-engaged the chain against seconds-stale history - a
+        // signal-proportional broadband transient heard as a soft click (issue #63).
+        // Enable the chain only when the nominal conversion keeps the ratio off unity across
+        // the entire correction range [MinRate, MaxRate], i.e. the filters can never toggle
+        // mid-stream. For identity conversion, linear interpolation alone is used: a <=4%
+        // trim folds only content above 0.96x Nyquist, so no anti-alias filtering is needed.
+        var nominalRatio = (double)source.WaveFormat.SampleRate / _targetSampleRate;
+        var ratioCanCrossUnity = nominalRatio * MaxRate >= 1.0 && nominalRatio * MinRate <= 1.0;
         _resampler = new WdlResampler();
-        _resampler.SetMode(true, 16, false); // Interpolating, 16-tap sinc, no filter on output
+        _resampler.SetMode(true, ratioCanCrossUnity ? 0 : 4, false);
         _resampler.SetFilterParms(0.90f, 0.60f); // 90% Nyquist, sharper transition (less processing)
         _resampler.SetFeedMode(true); // We're in output-driven mode (request N output samples)
         UpdateResamplerRates();

--- a/tests/Sendspin.Windows.Services.Tests/Audio/DynamicResamplerSampleProviderTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Audio/DynamicResamplerSampleProviderTests.cs
@@ -34,6 +34,152 @@ public class DynamicResamplerSampleProviderTests
         }
     }
 
+    /// <summary>
+    /// A continuous sine source; phase carries across reads so the signal itself has no
+    /// discontinuities. Any output step above the sine's per-sample slope bound was
+    /// manufactured by the resampler.
+    /// </summary>
+    private sealed class SineSampleProvider : ISampleProvider
+    {
+        private readonly double _phaseIncrement;
+        private double _phase;
+
+        public SineSampleProvider(int sampleRate, int channels, double frequencyHz)
+        {
+            WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
+            _phaseIncrement = 2 * Math.PI * frequencyHz / sampleRate;
+        }
+
+        public WaveFormat WaveFormat { get; }
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            var channels = WaveFormat.Channels;
+            for (var i = 0; i < count; i += channels)
+            {
+                var sample = (float)(0.5 * Math.Sin(_phase));
+                for (var c = 0; c < channels; c++)
+                {
+                    buffer[offset + i + c] = sample;
+                }
+
+                _phase += _phaseIncrement;
+            }
+
+            return count;
+        }
+    }
+
+    /// <summary>
+    /// Regression test for issue #63's audible click. WDL's IIR low-pass chain runs only while
+    /// the resample ratio is off 1.0, and its filter history is never cleared. Toggling the
+    /// playback rate between exactly 1.0 and 1.0+e - the corrector's None/Resampling limit
+    /// cycle under ordinary clock drift - re-engages the chain against seconds-stale history,
+    /// producing a signal-proportional broadband transient (the reported "soft click").
+    /// A 101 Hz sine moves at most ~0.0066/sample, so any output step well above that bound
+    /// is a manufactured discontinuity. 101 Hz and the 47-callback toggle period are chosen
+    /// incommensurate so the stale history is never phase-aligned with the live signal.
+    /// </summary>
+    [Fact]
+    public void RateCorrection_TogglingAcrossUnity_DoesNotProduceClicks()
+    {
+        const int sampleRate = 48000;
+        const int channels = 2;
+        const double frequency = 101.0;
+        const int count = 960; // one 10 ms callback at 48 kHz stereo
+
+        var source = new SineSampleProvider(sampleRate, channels, frequency);
+
+        // targetSampleRate == source rate => identity resampling, sync-correction only.
+        using var resampler = new DynamicResamplerSampleProvider(source, correctionProvider: null, targetSampleRate: sampleRate);
+
+        var maxDelta = MeasureMaxSampleDelta(
+            resampler, count, channels, callbacks: 1000,
+            rateForCallback: cb => (cb / 47) % 2 == 0 ? 1.0 : 1.0004);
+
+        var sineSlopeBound = 0.5 * 2 * Math.PI * frequency / sampleRate;
+        Assert.True(
+            maxDelta < 3 * sineSlopeBound,
+            $"resampler manufactured a discontinuity of {maxDelta:F4} (sine slope bound {sineSlopeBound:F4}) - the issue #63 click");
+    }
+
+    /// <summary>
+    /// Companion guard for the conversion branch: with genuine sample-rate conversion the
+    /// ratio never reaches 1.0 at any correction rate, the low-pass chain stays continuously
+    /// engaged (history stays warm), and rate toggling is click-free. Pins that path so an
+    /// identity-only filter change cannot regress it.
+    /// </summary>
+    [Fact]
+    public void RateCorrection_TogglingDuringCompoundConversion_DoesNotProduceClicks()
+    {
+        const int sourceRate = 48000;
+        const int targetRate = 44100;
+        const int channels = 2;
+        const double frequency = 101.0;
+        const int count = 882; // one 10 ms callback at 44.1 kHz stereo
+
+        var source = new SineSampleProvider(sourceRate, channels, frequency);
+        using var resampler = new DynamicResamplerSampleProvider(source, correctionProvider: null, targetSampleRate: targetRate);
+
+        var maxDelta = MeasureMaxSampleDelta(
+            resampler, count, channels, callbacks: 1000,
+            rateForCallback: cb => (cb / 47) % 2 == 0 ? 1.0 : 1.0004);
+
+        var sineSlopeBound = 0.5 * 2 * Math.PI * frequency / targetRate;
+        Assert.True(
+            maxDelta < 3 * sineSlopeBound,
+            $"compound conversion manufactured a discontinuity of {maxDelta:F4} (sine slope bound {sineSlopeBound:F4})");
+    }
+
+    /// <summary>
+    /// Drives the resampler through <paramref name="callbacks"/> read cycles, setting the
+    /// playback rate per callback, and returns the largest same-channel sample-to-sample
+    /// step in the output (measured across callback boundaries too). The first two callbacks
+    /// are excluded as filter/priming warm-up.
+    /// </summary>
+    private static double MeasureMaxSampleDelta(
+        DynamicResamplerSampleProvider resampler,
+        int count,
+        int channels,
+        int callbacks,
+        Func<int, double> rateForCallback)
+    {
+        var buffer = new float[count];
+        var previous = new float[channels];
+        var maxDelta = 0.0;
+
+        for (var cb = 0; cb < callbacks; cb++)
+        {
+            resampler.PlaybackRate = rateForCallback(cb);
+            resampler.Read(buffer, 0, count);
+
+            if (cb >= 2)
+            {
+                for (var c = 0; c < channels; c++)
+                {
+                    var prev = previous[c];
+                    for (var i = c; i < count; i += channels)
+                    {
+                        var delta = Math.Abs(buffer[i] - prev);
+                        if (delta > maxDelta)
+                        {
+                            maxDelta = delta;
+                        }
+
+                        prev = buffer[i];
+                    }
+                }
+            }
+
+            for (var c = 0; c < channels; c++)
+            {
+                previous[c] = buffer[count - channels + c];
+            }
+        }
+
+        return maxDelta;
+    }
+
     [Fact]
     public void RateCorrection_ConcealsShortfalls_WithoutSilenceGaps()
     {

--- a/tests/Sendspin.Windows.Services.Tests/Audio/DynamicResamplerSampleProviderTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Audio/DynamicResamplerSampleProviderTests.cs
@@ -132,6 +132,51 @@ public class DynamicResamplerSampleProviderTests
     }
 
     /// <summary>
+    /// Pins the other half of the ratio-can-cross-unity branch: compound conversion must
+    /// keep the WDL low-pass chain ENGAGED. The click tests cannot see this - a low-frequency
+    /// sine is click-free with the chain removed too. Observable: for 48 kHz -> 44.1 kHz the
+    /// chain's cutoff sits at ~19.9 kHz (0.90 x Nyquist / ratio), so a 21 kHz tone emerges
+    /// near-silent with the chain engaged (~0.005 RMS, about -37 dB) but at ~0.21 RMS through
+    /// bare linear interpolation. The 0.05 threshold sits 10x above the engaged level and 4x
+    /// below the disengaged level.
+    /// </summary>
+    [Fact]
+    public void CompoundConversion_AttenuatesContentAboveFilterCutoff()
+    {
+        const int sourceRate = 48000;
+        const int targetRate = 44100;
+        const int channels = 2;
+        const double frequency = 21000.0;
+        const int count = 882; // one 10 ms callback at 44.1 kHz stereo
+
+        var source = new SineSampleProvider(sourceRate, channels, frequency);
+        using var resampler = new DynamicResamplerSampleProvider(source, correctionProvider: null, targetSampleRate: targetRate);
+
+        var buffer = new float[count];
+        double sumSquares = 0;
+        long samples = 0;
+        for (var cb = 0; cb < 300; cb++)
+        {
+            resampler.Read(buffer, 0, count);
+            if (cb < 50)
+            {
+                continue; // let the filter chain settle before measuring
+            }
+
+            foreach (var sample in buffer)
+            {
+                sumSquares += (double)sample * sample;
+                samples++;
+            }
+        }
+
+        var rms = Math.Sqrt(sumSquares / samples);
+        Assert.True(
+            rms < 0.05,
+            $"21 kHz tone passed compound conversion at RMS {rms:F4} - the anti-alias chain is not engaged (engaged ~0.005, bare interpolation ~0.21)");
+    }
+
+    /// <summary>
     /// Drives the resampler through <paramref name="callbacks"/> read cycles, setting the
     /// playback rate per callback, and returns the largest same-channel sample-to-sample
     /// step in the output (measured across callback boundaries too). The first two callbacks


### PR DESCRIPTION
## Summary

Fixes the audible click from #63 (the first of that issue's two problems — the long-session sync drift is a separate, still-open matter).

**Mechanism:** `WdlResampler`'s IIR low-pass chain runs only while the resample ratio is off 1.0, and WDL never clears its filter history. With identity conversion (stream rate == device rate) the sync corrector parks the rate at exactly 1.0 whenever the error is inside the 1 ms deadband, so under ordinary clock drift the correction mode limit-cycles None/Resampling on a sub-second-to-seconds cadence — and every re-engagement runs 4 cascaded biquads against seconds-stale history. The result is a signal-proportional broadband transient: a soft click that lands at the start of each "Resampling" episode in stats-for-nerds and vanishes during quiet passages, matching the report exactly.

Related note: `SetMode(true, 16, false)` was never "16-tap sinc" — with `sinc=false` the argument is a biquad pass count that WDL clamps to 4, so the earlier 32-to-16 change was a no-op. The comment is corrected.

## Fix

Enable the low-pass chain only when the nominal conversion ratio keeps it engaged at every reachable correction rate (i.e. the ratio can never cross unity). Identity conversion now uses linear interpolation alone: a <=4% trim folds only content above 0.96x Nyquist, so nothing audible is lost, and steady-state output at rate 1.0 is unchanged (the chain was already bypassed there).

## Evidence

- New regression test fails on master with a **0.6118** discontinuity on a 0.5-amplitude sine (legit slope bound 0.0066) and passes with the fix.
- Companion test pins the compound-conversion path (48 kHz -> 44.1 kHz), where the chain stays continuously engaged and click-free — behavior unchanged.
- Suite: 146 passed. The 2 failures (`RateCorrection_ConcealsShortfalls_WithoutSilenceGaps`, `StartupPrefill_Uncompensated_DriftsOffSchedule`) fail identically on untouched master — one guard was invalidated by the #46 drain loop, the other's premise by the SDK 9.1.0 baseline-capture rework. Left for a separate cleanup.