### PR TITLE
refactor: rename static delay to output delay for SDK 10 surface

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -113,7 +113,7 @@ Offset:       can be billions of microseconds - THIS IS NORMAL
 ```
 
 The `IClockSynchronizer` interface provides:
-- `ServerToClientTime(serverTimestamp)` - Convert server time to local playback time (subtracts the configured static delay — audio scheduling semantics)
+- `ServerToClientTime(serverTimestamp)` - Convert server time to local playback time (subtracts the configured output delay — audio scheduling semantics)
 - `GetStatus()` - Current offset, drift rate, and convergence status
 
 **Kalman Configuration** (via appsettings.json):
@@ -304,7 +304,7 @@ Settings are stored in two locations:
     "RetainedFileCount": 5
   },
   "Audio": {
-    "StaticDelayMs": 0,
+    "OutputDelayMs": 0,
     "DeviceId": null,
     "Buffer": {
       "TargetMs": 250,
@@ -350,8 +350,8 @@ Settings are stored in two locations:
 - `SyncCorrection.UseResampling`: Use smooth playback rate adjustment (default: true)
 - `SyncCorrection.ResamplingThresholdMs`: Error threshold for resampling vs drop/insert (default: 15ms)
 
-### Static Delay Tuning
-Per the Sendspin spec (v8.0.0+), positive `StaticDelayMs` compensates for downstream
+### Output Delay Tuning
+Per the Sendspin spec (v8.0.0+), positive `OutputDelayMs` compensates for downstream
 hardware delay (Bluetooth, AV receivers, external amps) by scheduling audio earlier
 from the digital pipeline. The value is SUBTRACTED from converted server timestamps.
 - **Positive values**: Play earlier (if this player is behind others — speaker hardware adds latency)
@@ -360,6 +360,11 @@ from the digital pipeline. The value is SUBTRACTED from converted server timesta
 
 Sign convention flipped in SDK 8.0.0. If you see a "Positive = play later" reference
 anywhere in the codebase, it's stale — the v7 semantic was non-spec.
+
+SDK 10 renamed this setting from "static delay" to "output delay" (C# names and the
+config key; the wire string is still `static_delay_ms`). `Audio:StaticDelayMs` is still
+read as a fallback so an upgraded install keeps its calibrated value — see
+`Configuration/OutputDelaySettings.cs`.
 
 ---
 

--- a/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
+++ b/src/Sendspin.Windows.Services/Playback/TrackProgressTracker.cs
@@ -332,7 +332,7 @@ public sealed class TrackProgressTracker
             return nowMicroseconds;
         }
 
-        // The clock offset alone, with no static delay: the seek bar shows when the position
+        // The clock offset alone, with no output delay: the seek bar shows when the position
         // was measured, not when sound leaves the speakers. ServerToClientTime subtracts the
         // hardware compensation, which would run the bar ahead by a positive delay and push
         // every conversion into the future for a negative one, permanently tripping the

--- a/src/Sendspin.Windows/App.xaml.cs
+++ b/src/Sendspin.Windows/App.xaml.cs
@@ -305,11 +305,9 @@ public partial class App : Application
                 adaptiveCutoff: adaptiveCutoff,
                 minSamplesForForgetting: minSamplesForForgetting);
 
-            // Apply static delay from configuration. Must be non-negative: the Sendspin server
-            // (aiosendspin) validates static_delay_ms in 0-5000 and drops the connection if a client
-            // reports a negative value, so clamp on read (a stale negative config becomes 0).
-            var staticDelayMs = Math.Max(0, _configuration!.GetValue<double>("Audio:StaticDelayMs", 0));
-            clockSync.StaticDelayMs = staticDelayMs;
+            // Apply output delay from configuration (clamped, and migrated from the pre-SDK-10
+            // "Audio:StaticDelayMs" key — see OutputDelaySettings).
+            clockSync.OutputDelayMs = _configuration!.ReadOutputDelayMs();
 
             return clockSync;
         });

--- a/src/Sendspin.Windows/Configuration/OutputDelaySettings.cs
+++ b/src/Sendspin.Windows/Configuration/OutputDelaySettings.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Sendspin.Windows.Configuration;
+
+/// <summary>
+/// Reads the player's output delay from configuration, honouring the pre-SDK-10 key name.
+/// </summary>
+public static class OutputDelaySettings
+{
+    /// <summary>
+    /// Configuration key for the output delay, in milliseconds.
+    /// </summary>
+    public const string Key = "Audio:OutputDelayMs";
+
+    /// <summary>
+    /// Name this setting had before SDK 10 renamed "static delay" to "output delay".
+    /// </summary>
+    public const string LegacyKey = "Audio:StaticDelayMs";
+
+    /// <summary>
+    /// Reads the configured output delay in milliseconds, clamped to the non-negative range
+    /// the server accepts.
+    /// </summary>
+    /// <param name="configuration">The merged application configuration.</param>
+    /// <returns>The output delay in milliseconds, 0 when nothing is configured.</returns>
+    public static double ReadOutputDelayMs(this IConfiguration configuration)
+    {
+        // Config migration: an install that predates the SDK 10 rename has its calibrated
+        // value under the old key in the user's appsettings.json, so fall back to it when
+        // the new key is unset. The shipped appsettings.json deliberately seeds neither key
+        // — a shipped default would shadow the user's old value and defeat the fallback.
+        // The next save writes the new key only, so the old one stops being consulted.
+        var delayMs = configuration.GetValue<double?>(Key)
+            ?? configuration.GetValue<double>(LegacyKey, 0);
+
+        // Must be non-negative: the Sendspin server (aiosendspin) validates the reported
+        // delay in 0-5000 and drops the connection if a client reports a negative value,
+        // so clamp on read (a stale negative config becomes 0).
+        return Math.Max(0, delayMs);
+    }
+}

--- a/src/Sendspin.Windows/MainWindow.xaml
+++ b/src/Sendspin.Windows/MainWindow.xaml
@@ -987,9 +987,9 @@
                                        Foreground="{StaticResource TextMutedBrush}"
                                        Margin="0,8,0,12"/>
 
-                            <!-- Static Delay -->
+                            <!-- Output Delay -->
                             <StackPanel Margin="0,0,0,16">
-                                <TextBlock Text="Static Delay" Style="{StaticResource BodyText}"/>
+                                <TextBlock Text="Output Delay" Style="{StaticResource BodyText}"/>
                                 <TextBlock Text="Compensate for downstream hardware delay (e.g. Bluetooth, AV receivers). Positive = play earlier."
                                            Style="{StaticResource CaptionText}"
                                            Foreground="{StaticResource TextMutedBrush}"
@@ -1006,7 +1006,7 @@
                                     <!-- Decrement button -->
                                     <Button Grid.Column="0"
                                             Content="−"
-                                            Command="{Binding DecrementStaticDelayCommand}"
+                                            Command="{Binding DecrementOutputDelayCommand}"
                                             Width="28" Height="28"
                                             Background="{StaticResource SurfaceBrush}"
                                             Foreground="{StaticResource TextPrimaryBrush}"
@@ -1042,14 +1042,14 @@
                                     <!-- Slider -->
                                     <Slider Grid.Column="1"
                                             Minimum="0" Maximum="5000"
-                                            Value="{Binding SettingsStaticDelayMs}"
+                                            Value="{Binding SettingsOutputDelayMs}"
                                             TickFrequency="500"
                                             IsSnapToTickEnabled="False"
                                             VerticalAlignment="Center"/>
                                     <!-- Increment button -->
                                     <Button Grid.Column="2"
                                             Content="+"
-                                            Command="{Binding IncrementStaticDelayCommand}"
+                                            Command="{Binding IncrementOutputDelayCommand}"
                                             Width="28" Height="28"
                                             Background="{StaticResource SurfaceBrush}"
                                             Foreground="{StaticResource TextPrimaryBrush}"
@@ -1084,7 +1084,7 @@
                                     </Button>
                                     <!-- Editable value -->
                                     <TextBox Grid.Column="3"
-                                             Text="{Binding SettingsStaticDelayMs, UpdateSourceTrigger=PropertyChanged, StringFormat=0}"
+                                             Text="{Binding SettingsOutputDelayMs, UpdateSourceTrigger=PropertyChanged, StringFormat=0}"
                                              Width="60"
                                              Background="{StaticResource SurfaceBrush}"
                                              Foreground="{StaticResource TextPrimaryBrush}"

--- a/src/Sendspin.Windows/MainWindow.xaml.cs
+++ b/src/Sendspin.Windows/MainWindow.xaml.cs
@@ -119,11 +119,11 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Validates that only non-negative numeric input is entered in the TextBox.
-    /// Used by the Static Delay field, which the server requires to be 0 or greater.
+    /// Used by the Output Delay field, which the server requires to be 0 or greater.
     /// </summary>
     private void NumericTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
     {
-        // Digits only — no minus sign: static delay must be non-negative (server rejects negatives).
+        // Digits only — no minus sign: output delay must be non-negative (server rejects negatives).
         foreach (char c in e.Text)
         {
             if (!char.IsDigit(c))

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -46,14 +46,14 @@ public partial class MainViewModel : ViewModelBase
     private const int PositionTimerIntervalMs = 250;
 
     /// <summary>
-    /// Debounce delay in milliseconds before clearing the audio buffer after static delay changes.
+    /// Debounce delay in milliseconds before clearing the audio buffer after output delay changes.
     /// Prevents excessive buffer clears while the user is actively adjusting the slider.
     /// </summary>
-    private const int StaticDelayClearDebounceMs = 300;
+    private const int OutputDelayClearDebounceMs = 300;
 
     /// <summary>
     /// Debounce delay in milliseconds before auto-saving settings changes.
-    /// Used for static delay, player name, and other settings that auto-save.
+    /// Used for output delay, player name, and other settings that auto-save.
     /// </summary>
     private const int SettingsAutoSaveDebounceMs = 1000;
 
@@ -283,11 +283,11 @@ public partial class MainViewModel : ViewModelBase
     private bool _settingsEnableConsoleLogging;
 
     /// <summary>
-    /// Gets or sets the static delay in milliseconds for audio sync tuning.
+    /// Gets or sets the output delay in milliseconds for audio sync tuning.
     /// Positive values delay playback (play later), negative advance it (play earlier).
     /// </summary>
     [ObservableProperty]
-    private double _settingsStaticDelayMs;
+    private double _settingsOutputDelayMs;
 
     /// <summary>
     /// Gets or sets whether notifications are enabled.
@@ -877,19 +877,19 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private async Task SendPlayerStateToActiveClientAsync(int volume, bool muted)
     {
-        var staticDelay = SettingsStaticDelayMs;
+        var outputDelay = SettingsOutputDelayMs;
 
         // Prefer manual client (discovery/manual connection mode)
         if (_manualClient?.ConnectionState == ConnectionState.Connected)
         {
             _logger.LogDebug("Sending player state via manual client: Volume={Volume}, Muted={Muted}", volume, muted);
-            await _manualClient.SendPlayerStateAsync(volume, muted, staticDelay);
+            await _manualClient.SendPlayerStateAsync(volume, muted, outputDelay);
         }
         // Fall back to host service (server-initiated connection mode)
         else if (ConnectedServers.Count > 0)
         {
             _logger.LogDebug("Sending player state via host service: Volume={Volume}, Muted={Muted}", volume, muted);
-            await _hostService.SendPlayerStateAsync(volume, muted, staticDelay);
+            await _hostService.SendPlayerStateAsync(volume, muted, outputDelay);
         }
         else
         {
@@ -1853,42 +1853,42 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(CurrentGroupTooltip));
     }
 
-    private CancellationTokenSource? _staticDelayClearCts;
-    private CancellationTokenSource? _staticDelaySaveCts;
+    private CancellationTokenSource? _outputDelayClearCts;
+    private CancellationTokenSource? _outputDelaySaveCts;
     private CancellationTokenSource? _playerNameSaveCts;
 
     /// <summary>
-    /// Called when the static delay setting changes.
+    /// Called when the output delay setting changes.
     /// Applies the new delay immediately to the clock synchronizer.
     /// Buffer clear and save are debounced to avoid issues while dragging slider.
     /// </summary>
-    partial void OnSettingsStaticDelayMsChanged(double value)
+    partial void OnSettingsOutputDelayMsChanged(double value)
     {
-        // Static delay must be non-negative — the server rejects a negative static_delay_ms
+        // Output delay must be non-negative — the server rejects a negative static_delay_ms
         // (valid range 0-5000) and drops the connection. Clamp before applying/persisting.
         value = Math.Max(0, value);
 
         // Apply delay value immediately (this is cheap)
-        _clockSynchronizer.StaticDelayMs = value;
+        _clockSynchronizer.OutputDelayMs = value;
 
         // Debounce the re-anchor - only apply after the user stops adjusting the slider.
         // Re-anchor (not Clear): applies the new delay to the already-buffered audio in place.
         // Clear() would dump the buffer and, with a server that transmits far ahead of playback,
         // stall for the full transmit-ahead window (tens of seconds of silence) while it refills.
-        _staticDelayClearCts?.Cancel();
-        _staticDelayClearCts?.Dispose();
-        _staticDelayClearCts = new CancellationTokenSource();
-        var clearCts = _staticDelayClearCts;
+        _outputDelayClearCts?.Cancel();
+        _outputDelayClearCts?.Dispose();
+        _outputDelayClearCts = new CancellationTokenSource();
+        var clearCts = _outputDelayClearCts;
 
         _ = Task.Run(async () =>
         {
             try
             {
-                await Task.Delay(StaticDelayClearDebounceMs, clearCts.Token);
+                await Task.Delay(OutputDelayClearDebounceMs, clearCts.Token);
                 if (!clearCts.Token.IsCancellationRequested)
                 {
                     _audioPipeline.ReanchorTiming();
-                    _logger.LogDebug("Static delay changed to {DelayMs}ms, sync timing re-anchored (buffer preserved)", value);
+                    _logger.LogDebug("Output delay changed to {DelayMs}ms, sync timing re-anchored (buffer preserved)", value);
                 }
             }
             catch (OperationCanceledException)
@@ -1898,10 +1898,10 @@ public partial class MainViewModel : ViewModelBase
         });
 
         // Debounce auto-save - save after user stops adjusting the slider
-        _staticDelaySaveCts?.Cancel();
-        _staticDelaySaveCts?.Dispose();
-        _staticDelaySaveCts = new CancellationTokenSource();
-        var saveCts = _staticDelaySaveCts;
+        _outputDelaySaveCts?.Cancel();
+        _outputDelaySaveCts?.Dispose();
+        _outputDelaySaveCts = new CancellationTokenSource();
+        var saveCts = _outputDelaySaveCts;
 
         _ = Task.Run(async () =>
         {
@@ -1910,7 +1910,7 @@ public partial class MainViewModel : ViewModelBase
                 await Task.Delay(SettingsAutoSaveDebounceMs, saveCts.Token);
                 if (!saveCts.Token.IsCancellationRequested)
                 {
-                    await SaveStaticDelayAsync(value);
+                    await SaveOutputDelayAsync(value);
                 }
             }
             catch (OperationCanceledException)
@@ -1921,18 +1921,18 @@ public partial class MainViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Saves only the static delay setting to user appsettings.json.
+    /// Saves only the output delay setting to user appsettings.json.
     /// </summary>
-    private async Task SaveStaticDelayAsync(double value)
+    private async Task SaveOutputDelayAsync(double value)
     {
         try
         {
-            await _settingsService.UpdateSettingAsync("Audio", "StaticDelayMs", value);
-            _logger.LogInformation("Static delay saved: {DelayMs}ms", value);
+            await _settingsService.UpdateSettingAsync("Audio", "OutputDelayMs", value);
+            _logger.LogInformation("Output delay saved: {DelayMs}ms", value);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to auto-save static delay");
+            _logger.LogWarning(ex, "Failed to auto-save output delay");
         }
     }
 
@@ -2352,7 +2352,7 @@ public partial class MainViewModel : ViewModelBase
         SettingsEnableConsoleLogging = settings.EnableConsoleLogging;
 
         // Load audio settings
-        SettingsStaticDelayMs = Math.Max(0, _configuration.GetValue<double>("Audio:StaticDelayMs", 0));
+        SettingsOutputDelayMs = _configuration.ReadOutputDelayMs();
 
         // Load persisted player volume/mute (these get applied via OnVolumeChanged/OnIsMutedChanged).
         // 50% is the default when nothing has been saved/overridden yet.
@@ -2469,21 +2469,21 @@ public partial class MainViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Increments the static delay by 10ms.
+    /// Increments the output delay by 10ms.
     /// </summary>
     [RelayCommand]
-    private void IncrementStaticDelay()
+    private void IncrementOutputDelay()
     {
-        SettingsStaticDelayMs = Math.Min(5000, SettingsStaticDelayMs + 10);
+        SettingsOutputDelayMs = Math.Min(5000, SettingsOutputDelayMs + 10);
     }
 
     /// <summary>
-    /// Decrements the static delay by 10ms.
+    /// Decrements the output delay by 10ms.
     /// </summary>
     [RelayCommand]
-    private void DecrementStaticDelay()
+    private void DecrementOutputDelay()
     {
-        SettingsStaticDelayMs = Math.Max(0, SettingsStaticDelayMs - 10);
+        SettingsOutputDelayMs = Math.Max(0, SettingsOutputDelayMs - 10);
     }
 
     /// <summary>
@@ -2618,7 +2618,7 @@ public partial class MainViewModel : ViewModelBase
 
             // Update audio section
             var audioSection = root["Audio"]?.AsObject() ?? new JsonObject();
-            audioSection["StaticDelayMs"] = SettingsStaticDelayMs;
+            audioSection["OutputDelayMs"] = SettingsOutputDelayMs;
             audioSection["DeviceId"] = SettingsSelectedAudioDevice?.DeviceId;
             var preferredCodec = SettingsStreamType.StartsWith("FLAC", StringComparison.OrdinalIgnoreCase) ? "flac" : "opus";
             audioSection["PreferredCodec"] = preferredCodec;
@@ -2675,8 +2675,8 @@ public partial class MainViewModel : ViewModelBase
                 _logger.LogInformation("Player name changed to: {PlayerName}", SettingsPlayerName);
             }
 
-            _logger.LogInformation("Settings saved: LogLevel={LogLevel}, FileLogging={FileLogging}, ConsoleLogging={ConsoleLogging}, StaticDelayMs={StaticDelayMs}, Notifications={Notifications}, Discord={Discord}, MediaKeys={MediaKeys}, PlayerName={PlayerName}, DeviceId={DeviceId}, StartMinimized={StartMinimized}",
-                SettingsLogLevel, SettingsEnableFileLogging, SettingsEnableConsoleLogging, SettingsStaticDelayMs, SettingsShowNotifications, SettingsShowDiscordPresence, SettingsEnableMediaKeys, SettingsPlayerName, SettingsSelectedAudioDevice?.DeviceId ?? "default", SettingsStartMinimized);
+            _logger.LogInformation("Settings saved: LogLevel={LogLevel}, FileLogging={FileLogging}, ConsoleLogging={ConsoleLogging}, OutputDelayMs={OutputDelayMs}, Notifications={Notifications}, Discord={Discord}, MediaKeys={MediaKeys}, PlayerName={PlayerName}, DeviceId={DeviceId}, StartMinimized={StartMinimized}",
+                SettingsLogLevel, SettingsEnableFileLogging, SettingsEnableConsoleLogging, SettingsOutputDelayMs, SettingsShowNotifications, SettingsShowDiscordPresence, SettingsEnableMediaKeys, SettingsPlayerName, SettingsSelectedAudioDevice?.DeviceId ?? "default", SettingsStartMinimized);
 
             // Close settings panel first
             IsSettingsOpen = false;
@@ -2917,11 +2917,11 @@ public partial class MainViewModel : ViewModelBase
         _volumeSaveCts?.Dispose();
         _volumeSaveCts = null;
 
-        // Cancel any pending static delay debounce
-        _staticDelayClearCts?.Cancel();
-        _staticDelayClearCts?.Dispose();
-        _staticDelaySaveCts?.Cancel();
-        _staticDelaySaveCts?.Dispose();
+        // Cancel any pending output delay debounce
+        _outputDelayClearCts?.Cancel();
+        _outputDelayClearCts?.Dispose();
+        _outputDelaySaveCts?.Cancel();
+        _outputDelaySaveCts?.Dispose();
 
         // Stop server discovery
         await _serverDiscovery.StopAsync();

--- a/src/Sendspin.Windows/ViewModels/StatsViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/StatsViewModel.cs
@@ -210,10 +210,10 @@ public partial class StatsViewModel : ViewModelBase
     private Brush _driftReliableColor = ValueMuted;
 
     /// <summary>
-    /// Gets the static delay display string.
+    /// Gets the output delay display string.
     /// </summary>
     [ObservableProperty]
-    private string _staticDelayDisplay = "0 ms";
+    private string _outputDelayDisplay = "0 ms";
 
     /// <summary>
     /// Gets the detected output latency display string.
@@ -563,8 +563,8 @@ public partial class StatsViewModel : ViewModelBase
             DriftReliableColor = ValueMuted;
         }
 
-        // Static delay (from clock synchronizer)
-        StaticDelayDisplay = $"{_clockSynchronizer.StaticDelayMs:+0;-0;0} ms";
+        // Output delay (from clock synchronizer)
+        OutputDelayDisplay = $"{_clockSynchronizer.OutputDelayMs:+0;-0;0} ms";
 
         // Detected output latency (from audio pipeline)
         var detectedLatency = _audioPipeline.DetectedOutputLatencyMs;

--- a/src/Sendspin.Windows/Views/StatsWindow.xaml
+++ b/src/Sendspin.Windows/Views/StatsWindow.xaml
@@ -265,8 +265,8 @@
                         <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding OutputLatencyDisplay}" Style="{StaticResource StatValue}" Margin="0,8,0,0"
                                    Foreground="{StaticResource WarningBrush}"/>
 
-                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Static Delay" Style="{StaticResource StatLabel}" Margin="0,8,0,0"/>
-                        <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding StaticDelayDisplay}" Style="{StaticResource StatValue}" Margin="0,8,0,0"
+                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Output Delay" Style="{StaticResource StatLabel}" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding OutputDelayDisplay}" Style="{StaticResource StatValue}" Margin="0,8,0,0"
                                    Foreground="{StaticResource AccentBrush}"/>
                     </Grid>
                 </Border>

--- a/src/Sendspin.Windows/appsettings.json
+++ b/src/Sendspin.Windows/appsettings.json
@@ -10,7 +10,6 @@
   },
   "Audio": {
     "PreferredCodec": "flac",
-    "StaticDelayMs": 0,
     "Buffer": {
       "TargetMs": 250,
       "CapacityMs": 120000

--- a/tests/Sendspin.Windows.Services.Tests/Audio/MultiRoomSyncAlignmentTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Audio/MultiRoomSyncAlignmentTests.cs
@@ -54,17 +54,17 @@ public class MultiRoomSyncAlignmentTests
     /// </summary>
     private sealed class FixedOffsetClock : IClockSynchronizer
     {
-        private readonly long _offset; // ServerToClientTime(t) = t + offset (minus StaticDelay)
+        private readonly long _offset; // ServerToClientTime(t) = t + offset (minus OutputDelay)
 
         public FixedOffsetClock(long offset) => _offset = offset;
 
-        public double StaticDelayMs { get; set; }
+        public double OutputDelayMs { get; set; }
 
-        public long ServerToClientTime(long serverTime) => serverTime + _offset - (long)(StaticDelayMs * 1000);
+        public long ServerToClientTime(long serverTime) => serverTime + _offset - (long)(OutputDelayMs * 1000);
 
         public long ServerToClientTimeUncompensated(long serverTime) => serverTime + _offset;
 
-        public long ClientToServerTime(long clientTime) => clientTime - _offset + (long)(StaticDelayMs * 1000);
+        public long ClientToServerTime(long clientTime) => clientTime - _offset + (long)(OutputDelayMs * 1000);
 
         public bool IsConverged => true;
 

--- a/tests/Sendspin.Windows.Services.Tests/Audio/OutputDelayReanchorTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Audio/OutputDelayReanchorTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="StaticDelayReanchorTests.cs" company="Sendspin Windows Client">
+// <copyright file="OutputDelayReanchorTests.cs" company="Sendspin Windows Client">
 // Licensed under the MIT License. See LICENSE file in the project root.
 // </copyright>
 
@@ -11,16 +11,16 @@ using Xunit;
 namespace Sendspin.Windows.Services.Tests.Audio;
 
 /// <summary>
-/// Guards the static-delay-change fix: re-anchoring timing must preserve buffered audio so a delay
+/// Guards the output-delay-change fix: re-anchoring timing must preserve buffered audio so a delay
 /// tweak applies in place, instead of dumping the buffer (which, with a server that transmits far
 /// ahead of playback, stalls for the whole transmit-ahead window — the 30-second silence).
 /// </summary>
 /// <remarks>
-/// The app's <c>OnSettingsStaticDelayMsChanged</c> previously called <c>IAudioPipeline.Clear()</c>;
+/// The app's <c>OnSettingsOutputDelayMsChanged</c> previously called <c>IAudioPipeline.Clear()</c>;
 /// it now calls <c>ReanchorTiming()</c>, which forwards to <see cref="TimedAudioBuffer.ResetSyncTracking"/>.
 /// These tests exercise that buffer primitive directly (the property the pipeline passthrough relies on).
 /// </remarks>
-public class StaticDelayReanchorTests
+public class OutputDelayReanchorTests
 {
     private const int Rate = 48000;
     private const int Ch = 2;
@@ -35,13 +35,13 @@ public class StaticDelayReanchorTests
 
         public FixedClock(long offset) => _offset = offset;
 
-        public double StaticDelayMs { get; set; }
+        public double OutputDelayMs { get; set; }
 
-        public long ServerToClientTime(long t) => t + _offset - (long)(StaticDelayMs * 1000);
+        public long ServerToClientTime(long t) => t + _offset - (long)(OutputDelayMs * 1000);
 
         public long ServerToClientTimeUncompensated(long t) => t + _offset;
 
-        public long ClientToServerTime(long t) => t - _offset + (long)(StaticDelayMs * 1000);
+        public long ClientToServerTime(long t) => t - _offset + (long)(OutputDelayMs * 1000);
 
         public bool IsConverged => true;
 
@@ -93,9 +93,9 @@ public class StaticDelayReanchorTests
         var (buffer, clock) = SetupPlaying();
         Assert.True(buffer.BufferedMilliseconds > 1000, "precondition: a deep buffer is present");
 
-        // Apply a static-delay change the way the fixed app does: shift the clock, then re-anchor
+        // Apply an output-delay change the way the fixed app does: shift the clock, then re-anchor
         // (instead of Clear). This is what runs when the user moves the offset slider.
-        clock.StaticDelayMs = 200;
+        clock.OutputDelayMs = 200;
         buffer.ResetSyncTracking();
 
         // The whole point of the fix: the buffered audio survives, so there is nothing to re-fetch
@@ -116,7 +116,7 @@ public class StaticDelayReanchorTests
         var (buffer, _) = SetupPlaying();
         Assert.True(buffer.BufferedMilliseconds > 1000);
 
-        // The old static-delay path. Clear dumps everything; with a far-ahead server the only audio
+        // The old output-delay path. Clear dumps everything; with a far-ahead server the only audio
         // that refills is future-timestamped, so playback waits the transmit-ahead window in silence.
         buffer.Clear();
 

--- a/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Playback/TrackProgressTrackerTests.cs
@@ -492,12 +492,12 @@ public class TrackProgressTrackerTests
     }
 
     [Fact]
-    public void StaticDelay_DoesNotShiftDisplayAnchor()
+    public void OutputDelay_DoesNotShiftDisplayAnchor()
     {
         // ServerToClientTime targets audio scheduling and subtracts the configured static
         // delay; the display anchor converts with the clock offset alone, so the seek bar
         // reflects measurement time whatever the hardware delay is set to.
-        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true, StaticDelayMs = 400 };
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true, OutputDelayMs = 400 };
         var tracker = CreateTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - 200_000);
 
@@ -507,11 +507,11 @@ public class TrackProgressTrackerTests
     }
 
     [Fact]
-    public void NegativeStaticDelay_StillUsesServerAnchor()
+    public void NegativeOutputDelay_StillUsesServerAnchor()
     {
         // A negative delay used to push every converted anchor into the future, tripping
         // the plausibility guard so the spec-anchor path silently never engaged.
-        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true, StaticDelayMs = -400 };
+        var sync = new FakeClockSynchronizer { OffsetMicroseconds = 7_000_000_000_000L, IsConverged = true, OutputDelayMs = -400 };
         var tracker = CreateTracker(sync);
         var measuredAt = sync.ClientToServerTime(T0 - 200_000);
 
@@ -701,7 +701,7 @@ public class TrackProgressTrackerTests
     /// <summary>
     /// Minimal clock synchronizer with a fixed offset: server = client + offset.
     /// Mirrors the real Kalman contract where <see cref="ServerToClientTime"/> also
-    /// subtracts the configured static delay (audio-scheduling compensation), while
+    /// subtracts the configured output delay (audio-scheduling compensation), while
     /// <see cref="ServerToClientTimeUncompensated"/> and <see cref="ClientToServerTime"/>
     /// are the pure domain shift — exact inverses of each other, used to fabricate
     /// server-side measurement timestamps and convert them back.
@@ -714,11 +714,11 @@ public class TrackProgressTrackerTests
 
         public bool HasMinimalSync => IsConverged;
 
-        public double StaticDelayMs { get; set; }
+        public double OutputDelayMs { get; set; }
 
         public long ClientToServerTime(long clientTime) => clientTime + OffsetMicroseconds;
 
-        public long ServerToClientTime(long serverTime) => serverTime - OffsetMicroseconds - (long)(StaticDelayMs * 1000);
+        public long ServerToClientTime(long serverTime) => serverTime - OffsetMicroseconds - (long)(OutputDelayMs * 1000);
 
         public long ServerToClientTimeUncompensated(long serverTime) => serverTime - OffsetMicroseconds;
 


### PR DESCRIPTION
Follows SDK PR #243 (sendspin-dotnet `main` @ c3fabd6), which renamed the public "static delay" surface to "output delay". C# names only — the wire is untouched (`client/state` still carries `static_delay_ms`).

## Rename table, as applied to this app

| SDK symbol | Was | Now |
|---|---|---|
| `IClockSynchronizer` / `KalmanClockSynchronizer` | `StaticDelayMs` | `OutputDelayMs` |
| `ISendspinClient.SendPlayerStateAsync` / `SendspinHostService.SendPlayerStateAsync` | `staticDelayMs` arg | `outputDelayMs` arg |

`ClientCapabilities.SupportsSetStaticDelay`, `SendspinClientOptions.StaticDelayStore` and `IStaticDelayStore` are in the SDK's migration table but are not used by this app — nothing to change.

App-internal names followed the SDK vocabulary (the app tracks SDK/spec naming, as it did for PIN → pairing code):

| App identifier | Was | Now |
|---|---|---|
| `MainViewModel` property | `SettingsStaticDelayMs` | `SettingsOutputDelayMs` |
| `MainViewModel` commands | `Increment/DecrementStaticDelayCommand` | `Increment/DecrementOutputDelayCommand` |
| `MainViewModel` change handler / save | `OnSettingsStaticDelayMsChanged`, `SaveStaticDelayAsync` | `OnSettingsOutputDelayMsChanged`, `SaveOutputDelayAsync` |
| `MainViewModel` debounce field/const | `_staticDelay*Cts`, `StaticDelayClearDebounceMs` | `_outputDelay*Cts`, `OutputDelayClearDebounceMs` |
| `StatsViewModel` property | `StaticDelayDisplay` | `OutputDelayDisplay` |
| Test class/file | `StaticDelayReanchorTests` | `OutputDelayReanchorTests` |

User-visible labels: **Static Delay → Output Delay** in the Settings panel (`MainWindow.xaml`) and in Stats for Nerds (`Views/StatsWindow.xaml`).

## Config migration

`Audio:StaticDelayMs` → **`Audio:OutputDelayMs`**.

New `Configuration/OutputDelaySettings.ReadOutputDelayMs(IConfiguration)` is the single read point (used by `App.xaml.cs`'s clock-sync factory and `MainViewModel.LoadLoggingSettings`). It reads the new key and falls back to the old one when the new key is unset, so an existing install keeps its calibrated delay. It also carries the non-negative clamp that both call sites had.

Writes only ever use the new key (`SaveOutputDelayAsync`, `SaveSettingsAsync`), so the first save after upgrade migrates the user's `%LOCALAPPDATA%` settings file.

**One deliberate deviation:** the shipped `appsettings.json` no longer seeds a delay key *at all*, where it previously carried `"StaticDelayMs": 0`. It cannot seed `"OutputDelayMs": 0` — the install-directory `appsettings.json` is layered *under* the user's file, so a shipped `0` would always satisfy the new key, the fallback would never fire, and every upgraded install would silently lose its calibrated delay. With neither key seeded, "unset" is genuine and the fallback is exact; the read path already defaults to 0. The key stays documented in `claude.md`.

## Build lanes

| Lane | Command | Result |
|---|---|---|
| SDK source (what CI uses — `.github/workflows/ci-sdk-dev.yml`, default ref `main`) | `dotnet build -p:UseSdkSource=true -p:SdkSourcePath=<sdk>` | **Build succeeded — 0 errors** (6 errors before this change) |
| NuGet package (`Sendspin.SDK` 9.1.0) | `dotnet build` | **7 errors — unchanged from the base commit** |

The NuGet lane was already red on `feat/v10-sdk-surface` before this change, with the same 7 errors, none of them delay-related: `SyncCorrectionOptions.EffectiveMaxSpeedCorrection` / `.HardSyncThresholdMicroseconds`, `AudioBufferStats.HardSyncCount`, `SyncCorrectionMode.HardSync`, `IClockSynchronizer.ServerToClientTimeUncompensated` — all v10 APIs absent from the pinned 9.1.0 package. This branch is SDK-main-tracking, so that lane stays red until the 10.x package ships and the `PackageReference` version is bumped. No attempt was made to compile against both name sets.

## Tests

`dotnet test -p:UseSdkSource=true -p:SdkSourcePath=<sdk>`

```
Failed:     1, Passed:   150, Skipped:     0, Total:   151
```

The single failure is the known-red `DynamicResamplerSampleProviderTests.RateCorrection_ConcealsShortfalls_WithoutSilenceGaps` ("test did not exercise the resampler-short path" — resampler-drain workstream, not this change).

No differential against the base commit is possible: at 310dbfd *neither* lane built, so the suite could not run there at all (SDK-source lane failed to compile the test project on `IClockSynchronizer.OutputDelayMs`; NuGet lane failed to compile `Sendspin.Windows.Services`, which the test project references). Every one of the 150 passing tests is newly runnable on this branch.
