### PR TITLE
fix: cap advertised FLAC bit depth at 24

### DIFF
--- a/src/Sendspin.Windows/Configuration/AudioFormatBuilder.cs
+++ b/src/Sendspin.Windows/Configuration/AudioFormatBuilder.cs
@@ -20,6 +20,18 @@ namespace Sendspin.Windows.Configuration;
 public static class AudioFormatBuilder
 {
     /// <summary>
+    /// Highest bit depth advertised for FLAC.
+    /// </summary>
+    /// <remarks>
+    /// WASAPI's MixFormat reports 32 bits because the Windows audio engine mixes in 32-bit FLOAT.
+    /// That is a container width, not a PCM sample depth. Advertising flac/32 makes the entry
+    /// unencodable for servers whose FLAC encoder tops out at 24-bit (ffmpeg, among others), and
+    /// they drop it silently — costing us the hi-res lossless option and falling back to 48kHz/16.
+    /// PCM keeps the native depth, since 32-bit integer PCM encodes fine.
+    /// </remarks>
+    private const int MaxFlacBitDepth = 24;
+
+    /// <summary>
     /// Builds a list of audio formats to advertise to the server.
     /// </summary>
     /// <param name="capabilities">The device's native audio capabilities.</param>
@@ -38,16 +50,19 @@ public static class AudioFormatBuilder
         // SDK's PcmDecoder already reads 32-bit via ReadInt32LittleEndian.
         var bitDepth = capabilities.NativeBitDepth;
 
+        // FLAC caps at 24-bit; see MaxFlacBitDepth.
+        var flacBitDepth = Math.Min(bitDepth, MaxFlacBitDepth);
+
         // Preferred codec first at native resolution
         if (preferredCodec == "flac")
         {
-            // FLAC supports any sample rate and bit depth
+            // FLAC supports any sample rate, up to the encodable bit depth
             formats.Add(new AudioFormat
             {
                 Codec = "flac",
                 SampleRate = sampleRate,
                 Channels = 2,
-                BitDepth = bitDepth,
+                BitDepth = flacBitDepth,
             });
 
             // Opus is capped at 48kHz per codec specification
@@ -76,7 +91,7 @@ public static class AudioFormatBuilder
                 Codec = "flac",
                 SampleRate = sampleRate,
                 Channels = 2,
-                BitDepth = bitDepth,
+                BitDepth = flacBitDepth,
             });
         }
 


### PR DESCRIPTION
Fixes #72.

## The bug

`QueryDeviceCapabilities` reads `MixFormat.BitsPerSample`, which returns **32 because the Windows audio engine mixes in 32-bit float** — a container width, not a PCM sample depth. `AudioFormatBuilder` passed it straight into the protocol's `bit_depth` field, which means bits per PCM sample.

PCM is unaffected (32-bit integer PCM encodes fine). FLAC is not: servers whose FLAC encoder caps at 24-bit cannot use the entry, drop it silently, and negotiation falls back to 48 kHz/16-bit. A 192 kHz-capable DAC quietly gets 48 kHz.

## Evidence

Of the five formats advertised, Music Assistant's format picker listed four — in our order — and omitted exactly one:

| Advertised | MA offered |
|---|---|
| `flac 192000/32` | **— dropped —** |
| `opus 48000/16` | OPUS 48kHz/16bit |
| `pcm 192000/32` | PCM 192kHz/32bit |
| `flac 48000/16` | FLAC 48kHz/16bit |
| `pcm 48000/16` | PCM 48kHz/16bit |

It kept `pcm 192000/32`, so neither 192 kHz nor 32-bit is the problem alone — only FLAC + 32-bit. An exclusive-mode `IsFormatSupported` probe of the same endpoint reports `32-bit no` at every rate, so the hardware never wanted it either.

## The change

One constant and one `Math.Min`. The two native-resolution FLAC entries cap at 24 bits; PCM keeps native depth; the hardcoded 48 kHz/16-bit fallbacks are untouched.

No duplicate entries are introduced — the fallback block still keys off native `bitDepth`, so a 48 kHz/16-bit device produces the same list as before.

## Testing

`Sendspin.Windows` has no test project (the services test project deliberately does not reference the WPF app), so there is no unit coverage to add here. Verification is empirical:

- Solution builds clean, 0 errors.
- Test suite unchanged: 155 passed, 2 failed — both failures pre-existing on master and unrelated (`DynamicResamplerSampleProviderTests`, `MultiRoomSyncAlignmentTests`).
- Manual: confirm `client/hello` advertises `flac/<native>/24` and that the server's format picker now offers hi-res FLAC.

## Impact

Hi-res lossless becomes selectable. At 192 kHz that is roughly 5 Mbps for FLAC/24 versus ~12.3 Mbps for the PCM/32 workaround, for identical audio.
