### PR TITLE
fix: adapt to the SDK's sync/audio conformance batch

### DIFF
--- a/.github/workflows/ci-sdk-dev.yml
+++ b/.github/workflows/ci-sdk-dev.yml
@@ -1,7 +1,8 @@
 name: CI (SDK dev source)
 
 # Manually-triggered build of Sendspin for Windows against the Sendspin SDK *source*
-# (default: the SDK's `dev` branch) instead of the published NuGet package.
+# (default: the SDK's `main` branch, where the SDK develops) instead of the published
+# NuGet package.
 # Produces signed installers + a prerelease so in-flight SDK changes can be tested.
 # Normal CI (ci.yml) and releases are unaffected.
 
@@ -11,7 +12,7 @@ on:
       sdk_ref:
         description: 'SDK branch / tag / SHA to build against (within Sendspin/sendspin-dotnet)'
         required: true
-        default: 'dev'
+        default: 'main'
 
 permissions:
   contents: write  # Required for creating prereleases

--- a/src/Sendspin.Windows.Services/Diagnostics/EpisodeClassifier.cs
+++ b/src/Sendspin.Windows.Services/Diagnostics/EpisodeClassifier.cs
@@ -126,7 +126,7 @@ public static class EpisodeClassifier
         {
             Verdict = SyncHealthVerdict.Unknown,
             Evidence = string.Create(ci,
-                $"drops={e.Drops} inserts={e.Inserts} underruns={e.Underruns} reanchors={e.Reanchors} maxSyncErr={e.MaxAbsSyncErrorMs:F1}ms minBuffer={e.MinBufferedMs:F0}ms maxChunkGap={e.MaxChunkGapMs:F0}ms rttJitter={e.MaxRttJitterMs:F1}ms dirFlips={e.DirectionFlips} cbGaps={e.CallbackGaps} rateSaturated={e.RateSaturated}"),
+                $"drops={e.Drops} inserts={e.Inserts} hardSyncs={e.HardSyncs} underruns={e.Underruns} reanchors={e.Reanchors} maxSyncErr={e.MaxAbsSyncErrorMs:F1}ms minBuffer={e.MinBufferedMs:F0}ms maxChunkGap={e.MaxChunkGapMs:F0}ms rttJitter={e.MaxRttJitterMs:F1}ms dirFlips={e.DirectionFlips} cbGaps={e.CallbackGaps} rateSaturated={e.RateSaturated}"),
         };
     }
 }

--- a/src/Sendspin.Windows.Services/Diagnostics/EpisodeDetector.cs
+++ b/src/Sendspin.Windows.Services/Diagnostics/EpisodeDetector.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
+using Sendspin.SDK.Audio;
+
 namespace Sendspin.Windows.Services.Diagnostics;
 
 /// <summary>
@@ -10,9 +12,20 @@ namespace Sendspin.Windows.Services.Diagnostics;
 /// after <see cref="QuietCloseSeconds"/> with no triggers, or at the <see cref="HardCapSeconds"/> cap.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Single-threaded by contract: <see cref="Observe"/> is only called from the monitor's timer tick.
 /// Triggers are audibility-anchored (see design spec): correction activity, deadband crossings,
 /// callback gaps, and saturated correction rate.
+/// </para>
+/// <para>
+/// One-shot hard syncs (<see cref="SyncCorrectionMode.HardSync"/>) are counted separately from
+/// continuous correction. The SDK applies a snap by splicing samples out of, or silence into,
+/// the buffer timeline, which advances the same drop/insert counters the continuous corrector
+/// uses — but it is a single deliberate discontinuity, not a sustained grind, and the
+/// SDK's own corrector stands down while one is in flight. Folding a snap into the continuous
+/// aggregates would fabricate direction flips (reading as clock-sync instability) and inflate
+/// the drop/insert rate the skew rule turns into a ppm estimate.
+/// </para>
 /// </remarks>
 public sealed class EpisodeDetector
 {
@@ -109,6 +122,7 @@ public sealed class EpisodeDetector
         || s.SamplesInsertedForSync > prev.SamplesInsertedForSync
         || s.UnderrunCount > prev.UnderrunCount
         || s.ReanchorCount > prev.ReanchorCount
+        || s.HardSyncCount > prev.HardSyncCount
         || s.CallbackGapCount > prev.CallbackGapCount
         || Math.Abs(s.SmoothedSyncErrorMs) > _deadbandMs
         || Math.Abs(s.TargetPlaybackRate - 1.0) >= 0.9 * _maxSpeedCorrection;
@@ -173,7 +187,8 @@ public sealed class EpisodeDetector
         private int _directionFlips;
         private int _lastDirection;             // +1 dropping, -1 inserting, 0 none yet
         private bool _rateSaturated;
-        private long _endDrops, _endInserts, _endUnderruns, _endReanchors, _endCallbackGaps;
+        private long _hardSyncDrops, _hardSyncInserts;  // snap-attributed portion of the counters
+        private long _endDrops, _endInserts, _endUnderruns, _endReanchors, _endCallbackGaps, _endHardSyncs;
         private int _endForgetting;
         private long _bytesAtOpen, _bytesAtEnd;
         private int _sampleRate, _channels;
@@ -220,35 +235,60 @@ public sealed class EpisodeDetector
                 _rateSaturated = true;
             }
 
-            var dropped = s.SamplesDroppedForSync > prev.SamplesDroppedForSync;
-            var inserted = s.SamplesInsertedForSync > prev.SamplesInsertedForSync;
-            var direction = dropped ? 1 : inserted ? -1 : 0;
-            if (direction != 0)
-            {
-                if (_lastDirection != 0 && direction != _lastDirection)
-                {
-                    _directionFlips++;
-                }
+            var dropDelta = s.SamplesDroppedForSync - prev.SamplesDroppedForSync;
+            var insertDelta = s.SamplesInsertedForSync - prev.SamplesInsertedForSync;
 
-                _lastDirection = direction;
+            if (IsHardSyncInterval(in s, in prev))
+            {
+                // The snap owns this interval's movement: bank it separately and leave the
+                // direction history alone, so one deliberate discontinuity cannot read as the
+                // corrector hunting back and forth.
+                _hardSyncDrops += dropDelta;
+                _hardSyncInserts += insertDelta;
+            }
+            else
+            {
+                var direction = dropDelta > 0 ? 1 : insertDelta > 0 ? -1 : 0;
+                if (direction != 0)
+                {
+                    if (_lastDirection != 0 && direction != _lastDirection)
+                    {
+                        _directionFlips++;
+                    }
+
+                    _lastDirection = direction;
+                }
             }
 
             _endDrops = s.SamplesDroppedForSync;
             _endInserts = s.SamplesInsertedForSync;
             _endUnderruns = s.UnderrunCount;
             _endReanchors = s.ReanchorCount;
+            _endHardSyncs = s.HardSyncCount;
             _endCallbackGaps = s.CallbackGapCount;
             _endForgetting = s.AdaptiveForgettingTriggerCount;
             _bytesAtEnd = s.BytesReceived;
         }
+
+        /// <summary>
+        /// Whether the drop/insert movement between two samples belongs to a one-shot hard sync.
+        /// A snap can straddle several ticks (inserting silence is capped at one callback's worth
+        /// per read), so the mode flag on either end of the interval counts, not just the moment
+        /// the counter advanced.
+        /// </summary>
+        private static bool IsHardSyncInterval(in SyncHealthSample s, in SyncHealthSample prev) =>
+            s.HardSyncCount > prev.HardSyncCount
+            || s.CurrentCorrectionMode == SyncCorrectionMode.HardSync
+            || prev.CurrentCorrectionMode == SyncCorrectionMode.HardSync;
 
         /// <summary>Builds a closed <see cref="EpisodeRecord"/> from accumulated state.</summary>
         public readonly EpisodeRecord Build(double durationSeconds) => new()
         {
             StartedAt = _startedAt,
             DurationSeconds = durationSeconds,
-            Drops = _endDrops - _baseline.SamplesDroppedForSync,
-            Inserts = _endInserts - _baseline.SamplesInsertedForSync,
+            Drops = _endDrops - _baseline.SamplesDroppedForSync - _hardSyncDrops,
+            Inserts = _endInserts - _baseline.SamplesInsertedForSync - _hardSyncInserts,
+            HardSyncs = _endHardSyncs - _baseline.HardSyncCount,
             Underruns = _endUnderruns - _baseline.UnderrunCount,
             Reanchors = _endReanchors - _baseline.ReanchorCount,
             CallbackGaps = _endCallbackGaps - _baseline.CallbackGapCount,

--- a/src/Sendspin.Windows.Services/Diagnostics/EpisodeRecord.cs
+++ b/src/Sendspin.Windows.Services/Diagnostics/EpisodeRecord.cs
@@ -17,11 +17,26 @@ public sealed record EpisodeRecord
 
     // Counter deltas accumulated over the episode
 
-    /// <summary>Gets the total count of samples dropped for sync during the episode.</summary>
+    /// <summary>
+    /// Gets the count of samples dropped by <em>continuous</em> sync correction during the
+    /// episode. Samples spliced out by a one-shot hard sync are excluded and counted in
+    /// <see cref="HardSyncs"/> instead: a snap is a deliberate discontinuity, not the steady
+    /// grind that the drift and instability rules read these counters for.
+    /// </summary>
     public long Drops { get; init; }
 
-    /// <summary>Gets the total count of samples inserted for sync during the episode.</summary>
+    /// <summary>
+    /// Gets the count of samples inserted by <em>continuous</em> sync correction during the
+    /// episode. Excludes hard-sync silence for the same reason as <see cref="Drops"/>.
+    /// </summary>
     public long Inserts { get; init; }
+
+    /// <summary>
+    /// Gets the number of one-shot hard syncs applied during the episode. The spec requires
+    /// these to be rare; a count that keeps climbing means the continuous corrector cannot
+    /// keep up with whatever is moving the clock.
+    /// </summary>
+    public long HardSyncs { get; init; }
 
     /// <summary>Gets the total count of audio underruns during the episode.</summary>
     public long Underruns { get; init; }

--- a/src/Sendspin.Windows.Services/Diagnostics/SyncHealthLog.cs
+++ b/src/Sendspin.Windows.Services/Diagnostics/SyncHealthLog.cs
@@ -62,7 +62,7 @@ public sealed class SyncHealthLog
         sb.AppendLine(string.Create(ci,
             $"[{e.StartedAt:yyyy-MM-dd HH:mm:ss}] EPISODE verdict={verdict} duration={e.DurationSeconds:F1}s"));
         sb.AppendLine(string.Create(ci,
-            $"  drops={e.Drops} inserts={e.Inserts} underruns={e.Underruns} reanchors={e.Reanchors} maxSyncErr={e.MaxAbsSyncErrorMs:+0.0;-0.0}ms"));
+            $"  drops={e.Drops} inserts={e.Inserts} hardSyncs={e.HardSyncs} underruns={e.Underruns} reanchors={e.Reanchors} maxSyncErr={e.MaxAbsSyncErrorMs:+0.0;-0.0}ms"));
         sb.AppendLine(string.Create(ci,
             $"  minBuffer={e.MinBufferedMs:F0}ms/{e.TargetMs:F0}ms preRollMinBuffer={e.PreRollMinBufferedMs:F0}ms maxChunkGap={e.MaxChunkGapMs:F0}ms chunkAge={e.MaxChunkAgeMs:F0}ms bytesPerSec={e.BytesPerSecond:F0}"));
         sb.AppendLine(string.Create(ci,

--- a/src/Sendspin.Windows.Services/Diagnostics/SyncHealthMonitor.cs
+++ b/src/Sendspin.Windows.Services/Diagnostics/SyncHealthMonitor.cs
@@ -20,16 +20,18 @@ public sealed class SyncHealthMonitor : IDisposable
 {
     private const int SampleIntervalMs = 100;
 
-    // Matches SyncCorrectionOptions defaults used by the pipeline (syncOptions: null → SDK Default).
-    private const double DeadbandMs = 2.0;
-    private const double MaxSpeedCorrection = 0.02;
+    // A dead band of zero is a legal SDK setting ("always correct") but not a usable episode
+    // threshold — every tick of ordinary jitter would open one. Floor the detector's band here
+    // rather than in the pipeline, which is entitled to correct as tightly as it likes.
+    private const double MinEpisodeDeadbandMs = 0.1;
 
     private readonly IAudioPipeline _pipeline;
     private readonly IClockSynchronizer _clockSync;
     private readonly ReadCallbackGapTracker _gapTracker;
     private readonly SyncHealthLog _log;
     private readonly ILogger<SyncHealthMonitor> _logger;
-    private readonly EpisodeDetector _detector = new(DeadbandMs, MaxSpeedCorrection);
+    private readonly SyncCorrectionOptions _syncOptions;
+    private readonly EpisodeDetector _detector;
     private readonly Timer _timer;
 
     private volatile bool _wasActive;
@@ -51,19 +53,32 @@ public sealed class SyncHealthMonitor : IDisposable
     /// <param name="clockSync">The clock synchronizer to sample.</param>
     /// <param name="gapTracker">The read-callback gap tracker for audio-thread starvation diagnostics.</param>
     /// <param name="log">The sync-health log writer.</param>
+    /// <param name="syncOptions">
+    /// The correction options the pipeline's buffers are built with. The detector judges
+    /// "is the corrector engaged / saturated?" against the thresholds actually in force —
+    /// mirroring them as constants here made the monitor silently wrong whenever either the
+    /// app's configuration or the SDK's defaults moved.
+    /// </param>
     /// <param name="logger">Logger for episode warnings and fault reporting.</param>
     public SyncHealthMonitor(
         IAudioPipeline pipeline,
         IClockSynchronizer clockSync,
         ReadCallbackGapTracker gapTracker,
         SyncHealthLog log,
+        SyncCorrectionOptions syncOptions,
         ILogger<SyncHealthMonitor> logger)
     {
+        ArgumentNullException.ThrowIfNull(syncOptions);
+
         _pipeline = pipeline;
         _clockSync = clockSync;
         _gapTracker = gapTracker;
         _log = log;
+        _syncOptions = syncOptions;
         _logger = logger;
+        _detector = new EpisodeDetector(
+            deadbandMs: Math.Max(syncOptions.DeadbandMicroseconds / 1000.0, MinEpisodeDeadbandMs),
+            maxSpeedCorrection: syncOptions.EffectiveMaxSpeedCorrection);
         _timer = new Timer(OnTick, state: null, dueTime: SampleIntervalMs, period: SampleIntervalMs);
     }
 
@@ -104,6 +119,8 @@ public sealed class SyncHealthMonitor : IDisposable
                 SamplesDroppedForSync = stats.SamplesDroppedForSync,
                 SamplesInsertedForSync = stats.SamplesInsertedForSync,
                 ReanchorCount = stats.ReanchorCount,
+                HardSyncCount = stats.HardSyncCount,
+                CurrentCorrectionMode = stats.CurrentCorrectionMode,
                 TargetPlaybackRate = stats.TargetPlaybackRate,
                 TotalSamplesWritten = stats.TotalSamplesWritten,
                 LastChunkAgeMs = stats.LastChunkAgeMs,
@@ -151,7 +168,10 @@ public sealed class SyncHealthMonitor : IDisposable
         _log.WriteSessionHeader(
             $"app={version} os={Environment.OSVersion.VersionString} " +
             $"format={format?.SampleRate}Hz/{format?.Channels}ch " +
-            $"outputLatency={_pipeline.DetectedOutputLatencyMs}ms");
+            $"outputLatency={_pipeline.DetectedOutputLatencyMs}ms " +
+            $"deadband={_syncOptions.DeadbandMicroseconds / 1000.0:0.###}ms " +
+            $"maxSpeed={_syncOptions.EffectiveMaxSpeedCorrection * 100:0.###}% " +
+            $"hardSync={_syncOptions.HardSyncThresholdMicroseconds / 1000.0:0.#}ms");
     }
 
     private static string Describe(SyncHealthClassification c) => c.Verdict switch

--- a/src/Sendspin.Windows.Services/Diagnostics/SyncHealthSample.cs
+++ b/src/Sendspin.Windows.Services/Diagnostics/SyncHealthSample.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
+using Sendspin.SDK.Audio;
+
 namespace Sendspin.Windows.Services.Diagnostics;
 
 /// <summary>
@@ -35,6 +37,12 @@ public readonly record struct SyncHealthSample
 
     /// <summary>Gets the count of times the buffer was re-anchored.</summary>
     public long ReanchorCount { get; init; }
+
+    /// <summary>Gets the count of one-shot hard syncs the buffer has applied.</summary>
+    public long HardSyncCount { get; init; }
+
+    /// <summary>Gets the correction mode the buffer reports for this tick.</summary>
+    public SyncCorrectionMode CurrentCorrectionMode { get; init; }
 
     /// <summary>Gets the target playback rate for smooth sync correction.</summary>
     public double TargetPlaybackRate { get; init; }

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -332,13 +332,12 @@ public sealed class TrackProgressTracker
             return nowMicroseconds;
         }
 
-        // ServerToClientTime targets audio scheduling and subtracts the configured static
-        // delay (hardware compensation); add it back so the display anchor reflects the
-        // measurement time. Without this, a positive delay runs the bar ahead by the delay
-        // and a negative delay pushes every conversion into the future, permanently
-        // tripping the plausibility guard below.
-        var converted = _clockSynchronizer.ServerToClientTime(serverTimestampMicroseconds.Value)
-            + (long)(_clockSynchronizer.StaticDelayMs * 1000);
+        // The clock offset alone, with no static delay: the seek bar shows when the position
+        // was measured, not when sound leaves the speakers. ServerToClientTime subtracts the
+        // hardware compensation, which would run the bar ahead by a positive delay and push
+        // every conversion into the future for a negative one, permanently tripping the
+        // plausibility guard below.
+        var converted = _clockSynchronizer.ServerToClientTimeUncompensated(serverTimestampMicroseconds.Value);
         var age = nowMicroseconds - converted;
         if (age < 0 || age > MaxAnchorAgeMicroseconds)
         {

--- a/src/Sendspin.Windows/App.xaml.cs
+++ b/src/Sendspin.Windows/App.xaml.cs
@@ -339,6 +339,21 @@ public partial class App : Application
         // DAC clock genuinely diverges from the system clock (most report a 1.0000 ratio = no benefit).
         var useDeviceClock = _configuration!.GetValue("Audio:SyncCorrection:UseDeviceClock", false);
 
+        // Correction-loop knobs, tunable so they can be dialed by ear. The dead band is
+        // deliberately wider than the SDK's 0.1 ms: WASAPI's per-callback jitter is
+        // millisecond-scale, and a tighter band just has the corrector hunting it. The speed cap
+        // is not a comfort setting — it defaults to the spec's 0.5% MUST, and the SDK clamps
+        // anything above that to the cap and logs a warning per stream, so a larger value buys
+        // log noise and nothing else.
+        // Built once and shared: the pipeline's buffers and the sync-health monitor must judge
+        // correction activity against the same numbers. Consumers that need to tweak the options
+        // (WasapiAudioPlayer) clone first, so this instance stays the configured truth.
+        var syncOptions = SyncCorrectionOptions.Default;
+        syncOptions.DeadbandMicroseconds = (long)(_configuration!.GetValue("Audio:SyncCorrection:DeadbandMs", 1.0) * 1000.0);
+        syncOptions.MaxSpeedCorrection = _configuration!.GetValue("Audio:SyncCorrection:MaxSpeedCorrectionPercent", 0.5) / 100.0;
+        syncOptions.CorrectionTargetSeconds = _configuration!.GetValue("Audio:SyncCorrection:CorrectionTargetSeconds", 3.0);
+        services.AddSingleton(syncOptions);
+
         services.AddTransient<IAudioPlayer>(sp =>
         {
             var logger = sp.GetRequiredService<ILogger<WasapiAudioPlayer>>();
@@ -373,14 +388,6 @@ public partial class App : Application
                 clockSync,
                 bufferFactory: (format, sync) =>
                 {
-                    // Correction-loop calming knobs (default to the SDK defaults). A wider deadband
-                    // stops the corrector hunting around small per-callback jitter; a tighter max-rate
-                    // and longer target make any correction gentler. Tunable so it can be dialed by ear.
-                    var syncOptions = SyncCorrectionOptions.Default;
-                    syncOptions.DeadbandMicroseconds = (long)(_configuration!.GetValue("Audio:SyncCorrection:DeadbandMs", 1.0) * 1000.0);
-                    syncOptions.MaxSpeedCorrection = _configuration!.GetValue("Audio:SyncCorrection:MaxSpeedCorrectionPercent", 2.0) / 100.0;
-                    syncOptions.CorrectionTargetSeconds = _configuration!.GetValue("Audio:SyncCorrection:CorrectionTargetSeconds", 3.0);
-
                     var buffer = new TimedAudioBuffer(format, sync, bufferCapacityMs, syncOptions, bufferLogger);
                     buffer.TargetBufferMilliseconds = bufferTargetMs;
                     return buffer;

--- a/src/Sendspin.Windows/App.xaml.cs
+++ b/src/Sendspin.Windows/App.xaml.cs
@@ -237,19 +237,6 @@ public partial class App : Application
         var configuredCapacityMs = _configuration!.GetValue<int>("Audio:Buffer:CapacityMs", 120000);
         var bufferCapacityMs = Math.Max(configuredCapacityMs, minBufferCapacityMs);
 
-        // Derive compressed-byte buffer capacity from our PCM buffer duration.
-        // The server uses this to limit how much audio it sends ahead.
-        // Use worst-case bitrate (PCM uncompressed) so no codec can overflow our buffer.
-        var maxBytesPerSecond = audioFormats
-            .Select(f => f.Codec == "opus" && f.Bitrate > 0
-                ? f.Bitrate * 1000 / 8  // OPUS: use declared bitrate (kbps → bytes/sec)
-                : f.SampleRate * f.Channels * Math.Max(f.BitDepth ?? 16, 16) / 8)  // PCM/FLAC: raw sample rate
-            .Max();
-        var bufferCapacityBytes = (int)((long)bufferCapacityMs * maxBytesPerSecond / 1000);
-        Log.Information(
-            "Buffer: {CapacityMs}ms PCM → {CapacityMB:F1}MB advertised to server (worst-case {MaxKbps}kbps)",
-            bufferCapacityMs, bufferCapacityBytes / 1024.0 / 1024.0, maxBytesPerSecond * 8 / 1000);
-
         // Visualizer (ambient glow) capability — request only loudness + beat features.
         var visualizerRateMax = _configuration!.GetValue<int>("Visualizer:RateMax", 30);
         var visualizerBufferCapacity = _configuration!.GetValue<int>("Visualizer:BufferCapacity", 4096);
@@ -268,7 +255,13 @@ public partial class App : Application
             AudioFormats = audioFormats,
             InitialVolume = playerVolume,
             InitialMuted = playerMuted,
-            BufferCapacity = bufferCapacityBytes,
+
+            // Single source of truth for buffering: the SDK derives the advertised
+            // compressed-byte BufferCapacity from this duration and the advertised formats,
+            // using the *minimum* byte rate across them so the promise holds whichever codec
+            // the server picks (a megabyte of Opus is minutes; of PCM, seconds). The same
+            // value goes to TimedAudioBuffer below, so the two cannot drift apart.
+            AudioBufferCapacityMs = bufferCapacityMs,
             UnpairedAccessEnabled = unpairedAccessEnabled,
 
             // Offer dynamic pairing code alongside the mandatory Pairing PSK method: the
@@ -282,6 +275,10 @@ public partial class App : Application
                 BufferCapacity = visualizerBufferCapacity,
             },
         };
+
+        Log.Information(
+            "Buffer: {CapacityMs}ms decoded → {CapacityMB:F1}MB advertised to server",
+            bufferCapacityMs, clientCapabilities.BufferCapacity / 1024.0 / 1024.0);
 
         // Add the visualizer@v1 role so the server streams loudness/beat frames.
         // (color@v1 is included in the SDK's default roles and needs no explicit add.)

--- a/src/Sendspin.Windows/appsettings.json
+++ b/src/Sendspin.Windows/appsettings.json
@@ -28,7 +28,7 @@
       "ResamplingThresholdMs": 15,
       "UseDeviceClock": false,
       "DeadbandMs": 1,
-      "MaxSpeedCorrectionPercent": 2.0,
+      "MaxSpeedCorrectionPercent": 0.5,
       "CorrectionTargetSeconds": 3.0
     }
   },

--- a/tests/Sendspin.Windows.Services.Tests/Audio/MultiRoomSyncAlignmentTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Audio/MultiRoomSyncAlignmentTests.cs
@@ -164,10 +164,6 @@ public class MultiRoomSyncAlignmentTests
     // property of the code under test. The signal we care about is ~100ms vs ~0ms, not the floor.
     private const double InSyncToleranceMs = 15.0;
 
-    // The threshold above which a player is audibly/measurably off the shared schedule. Huge margin
-    // below the observed ~100ms so the test is about presence-of-misalignment, not a tuning knob.
-    private const double OutOfSyncThresholdMs = 50.0;
-
     /// <summary>
     /// Control: with no drift and no startup offset, the player holds the server schedule exactly
     /// (steady-state sync error ≈ 0). Proves the harness measures real alignment, not noise.
@@ -183,20 +179,22 @@ public class MultiRoomSyncAlignmentTests
     }
 
     /// <summary>
-    /// The box: an uncompensated WASAPI-style prefill leaks straight into the external-correction
-    /// path (ReadRaw never captures the startup baseline that the internal path does), leaving this
-    /// player ~100 ms off the server schedule for the whole session — out of sync with other players.
-    /// This is issue #33's "initial slowdown", and the multi-room-sync risk, measured at the code level.
+    /// Issue #33's "initial slowdown" was an uncompensated WASAPI-style prefill leaking into the
+    /// external-correction path — ReadRaw never captured the startup baseline the internal path
+    /// did — leaving the player ~100 ms off the server schedule for the whole session. The SDK now
+    /// self-measures that residual constant offset at the end of the startup grace period and
+    /// subtracts it, so an app that declares nothing still holds the schedule. This pins the
+    /// recovery: the case that used to prove the box must now come out in sync.
     /// </summary>
     [Fact]
-    public void StartupPrefill_Uncompensated_DriftsOffSchedule()
+    public void StartupPrefill_Uncompensated_IsAbsorbedBySelfMeasuredBaseline()
     {
         var result = RunDriftFreeSession(prefillMicros: 100_000, calibratedStartupMicros: 0, seconds: 20);
 
         Assert.True(
-            Math.Abs(result.FinalSyncErrorMs) > OutOfSyncThresholdMs,
-            $"expected the uncompensated prefill to leave the player far off schedule, " +
-            $"got {result.FinalSyncErrorMs:F1}ms (net correction {result.NetCorrectionMs:F1}ms)");
+            Math.Abs(result.FinalSyncErrorMs) < InSyncToleranceMs,
+            $"the self-measured startup baseline should absorb an undeclared prefill, but the " +
+            $"player settled {result.FinalSyncErrorMs:F1}ms off (net correction {result.NetCorrectionMs:F1}ms)");
     }
 
     /// <summary>

--- a/tests/Sendspin.Windows.Services.Tests/Audio/MultiRoomSyncAlignmentTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Audio/MultiRoomSyncAlignmentTests.cs
@@ -62,6 +62,8 @@ public class MultiRoomSyncAlignmentTests
 
         public long ServerToClientTime(long serverTime) => serverTime + _offset - (long)(StaticDelayMs * 1000);
 
+        public long ServerToClientTimeUncompensated(long serverTime) => serverTime + _offset;
+
         public long ClientToServerTime(long clientTime) => clientTime - _offset + (long)(StaticDelayMs * 1000);
 
         public bool IsConverged => true;

--- a/tests/Sendspin.Windows.Services.Tests/Audio/StaticDelayReanchorTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Audio/StaticDelayReanchorTests.cs
@@ -39,6 +39,8 @@ public class StaticDelayReanchorTests
 
         public long ServerToClientTime(long t) => t + _offset - (long)(StaticDelayMs * 1000);
 
+        public long ServerToClientTimeUncompensated(long t) => t + _offset;
+
         public long ClientToServerTime(long t) => t - _offset + (long)(StaticDelayMs * 1000);
 
         public bool IsConverged => true;

--- a/tests/Sendspin.Windows.Services.Tests/Diagnostics/EpisodeDetectorTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Diagnostics/EpisodeDetectorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
+using Sendspin.SDK.Audio;
 using Sendspin.Windows.Services.Diagnostics;
 using Xunit;
 
@@ -23,6 +24,8 @@ public class EpisodeDetectorTests
         long underruns = 0,
         long reanchors = 0,
         long cbGaps = 0,
+        long hardSyncs = 0,
+        SyncCorrectionMode mode = SyncCorrectionMode.None,
         double rate = 1.0,
         double bufferedMs = 250,
         long totalWritten = 1_000_000) => new()
@@ -34,6 +37,8 @@ public class EpisodeDetectorTests
         UnderrunCount = underruns,
         ReanchorCount = reanchors,
         CallbackGapCount = cbGaps,
+        HardSyncCount = hardSyncs,
+        CurrentCorrectionMode = mode,
         TargetPlaybackRate = rate,
         BufferedMs = bufferedMs,
         TargetMs = 250,
@@ -59,6 +64,7 @@ public class EpisodeDetectorTests
     [InlineData("underruns")]
     [InlineData("reanchors")]
     [InlineData("cbGaps")]
+    [InlineData("hardSyncs")]
     [InlineData("syncErr")]
     [InlineData("rateSaturated")]
     public void EachTrigger_OpensEpisode_AndClosesAfterQuietPeriod(string trigger)
@@ -74,6 +80,7 @@ public class EpisodeDetectorTests
             "underruns" => Sample(100, underruns: 1),
             "reanchors" => Sample(100, reanchors: 1),
             "cbGaps" => Sample(100, cbGaps: 1),
+            "hardSyncs" => Sample(100, hardSyncs: 1),
             "syncErr" => Sample(100, syncErrMs: 2.5),       // > 2.0 deadband
             "rateSaturated" => Sample(100, rate: 1.019),    // ≥ 0.9 * 0.02 away from 1.0
             _ => throw new InvalidOperationException(),
@@ -88,6 +95,7 @@ public class EpisodeDetectorTests
             "underruns" => Sample(0, underruns: 1),
             "reanchors" => Sample(0, reanchors: 1),
             "cbGaps" => Sample(0, cbGaps: 1),
+            "hardSyncs" => Sample(0, hardSyncs: 1),
             _ => Sample(0),
         };
 
@@ -122,6 +130,32 @@ public class EpisodeDetectorTests
         Assert.Equal(40, closed.MinBufferedMs);
         Assert.Equal(25, closed.MaxAbsSyncErrorMs);
         Assert.Equal(1, closed.DirectionFlips);
+    }
+
+    [Fact]
+    public void HardSync_CountedSeparately_NotAsContinuousCorrection()
+    {
+        // The SDK applies a one-shot snap by splicing the buffer timeline, which advances the
+        // same drop/insert counters as continuous correction. Folding it in would invent a
+        // direction flip (reading as clock-sync instability) and inflate the drop/insert rate
+        // the skew rule turns into a ppm estimate — so the snap gets its own counter.
+        var d = NewDetector();
+        d.Observe(Sample(0));
+        d.Observe(Sample(100, drops: 480));                                            // continuous: dropping
+        d.Observe(Sample(200, drops: 480, inserts: 48_000, hardSyncs: 1, mode: SyncCorrectionMode.HardSync));
+        d.Observe(Sample(300, drops: 480, inserts: 52_800, hardSyncs: 1));             // snap tail drains
+
+        EpisodeRecord? closed = null;
+        for (long t = 400; t <= 3_800 && closed is null; t += 100)
+        {
+            closed = d.Observe(Sample(t, drops: 480, inserts: 52_800, hardSyncs: 1));
+        }
+
+        Assert.NotNull(closed);
+        Assert.Equal(1, closed!.HardSyncs);
+        Assert.Equal(480, closed.Drops);
+        Assert.Equal(0, closed.Inserts);
+        Assert.Equal(0, closed.DirectionFlips);
     }
 
     [Fact]

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -495,7 +495,8 @@ public class TrackProgressTrackerTests
     public void StaticDelay_DoesNotShiftDisplayAnchor()
     {
         // ServerToClientTime targets audio scheduling and subtracts the configured static
-        // delay; the display anchor adds it back so the seek bar reflects measurement time.
+        // delay; the display anchor converts with the clock offset alone, so the seek bar
+        // reflects measurement time whatever the hardware delay is set to.
         var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true, StaticDelayMs = 400 };
         var tracker = CreateTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - 200_000);

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -701,8 +701,9 @@ public class TrackProgressTrackerTests
     /// Minimal clock synchronizer with a fixed offset: server = client + offset.
     /// Mirrors the real Kalman contract where <see cref="ServerToClientTime"/> also
     /// subtracts the configured static delay (audio-scheduling compensation), while
-    /// <see cref="ClientToServerTime"/> is the pure domain shift used to fabricate
-    /// server-side measurement timestamps.
+    /// <see cref="ServerToClientTimeUncompensated"/> and <see cref="ClientToServerTime"/>
+    /// are the pure domain shift — exact inverses of each other, used to fabricate
+    /// server-side measurement timestamps and convert them back.
     /// </summary>
     private sealed class FakeClockSynchronizer : IClockSynchronizer
     {
@@ -717,6 +718,8 @@ public class TrackProgressTrackerTests
         public long ClientToServerTime(long clientTime) => clientTime + OffsetMicroseconds;
 
         public long ServerToClientTime(long serverTime) => serverTime - OffsetMicroseconds - (long)(StaticDelayMs * 1000);
+
+        public long ServerToClientTimeUncompensated(long serverTime) => serverTime - OffsetMicroseconds;
 
         public void ProcessMeasurement(long t1, long t2, long t3, long t4)
         {


### PR DESCRIPTION
Adapts Sendspin for Windows to the SDK's sync/audio conformance batch (SDK issues #222-#235, PRs #236/#237/#238), verified against SDK `main` @ `d6f71e9`.

Base is `feat/v10-sdk-surface`, not `master`.

## Changes

**Clock fakes implement `ServerToClientTimeUncompensated`.** SDK 10 splits the server→client conversion: `ServerToClientTime` still subtracts `static_delay_ms` for anything scheduling sound out of the speakers, and the new uncompensated variant is the clock offset alone. All three test fakes already model the static delay, so each got the real conversion (the same linear map without the delay term) rather than an alias — which also makes it the exact inverse of each fake's `ClientToServerTime`.

**Sync speed correction defaults to the spec's 0.5% cap.** `MaxSpeedCorrectionPercent` was 2.0 in both the code fallback and `appsettings.json`. SDK 10 clamps anything above 0.5% to the cap and warns once per stream, so the old default was permanent log noise for zero behavioural difference.

**The sync-health monitor judges against the options actually in force.** It mirrored the correction thresholds as constants (`DeadbandMs = 2.0`, `MaxSpeedCorrection = 0.02`) labelled "matches the pipeline" — they matched neither the app's own configuration (1.0 ms dead band) nor the SDK's defaults, and replacing them with the new numbers would only have re-armed the same trap. `SyncCorrectionOptions` is now built once, registered, and shared by the pipeline's buffers and the monitor, so the detector reads the same instance the corrector runs on. The detector's dead band is floored at 0.1 ms because zero is a legal SDK setting but not a usable episode trigger.

**Hard sync is accounted separately from continuous correction.** The SDK's new one-shot tier (5–500 ms errors) splices samples out of, or silence into, the buffer timeline, which advances the same drop/insert counters the continuous corrector uses. It is a single deliberate discontinuity that the SDK's own `SyncCorrectionCalculator` stands down for — folding it into the continuous aggregates fabricated direction flips (reading as clock-sync instability) and inflated the drop/insert rate the skew rule turns into a ppm estimate. Episodes now carry a `HardSyncs` count, excluded from `Drops`/`Inserts` and from the direction history; it appears in `sync-health.log` and in the evidence string. A snap that straddles several 10 Hz ticks is attributed by `CurrentCorrectionMode` as well as the counter, since inserting silence is capped at one callback's worth per read. The session header now records the dead band, effective cap, and hard-sync threshold so an episode block can be read against the thresholds that produced it.

**Advertised buffer capacity comes from the SDK's derivation.** The compressed-byte figure was hand-derived with `.Max()` over the advertised formats' byte rates — the wrong direction. A megabyte of Opus is minutes and a megabyte of PCM is seconds, so the binding codec is the one that packs the most audio into a byte; taking the maximum sized the promise for PCM and under-protected Opus by roughly six times. `ClientCapabilities.AudioBufferCapacityMs` is now the single source of truth (set to the same duration `TimedAudioBuffer` is built with), and the SDK derives `BufferCapacity` from it using the minimum byte rate. Advertised size drops from ~46 MB to ~3 MB at the default 120 s buffer with Opus advertised — which is what the buffer can actually hold.

**Track progress anchors on the uncompensated conversion.** `TrackProgressTracker` called `ServerToClientTime` and added the static delay back by hand; that is now exactly `ServerToClientTimeUncompensated`. No behaviour change, and the static-delay tests still assert the anchor does not move when the delay does.

**`ci-sdk-dev.yml` defaults to the SDK's `main`.** The `sdk_ref` input defaulted to `dev`, which the SDK repo no longer develops on, so a manual run taking the default would build against a stale ref. Only the default and the comment changed.

## Test suite

`dotnet test -p:UseSdkSource=true -p:SdkSourcePath=…` — **150 passed, 1 failed, 151 total** (from 147/2/149 before).

Tests changed:

- **`MultiRoomSyncAlignmentTests.StartupPrefill_Uncompensated_DriftsOffSchedule` → `…_IsAbsorbedBySelfMeasuredBaseline`** — this asserted that an undeclared WASAPI-style prefill leaves the player >50 ms off the schedule, recording issue #33's "initial slowdown" as an open box. The SDK now self-measures the residual constant offset at the end of the startup grace period and subtracts it, so the session settles at −0.8 ms and the assertion has been failing on its own terms since that landed (it fails identically against NuGet 9.1.0). Inverted to assert the session comes out in sync, so it guards the recovery instead of demanding the defect. `OutOfSyncThresholdMs`, its only user, went with it.
- **`EpisodeDetectorTests`** — added a `hardSyncs` case to the trigger theory and `HardSync_CountedSeparately_NotAsContinuousCorrection`, which pins that a snap lands in `HardSyncs`, stays out of `Drops`/`Inserts`, and produces no direction flip. The `Sample` helper gained `hardSyncs` and `mode` parameters. `EpisodeAggregates_AreCorrect` is the control for the continuous path and is unchanged.
- Comment-only updates in `TrackProgressTrackerTests` and the three clock fakes.

**Still red — pre-existing and unrelated: `DynamicResamplerSampleProviderTests.RateCorrection_ConcealsShortfalls_WithoutSilenceGaps`.** It fails on `master` too, and identically on both SDK lanes. The provider under test takes `correctionProvider: null` and touches no SDK type; the guard `ResamplerShortCount > 0` no longer holds because the drain loop added in `45e7b79` (the resampler-IIR-click work) made the shortfall path unreachable in this scenario. Left alone — relaxing a guard belonging to that work does not belong in an SDK-conformance PR.

## Build lanes

- **SDK source** (`-p:UseSdkSource=true`): 0 errors. No new warning kinds; one fewer (`CS8629`, from the deleted nullable-bitrate arithmetic).
- **NuGet 9.1.0 default lane: still fails, as it already did.** `feat/v10-sdk-surface` fails this lane by design — before this PR, 7 errors in the WPF app project from v10-only APIs (`Sendspin.SDK.Connection.Noise`, `PairingCodePresentation`, `PairingConfigChangedEventArgs`, `PairingGestureRequestedEventArgs`, `SendspinClientOptions`). `Sendspin.Windows.Services` happened to still compile against 9.1.0; it no longer does, because the health monitor and the progress tracker now use `EffectiveMaxSpeedCorrection`, `AudioBufferStats.HardSyncCount`, `SyncCorrectionMode.HardSync`, `HardSyncThresholdMicroseconds`, and `ServerToClientTimeUncompensated`. The branch does not dual-support, so nothing was guarded. No CI lane is affected: `ci.yml` triggers only on push/PR to `master`/`main`.

## Test build

Built through the repo's own packaging path (publish → Inno Setup), skipping only the Azure signing steps:

```
dotnet publish src/Sendspin.Windows/Sendspin.Windows.csproj -c Release -r win-x64 --self-contained false \
  -p:UseSdkSource=true -p:SdkSourcePath=C:/CodeProjects/SendspinSDK-wt-integration \
  -p:Version=0.0.0-sdkdev.d6f71e9 -p:AssemblyVersion=0.0.0.0 -p:FileVersion=0.0.0.0 \
  -o src/Sendspin.Windows/bin/publish/win-x64-framework

dotnet publish src/Sendspin.Windows/Sendspin.Windows.csproj -c Release -r win-x64 --self-contained true \
  -p:PublishSingleFile=false -p:PublishTrimmed=false \
  -p:UseSdkSource=true -p:SdkSourcePath=C:/CodeProjects/SendspinSDK-wt-integration \
  -p:Version=0.0.0-sdkdev.d6f71e9 -p:AssemblyVersion=0.0.0.0 -p:FileVersion=0.0.0.0 \
  -o src/Sendspin.Windows/bin/publish/win-x64-selfcontained

ISCC.exe /DMyAppVersion=0.0.0-sdkdev.d6f71e9 /DBuildType=framework      installer/Sendspin.Windows.iss
ISCC.exe /DMyAppVersion=0.0.0-sdkdev.d6f71e9 /DBuildType=selfcontained  installer/Sendspin.Windows.iss
```

`Sendspin.SDK.dll` in the output carries `0.0.0-sdkdev.d6f71e9+d6f71e92ed8bc145563af173dec7c19cba8bdca8`, i.e. the SDK-source commit, and the published `appsettings.json` carries the new 0.5% default. The same run against the SDK's `main` can be reproduced in CI via the **CI (SDK dev source)** workflow, which now defaults to that ref.

## Noticed, not touched

`7432d76` ("refactor!: rename PIN to pairing code") search-and-replaced two doc comments in `DynamicResamplerSampleProviderTests.cs` into nonsense — "Pins that path" → "PairingCodes that path", and the same at line 135. Comment-only; left for whoever wants to sweep the rename.
