### PR TITLE
fix: use exactly one connection transport at a time (forward-port of #78)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -103,8 +103,16 @@ mode.**
 - Advertises as `_sendspin._tcp.local` with a required `path` TXT record
 - Music Assistant servers discover and connect to us
 - Server admission (which server wins when several connect) is arbitrated inside the SDK's
-  `SendspinHostService` using activity ranking and the `LastPlayedServerId` tiebreak — the app
-  does no arbitration of its own
+  `SendspinHostService` — the app does no arbitration of its own, and must not reimplement or
+  override it
+- What the spec defines vs. what ships today:
+  - **Spec:** admission is ranked by connection *activity* — `management` > `playback` >
+    `pairing` — with a new connection held provisional until the server sends
+    `server/activate`, and dropped after 30s if it never does.
+  - **SDK 9.3.0 (the version this branch builds against):** arbitration is the earlier
+    `connection_reason` comparison — `"playback"` beats `"discovery"` — with
+    `LastPlayedServerId` breaking ordinary ties. Activity-based arbitration arrives with the
+    v10 SDK; until then, do not write app code that assumes it.
 - Discovery of `_sendspin-server._tcp` is NOT running in this mode
 
 Preferred because multi-server behavior is *standardized* here. The spec defines admission

--- a/claude.md
+++ b/claude.md
@@ -92,12 +92,20 @@ advertising `_sendspin._tcp`, and do not advertise `_sendspin._tcp` if the clien
 initiate the connection. Running both transports concurrently is a protocol violation, not a
 convenience — see "No Auto mode" below.
 
-### 1. Server-Initiated Mode (Primary)
+The mode is chosen by `Connection.Mode` in `appsettings.json` and switched at runtime through
+`MainViewModel.ApplyConnectionModeAsync`, which always stops the outgoing transport before
+starting the incoming one and aborts the switch if that stop fails.
+
+### 1. Server-Initiated Mode — `AdvertiseOnly` (Primary, default)
 We advertise via mDNS and servers connect to us. **This is the default and the spec-recommended
 mode.**
 - `SendspinHostService` runs a WebSocket server (recommended port 8928)
 - Advertises as `_sendspin._tcp.local` with a required `path` TXT record
 - Music Assistant servers discover and connect to us
+- Server admission (which server wins when several connect) is arbitrated inside the SDK's
+  `SendspinHostService` using activity ranking and the `LastPlayedServerId` tiebreak — the app
+  does no arbitration of its own
+- Discovery of `_sendspin-server._tcp` is NOT running in this mode
 
 Preferred because multi-server behavior is *standardized* here. The spec defines admission
 precisely: the client holds at most one admitted connection, ranked by its highest declared
@@ -113,13 +121,16 @@ not override its decisions (for example by calling `DisconnectAllAsync` to rejec
 unwanted connection; that tears down every connection and resets the shared `IAudioPipeline`
 and `IClockSynchronizer`).
 
-### 2. Client-Initiated Mode (Alternative)
-We discover servers via mDNS and connect to them. Retained as an explicit opt-in for networks
-where the server cannot discover or reach us (cross-subnet, VLAN-segmented, containerized
-servers).
+### 2. Client-Initiated Mode — `DiscoverOnly` (Alternative)
+We discover servers via mDNS and connect out to them. Retained as an explicit opt-in for
+networks where the server cannot discover or reach us (different subnet/VLAN, client-isolating
+AP, restrictive firewall, containerized servers).
 - Uses `MdnsServerDiscovery` to find `_sendspin-server._tcp` services
 - Client connects to the server's WebSocket endpoint
-- We must NOT advertise `_sendspin._tcp` while in this mode
+- Also covers manual connection by URL (`ConnectToServerAsync`, which refuses to run in any
+  other mode)
+- The host service is stopped in this mode: we neither advertise `_sendspin._tcp` nor accept
+  incoming connections
 
 The trade-off is that the spec gives no help here: "How clients handle multiple discovered
 servers, server selection, and switching is implementation-defined." Every multi-server
@@ -129,9 +140,8 @@ behavior we want on this path we have to build and maintain ourselves.
 There is deliberately no mode that runs both transports. A prior `Connection:Mode = "Auto"`
 default did exactly that and violated the MUST above; it also left `SendspinHostService`
 arbitrating without visibility of the client-initiated connection, since per spec that state
-cannot occur. Removal is tracked in
-[#76](https://github.com/chrisuthe/windowsSpin/issues/76). Existing configs carrying `"Auto"`
-migrate to server-initiated.
+cannot occur. Removed in [#76](https://github.com/chrisuthe/windowsSpin/issues/76); existing
+configs carrying `"Auto"` migrate to server-initiated.
 
 ---
 
@@ -379,13 +389,14 @@ Settings are stored in two locations:
 
 ### Connection Configuration
 - `Mode`: `AdvertiseOnly` (server-initiated, the default) or `DiscoverOnly` (client-initiated).
-  The legacy `Auto` value ran both transports and is being removed — see
-  [Connection Modes](#connection-modes). Configs still carrying it migrate to `AdvertiseOnly`.
-- `AutoConnectServerId`: client-initiated only. Set by the "always connect" choice in the server
-  picker; unused in server-initiated mode, where the server decides when to connect.
-- `LastPlayedServerId`: server-initiated only. The spec's "last-playback server", passed to
-  `SendspinHostService` at startup and used as the arbitration tiebreak when a current and an
-  incoming connection both declare empty activities.
+  Exactly one method at a time, per spec — there is no combined mode. The legacy `Auto` value
+  ran both transports; configs still carrying it migrate to `AdvertiseOnly` on load.
+- `AutoConnectServerId`: **`DiscoverOnly` only.** The discovered server to auto-connect to, set
+  by the "always connect" choice in the server picker. Ignored in `AdvertiseOnly`, where the
+  client never initiates a connection.
+- `LastPlayedServerId`: the spec's "last-playback server", used by `SendspinHostService` to break
+  arbitration ties when a current and an incoming connection both declare empty activities.
+  Written in both modes (see `SetLastPlayedServerId`); consumed only in `AdvertiseOnly`.
 
 ### Audio Buffer Configuration
 - `Buffer.TargetMs`: Target buffer depth before starting playback (default: 250ms)

--- a/docs/superpowers/plans/2026-08-30-spec-compliant-connection-modes.md
+++ b/docs/superpowers/plans/2026-08-30-spec-compliant-connection-modes.md
@@ -1,0 +1,968 @@
+# Spec-Compliant Connection Modes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the `Auto` connection mode so the client uses exactly one transport at a time, defaulting to server-initiated.
+
+**Architecture:** The two transports become an if/else rather than two independent `if`s, making exclusivity structural. The mode string mapping — the part that can fail silently — moves into a pure, unit-tested class in `Sendspin.Windows.Services`. The app-side rejection of duplicate connections is deleted so the SDK's spec-compliant arbitration is left alone.
+
+**Tech Stack:** .NET 10, WPF, CommunityToolkit.Mvvm, xUnit, Sendspin.SDK 9.3.0
+
+**Spec:** `docs/superpowers/specs/2026-08-30-spec-compliant-connection-modes-design.md`
+
+## Global Constraints
+
+- Branch: `feat/spec-compliant-connection-modes`, cut from `release/2.2.4`. Forward-port to `master` after merge.
+- The app MUST NEVER produce `ConnectionMode.Auto`. The SDK enum retains it (removal tracked in Sendspin/sendspin-dotnet#254); our mapping must never return it for any input.
+- Config values are exactly `"AdvertiseOnly"` and `"DiscoverOnly"`.
+- Display names are exactly `"Let servers connect to me"` and `"I choose a server"`.
+- Default for any unrecognized, legacy, null, or empty config value is `AdvertiseOnly`.
+- Migration is silent and logged at information level. No user prompt.
+- Build command: `dotnet build Sendspin.Windows.sln`
+- Test command: `dotnet test tests\Sendspin.Windows.Services.Tests\Sendspin.Windows.Services.Tests.csproj`
+- **Pre-existing test failures:** `DynamicResamplerSampleProviderTests.RateCorrection_ConcealsShortfalls_WithoutSilenceGaps` and `MultiRoomSyncAlignmentTests.StartupPrefill_Uncompensated_DriftsOffSchedule` fail on `release/2.2.4` before any of this work. Expect them. A run showing exactly these two failures is a pass.
+
+---
+
+### Task 1: ConnectionModeMapping
+
+The only unit-testable piece. `Sendspin.Windows` (the WPF app) has no test project, so everything in later tasks is verified by build plus manual checks — which is precisely why the fallible string logic is extracted here.
+
+**Files:**
+- Create: `src/Sendspin.Windows.Services/Configuration/ConnectionModeMapping.cs`
+- Test: `tests/Sendspin.Windows.Services.Tests/Configuration/ConnectionModeMappingTests.cs`
+
+**Interfaces:**
+- Consumes: `Sendspin.SDK.Client.ConnectionMode` (already referenced by the Services project via `Sendspin.SDK` 9.3.0)
+- Produces:
+  - `const string ConnectionModeMapping.AdvertiseOnlyDisplayName = "Let servers connect to me"`
+  - `const string ConnectionModeMapping.DiscoverOnlyDisplayName = "I choose a server"`
+  - `static string[] ConnectionModeMapping.DisplayNames { get; }`
+  - `static ConnectionMode ConnectionModeMapping.FromConfigValue(string? configValue)`
+  - `static string ConnectionModeMapping.ToConfigValue(ConnectionMode mode)`
+  - `static string ConnectionModeMapping.ToDisplayName(ConnectionMode mode)`
+  - `static ConnectionMode ConnectionModeMapping.FromDisplayName(string? displayName)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Sendspin.Windows.Services.Tests/Configuration/ConnectionModeMappingTests.cs`:
+
+```csharp
+using Sendspin.SDK.Client;
+using Sendspin.Windows.Services.Configuration;
+using Xunit;
+
+namespace Sendspin.Windows.Services.Tests.Configuration;
+
+public class ConnectionModeMappingTests
+{
+    [Theory]
+    [InlineData("AdvertiseOnly")]
+    [InlineData("DiscoverOnly")]
+    public void FromConfigValue_RoundTripsKnownValues(string configValue)
+    {
+        var mode = ConnectionModeMapping.FromConfigValue(configValue);
+        Assert.Equal(configValue, ConnectionModeMapping.ToConfigValue(mode));
+    }
+
+    [Fact]
+    public void FromConfigValue_DiscoverOnly_ReturnsDiscoverOnly()
+    {
+        Assert.Equal(ConnectionMode.DiscoverOnly, ConnectionModeMapping.FromConfigValue("DiscoverOnly"));
+    }
+
+    [Fact]
+    public void FromConfigValue_AdvertiseOnly_ReturnsAdvertiseOnly()
+    {
+        Assert.Equal(ConnectionMode.AdvertiseOnly, ConnectionModeMapping.FromConfigValue("AdvertiseOnly"));
+    }
+
+    [Fact]
+    public void FromConfigValue_LegacyAuto_MigratesToAdvertiseOnly()
+    {
+        Assert.Equal(ConnectionMode.AdvertiseOnly, ConnectionModeMapping.FromConfigValue("Auto"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Nonsense")]
+    [InlineData("advertiseonly")]
+    public void FromConfigValue_UnrecognizedInput_DefaultsToAdvertiseOnly(string? configValue)
+    {
+        Assert.Equal(ConnectionMode.AdvertiseOnly, ConnectionModeMapping.FromConfigValue(configValue));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Auto")]
+    [InlineData("Nonsense")]
+    [InlineData("AdvertiseOnly")]
+    [InlineData("DiscoverOnly")]
+    public void FromConfigValue_NeverReturnsAuto(string? configValue)
+    {
+        Assert.NotEqual(ConnectionMode.Auto, ConnectionModeMapping.FromConfigValue(configValue));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Auto")]
+    [InlineData("Advertise Only")]
+    [InlineData("Let servers connect to me")]
+    [InlineData("I choose a server")]
+    public void FromDisplayName_NeverReturnsAuto(string? displayName)
+    {
+        Assert.NotEqual(ConnectionMode.Auto, ConnectionModeMapping.FromDisplayName(displayName));
+    }
+
+    [Fact]
+    public void FromDisplayName_DiscoverOnlyLabel_ReturnsDiscoverOnly()
+    {
+        Assert.Equal(
+            ConnectionMode.DiscoverOnly,
+            ConnectionModeMapping.FromDisplayName(ConnectionModeMapping.DiscoverOnlyDisplayName));
+    }
+
+    [Fact]
+    public void FromDisplayName_UnrecognizedLabel_DefaultsToAdvertiseOnly()
+    {
+        Assert.Equal(ConnectionMode.AdvertiseOnly, ConnectionModeMapping.FromDisplayName("Advertise Only"));
+    }
+
+    [Theory]
+    [InlineData(ConnectionMode.AdvertiseOnly)]
+    [InlineData(ConnectionMode.DiscoverOnly)]
+    public void ToDisplayName_RoundTrips(ConnectionMode mode)
+    {
+        Assert.Equal(mode, ConnectionModeMapping.FromDisplayName(ConnectionModeMapping.ToDisplayName(mode)));
+    }
+
+    [Fact]
+    public void ToConfigValue_Auto_CoercedToAdvertiseOnly()
+    {
+        // Auto is unreachable through our own mapping, but the SDK enum still allows it.
+        // Coerce rather than emit a value we would refuse to read back.
+        Assert.Equal("AdvertiseOnly", ConnectionModeMapping.ToConfigValue(ConnectionMode.Auto));
+    }
+
+    [Fact]
+    public void ToDisplayName_Auto_CoercedToAdvertiseOnlyLabel()
+    {
+        Assert.Equal(
+            ConnectionModeMapping.AdvertiseOnlyDisplayName,
+            ConnectionModeMapping.ToDisplayName(ConnectionMode.Auto));
+    }
+
+    [Fact]
+    public void DisplayNames_ContainsExactlyTheTwoSupportedModes()
+    {
+        Assert.Equal(
+            new[] { ConnectionModeMapping.AdvertiseOnlyDisplayName, ConnectionModeMapping.DiscoverOnlyDisplayName },
+            ConnectionModeMapping.DisplayNames);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet build tests\Sendspin.Windows.Services.Tests\Sendspin.Windows.Services.Tests.csproj`
+
+Expected: FAIL with `error CS0246: The type or namespace name 'ConnectionModeMapping' could not be found`.
+
+- [ ] **Step 3: Create a stub so the tests fail on assertions rather than compilation**
+
+Create `src/Sendspin.Windows.Services/Configuration/ConnectionModeMapping.cs`:
+
+```csharp
+using Sendspin.SDK.Client;
+
+namespace Sendspin.Windows.Services.Configuration;
+
+/// <summary>
+/// Maps connection mode between its persisted config value, its settings display name, and
+/// <see cref="ConnectionMode"/>.
+/// </summary>
+public static class ConnectionModeMapping
+{
+    /// <summary>Display name for server-initiated mode.</summary>
+    public const string AdvertiseOnlyDisplayName = "Let servers connect to me";
+
+    /// <summary>Display name for client-initiated mode.</summary>
+    public const string DiscoverOnlyDisplayName = "I choose a server";
+
+    /// <summary>Gets the display names offered in the settings dropdown, in order.</summary>
+    public static string[] DisplayNames => Array.Empty<string>();
+
+    /// <summary>Maps a persisted config value to a mode.</summary>
+    /// <param name="configValue">The stored value, which may be legacy or absent.</param>
+    /// <returns>The mode; never <see cref="ConnectionMode.Auto"/>.</returns>
+    public static ConnectionMode FromConfigValue(string? configValue) => ConnectionMode.Auto;
+
+    /// <summary>Maps a mode to its persisted config value.</summary>
+    /// <param name="mode">The mode to persist.</param>
+    /// <returns>The config value.</returns>
+    public static string ToConfigValue(ConnectionMode mode) => string.Empty;
+
+    /// <summary>Maps a mode to its settings display name.</summary>
+    /// <param name="mode">The mode to display.</param>
+    /// <returns>The display name.</returns>
+    public static string ToDisplayName(ConnectionMode mode) => string.Empty;
+
+    /// <summary>Maps a settings display name to a mode.</summary>
+    /// <param name="displayName">The selected display name.</param>
+    /// <returns>The mode; never <see cref="ConnectionMode.Auto"/>.</returns>
+    public static ConnectionMode FromDisplayName(string? displayName) => ConnectionMode.Auto;
+}
+```
+
+Run: `dotnet test tests\Sendspin.Windows.Services.Tests\Sendspin.Windows.Services.Tests.csproj --filter "FullyQualifiedName~ConnectionModeMapping"`
+
+Expected: FAIL on assertions, not compilation. `FromConfigValue_NeverReturnsAuto` should fail with `Assert.NotEqual() Failure`.
+
+- [ ] **Step 4: Write the implementation**
+
+Replace everything from `public static string[] DisplayNames` to the end of the class in
+`src/Sendspin.Windows.Services/Configuration/ConnectionModeMapping.cs` with the following. The two
+public display-name constants at the top of the class stay exactly as written in Step 3.
+
+```csharp
+    private const string AdvertiseOnlyConfigValue = "AdvertiseOnly";
+    private const string DiscoverOnlyConfigValue = "DiscoverOnly";
+
+    /// <summary>Gets the display names offered in the settings dropdown, in order.</summary>
+    public static string[] DisplayNames { get; } =
+    {
+        AdvertiseOnlyDisplayName,
+        DiscoverOnlyDisplayName,
+    };
+
+    /// <summary>Maps a persisted config value to a mode.</summary>
+    /// <param name="configValue">The stored value, which may be legacy or absent.</param>
+    /// <returns>The mode; never <see cref="ConnectionMode.Auto"/>.</returns>
+    /// <remarks>
+    /// Anything unrecognized — including the legacy "Auto", which ran both transports in
+    /// violation of the spec — resolves to <see cref="ConnectionMode.AdvertiseOnly"/>.
+    /// </remarks>
+    public static ConnectionMode FromConfigValue(string? configValue)
+        => configValue == DiscoverOnlyConfigValue
+            ? ConnectionMode.DiscoverOnly
+            : ConnectionMode.AdvertiseOnly;
+
+    /// <summary>Maps a mode to its persisted config value.</summary>
+    /// <param name="mode">The mode to persist.</param>
+    /// <returns>The config value.</returns>
+    public static string ToConfigValue(ConnectionMode mode)
+        => mode == ConnectionMode.DiscoverOnly
+            ? DiscoverOnlyConfigValue
+            : AdvertiseOnlyConfigValue;
+
+    /// <summary>Maps a mode to its settings display name.</summary>
+    /// <param name="mode">The mode to display.</param>
+    /// <returns>The display name.</returns>
+    public static string ToDisplayName(ConnectionMode mode)
+        => mode == ConnectionMode.DiscoverOnly
+            ? DiscoverOnlyDisplayName
+            : AdvertiseOnlyDisplayName;
+
+    /// <summary>Maps a settings display name to a mode.</summary>
+    /// <param name="displayName">The selected display name.</param>
+    /// <returns>The mode; never <see cref="ConnectionMode.Auto"/>.</returns>
+    public static ConnectionMode FromDisplayName(string? displayName)
+        => displayName == DiscoverOnlyDisplayName
+            ? ConnectionMode.DiscoverOnly
+            : ConnectionMode.AdvertiseOnly;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test tests\Sendspin.Windows.Services.Tests\Sendspin.Windows.Services.Tests.csproj --filter "FullyQualifiedName~ConnectionModeMapping"`
+
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `dotnet test tests\Sendspin.Windows.Services.Tests\Sendspin.Windows.Services.Tests.csproj`
+
+Expected: exactly the two pre-existing failures listed in Global Constraints; everything else passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Sendspin.Windows.Services/Configuration/ConnectionModeMapping.cs tests/Sendspin.Windows.Services.Tests/Configuration/ConnectionModeMappingTests.cs
+git commit -m "feat: add ConnectionModeMapping with Auto migration
+
+Pure mapping between config value, display name, and ConnectionMode. Any
+unrecognized value — including the legacy Auto, which ran both transports
+against the spec's MUST — resolves to AdvertiseOnly. Tests assert Auto is
+never returned for any input.
+
+Refs #76"
+```
+
+---
+
+### Task 2: Adopt the mapping in MainViewModel
+
+Replaces all four sites where `Auto` currently appears. Three of them are `_ =>` fallbacks that would otherwise silently resurrect it.
+
+**Files:**
+- Modify: `src/Sendspin.Windows/ViewModels/MainViewModel.cs`
+
+**Interfaces:**
+- Consumes: `ConnectionModeMapping` from Task 1 (all members)
+- Produces: `MainViewModel.SettingsConnectionMode` now holds one of `ConnectionModeMapping.DisplayNames`; `ParseConnectionMode` no longer exists.
+
+- [ ] **Step 1: Add the using**
+
+At the top of `MainViewModel.cs`, alongside the other `Sendspin.Windows.Services.*` usings:
+
+```csharp
+using Sendspin.Windows.Services.Configuration;
+```
+
+- [ ] **Step 2: Change the default and the dropdown list**
+
+Replace (around line 367):
+
+```csharp
+    [ObservableProperty]
+    private string _settingsConnectionMode = "Auto";
+
+    /// <summary>
+    /// Gets the available connection mode options for the settings dropdown.
+    /// </summary>
+    public string[] AvailableConnectionModes { get; } = new[]
+    {
+        "Auto",
+        "Advertise Only",
+        "Discover Only"
+    };
+```
+
+with:
+
+```csharp
+    [ObservableProperty]
+    private string _settingsConnectionMode = ConnectionModeMapping.AdvertiseOnlyDisplayName;
+
+    /// <summary>
+    /// Gets the available connection mode options for the settings dropdown.
+    /// </summary>
+    public string[] AvailableConnectionModes { get; } = ConnectionModeMapping.DisplayNames;
+```
+
+- [ ] **Step 3: Delete ParseConnectionMode**
+
+Delete this method entirely (around line 671):
+
+```csharp
+    private static ConnectionMode ParseConnectionMode(string displayName)
+    {
+        return displayName switch
+        {
+            "Advertise Only" => ConnectionMode.AdvertiseOnly,
+            "Discover Only" => ConnectionMode.DiscoverOnly,
+            _ => ConnectionMode.Auto
+        };
+    }
+```
+
+In `InitializeAsync` (around line 633), replace:
+
+```csharp
+        var mode = ParseConnectionMode(SettingsConnectionMode);
+```
+
+with:
+
+```csharp
+        var mode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
+```
+
+- [ ] **Step 4: Replace the save mapping**
+
+Replace `OnSettingsConnectionModeChanged` (around line 2088):
+
+```csharp
+    partial void OnSettingsConnectionModeChanged(string value)
+    {
+        // Convert display name to config value
+        var configValue = value switch
+        {
+            "Advertise Only" => "AdvertiseOnly",
+            "Discover Only" => "DiscoverOnly",
+            _ => "Auto"
+        };
+        SaveConnectionModeAsync(configValue).SafeFireAndForget(_logger);
+    }
+```
+
+with:
+
+```csharp
+    partial void OnSettingsConnectionModeChanged(string value)
+    {
+        var configValue = ConnectionModeMapping.ToConfigValue(
+            ConnectionModeMapping.FromDisplayName(value));
+        SaveConnectionModeAsync(configValue).SafeFireAndForget(_logger);
+    }
+```
+
+- [ ] **Step 5: Replace the load mapping and log the migration**
+
+Replace the settings-load block (around line 2359):
+
+```csharp
+        // Load connection mode
+        var modeStr = _configuration.GetValue<string>("Connection:Mode", "Auto") ?? "Auto";
+        SettingsConnectionMode = modeStr switch
+        {
+            "AdvertiseOnly" => "Advertise Only",
+            "DiscoverOnly" => "Discover Only",
+            _ => "Auto"
+        };
+```
+
+with:
+
+```csharp
+        // Load connection mode. Anything we do not recognize — including the legacy "Auto",
+        // which ran both transports in violation of the spec — resolves to AdvertiseOnly.
+        var modeStr = _configuration.GetValue<string>("Connection:Mode", string.Empty) ?? string.Empty;
+        var loadedMode = ConnectionModeMapping.FromConfigValue(modeStr);
+        var canonicalValue = ConnectionModeMapping.ToConfigValue(loadedMode);
+        if (!string.IsNullOrEmpty(modeStr) && modeStr != canonicalValue)
+        {
+            _logger.LogInformation(
+                "Migrating unsupported connection mode {StoredMode} to {NewMode}",
+                modeStr,
+                canonicalValue);
+        }
+
+        SettingsConnectionMode = ConnectionModeMapping.ToDisplayName(loadedMode);
+```
+
+- [ ] **Step 6: Build**
+
+Run: `dotnet build Sendspin.Windows.sln`
+
+Expected: `0 Error(s)`. If `ConnectionMode` is now an unused using in `MainViewModel.cs`, leave it — `Sendspin.SDK.Client` is used for other types.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Sendspin.Windows/ViewModels/MainViewModel.cs
+git commit -m "refactor: route connection mode through ConnectionModeMapping
+
+Replaces the four sites that referenced Auto, three of which were _ =>
+fallbacks that would silently resurrect it once the mode is removed from
+the UI. Logs the migration when a stored value is not one we support.
+
+Refs #76"
+```
+
+---
+
+### Task 3: Make the transports mutually exclusive
+
+The core fix. Two independent `if`s become an if/else, so no mode can start both.
+
+**Files:**
+- Modify: `src/Sendspin.Windows/ViewModels/MainViewModel.cs`
+
+**Interfaces:**
+- Consumes: `ConnectionModeMapping.FromDisplayName` (Task 1), `SettingsConnectionMode` (Task 2)
+- Produces: `ApplyConnectionModeAsync(ConnectionMode mode)` — note the parameter type changes from `string` to `ConnectionMode`.
+
+- [ ] **Step 1: Make InitializeAsync exclusive**
+
+In `InitializeAsync` (around line 637), replace:
+
+```csharp
+            // Start host service (server-initiated mode) unless DiscoverOnly
+            if (mode != ConnectionMode.DiscoverOnly)
+            {
+                StatusMessage = "Starting host service...";
+                await _hostService.StartAsync();
+                ClientId = _hostService.ClientId;
+                IsHosting = true;
+                _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
+            }
+
+            // Start server discovery (client-initiated mode) unless AdvertiseOnly
+            if (mode != ConnectionMode.AdvertiseOnly)
+            {
+                StatusMessage = "Discovering Sendspin servers...";
+                await _serverDiscovery.StartAsync();
+                _logger.LogInformation("Server discovery started, looking for _sendspin-server._tcp");
+            }
+
+            StatusMessage = mode switch
+            {
+                ConnectionMode.AdvertiseOnly => $"Advertising as player...\nClient ID: {ClientId}",
+                ConnectionMode.DiscoverOnly => "Searching for servers...",
+                _ => $"Searching for servers...\nClient ID: {ClientId}"
+            };
+```
+
+with:
+
+```csharp
+            // Exactly one transport, per spec: a client MUST use exactly one of the two
+            // connection methods at a time. An if/else keeps that structural — the previous
+            // pair of independent ifs let Auto satisfy neither exclusion and start both.
+            if (mode == ConnectionMode.DiscoverOnly)
+            {
+                StatusMessage = "Discovering Sendspin servers...";
+                await _serverDiscovery.StartAsync();
+                _logger.LogInformation("Server discovery started, looking for _sendspin-server._tcp");
+                StatusMessage = "Searching for servers...";
+            }
+            else
+            {
+                StatusMessage = "Starting host service...";
+                await _hostService.StartAsync();
+                ClientId = _hostService.ClientId;
+                IsHosting = true;
+                _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
+                StatusMessage = $"Waiting for a server to connect...\nClient ID: {ClientId}";
+            }
+```
+
+- [ ] **Step 2: Make the runtime mode switch exclusive and stop-before-start**
+
+Replace `ApplyConnectionModeAsync` (starting around line 2116) in full:
+
+```csharp
+    private async Task ApplyConnectionModeAsync(ConnectionMode mode)
+    {
+        var shouldAdvertise = mode != ConnectionMode.DiscoverOnly;
+
+        // Stop the outgoing transport BEFORE starting the incoming one, so the two are never
+        // running together even momentarily.
+        if (shouldAdvertise && _serverDiscovery.IsDiscovering)
+        {
+            try
+            {
+                await _serverDiscovery.StopAsync();
+                _logger.LogInformation("Server discovery stopped");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to stop server discovery");
+            }
+        }
+        else if (!shouldAdvertise && IsHosting)
+        {
+            try
+            {
+                await _hostService.StopAsync();
+                IsHosting = false;
+                _logger.LogInformation("Host service stopped");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to stop host service");
+            }
+        }
+
+        if (shouldAdvertise && !IsHosting)
+        {
+            try
+            {
+                await _hostService.StartAsync();
+                ClientId = _hostService.ClientId;
+                IsHosting = true;
+                _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to start host service");
+            }
+        }
+        else if (!shouldAdvertise && !_serverDiscovery.IsDiscovering)
+        {
+            try
+            {
+                await _serverDiscovery.StartAsync();
+                _logger.LogInformation("Server discovery started");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to start server discovery");
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Update the call site**
+
+In `SaveConnectionModeAsync` (around line 2108), replace:
+
+```csharp
+            await ApplyConnectionModeAsync(mode);
+```
+
+with:
+
+```csharp
+            await ApplyConnectionModeAsync(ConnectionModeMapping.FromConfigValue(mode));
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build Sendspin.Windows.sln`
+
+Expected: `0 Error(s)`. If the compiler reports an unused local or an unreachable branch left over from the old `shouldDiscover` variable, delete it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Sendspin.Windows/ViewModels/MainViewModel.cs
+git commit -m "fix: run exactly one connection transport at a time
+
+The spec requires clients use exactly one of the two connection methods at
+a time. Two independent ifs, each excluding one mode, let Auto satisfy
+neither and start both. An if/else makes exclusivity structural.
+
+The runtime mode switch now stops the outgoing transport before starting
+the incoming one, so the two never overlap.
+
+Refs #76"
+```
+
+---
+
+### Task 4: Delete the app-side connection rejection
+
+With exclusive transports this guard is unreachable, and it was the mechanism that tore down playing sessions.
+
+**Files:**
+- Modify: `src/Sendspin.Windows/ViewModels/MainViewModel.cs`
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces: `OnServerConnected` no longer calls `_hostService.DisconnectAllAsync`
+
+- [ ] **Step 1: Delete the rejection block**
+
+In `OnServerConnected` (around line 1258), delete:
+
+```csharp
+            // Reject server-initiated connections if we already have a client-initiated connection
+            if (_manualClient?.ConnectionState == ConnectionState.Connected)
+            {
+                _logger.LogInformation(
+                    "Rejecting server-initiated connection from {ServerName} - already connected via client-initiated mode",
+                    server.ServerName);
+                _hostService.DisconnectAllAsync("already_connected").SafeFireAndForget(_logger);
+                return;
+            }
+
+```
+
+Leave the rest of the method unchanged, so it begins:
+
+```csharp
+    private void OnServerConnected(object? sender, ConnectedServerInfo server)
+    {
+        App.Current.Dispatcher.Invoke(() =>
+        {
+            ConnectedServers.Add(server);
+```
+
+Add this comment immediately above `ConnectedServers.Add(server);`:
+
+```csharp
+            // No app-side arbitration. SendspinHostService already applies the spec's admission
+            // rules (activity ranking, LastPlayedServerId tiebreak) and disconnects only the
+            // loser. The previous guard here called DisconnectAllAsync to reject a single
+            // unwanted socket, which tore down every connection and reset the shared
+            // IAudioPipeline and IClockSynchronizer that the playing session was using.
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Sendspin.Windows.sln`
+
+Expected: `0 Error(s)`. If `_manualClient` or `ConnectionState` become unused as a result, they will not — both are used elsewhere in the file (for example `IsConnected` at line ~451).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Sendspin.Windows/ViewModels/MainViewModel.cs
+git commit -m "fix: stop overriding SDK connection arbitration
+
+OnServerConnected called DisconnectAllAsync to reject one unwanted incoming
+socket, which disconnected every connection and reset the shared audio
+pipeline and clock synchronizer — dropping the session that was playing.
+
+SendspinHostService already arbitrates per spec and disconnects only the
+loser. With exclusive transports the guard is unreachable anyway.
+
+Refs #76"
+```
+
+---
+
+### Task 5: Fix the searching indicator and gate the server picker
+
+`IsSearchingForServers` keys off `IsHosting`, not discovery. Under `Auto` both ran, so it worked by accident; with exclusive modes `AdvertiseOnly` would show "Searching for servers…" permanently in a mode that never searches.
+
+**Files:**
+- Modify: `src/Sendspin.Windows/ViewModels/MainViewModel.cs`
+- Modify: `src/Sendspin.Windows/MainWindow.xaml`
+
+**Interfaces:**
+- Consumes: `ConnectionModeMapping.FromDisplayName` (Task 1)
+- Produces: `MainViewModel.IsDiscoverMode` (bool), `MainViewModel.IsSearchingForServers` (bool, semantics corrected)
+
+- [ ] **Step 1: Add IsDiscoverMode and correct IsSearchingForServers**
+
+Replace (around line 445):
+
+```csharp
+    public bool IsSearchingForServers => DiscoveredServers.Count == 0 && IsHosting;
+```
+
+with:
+
+```csharp
+    /// <summary>
+    /// Gets whether the client picks its own server (client-initiated mode). The server list and
+    /// the auto-connect preference are meaningful only in this mode; in server-initiated mode the
+    /// server decides when to connect.
+    /// </summary>
+    public bool IsDiscoverMode
+        => ConnectionModeMapping.FromDisplayName(SettingsConnectionMode) == ConnectionMode.DiscoverOnly;
+
+    /// <summary>
+    /// Gets whether a discovery scan is running and has not yet found anything.
+    /// </summary>
+    /// <remarks>
+    /// Keyed off discovery, not hosting. It previously read <c>IsHosting</c>, which only appeared
+    /// correct because Auto ran both transports; in server-initiated mode that would show a
+    /// permanent "searching" state for a mode that never searches.
+    /// </remarks>
+    public bool IsSearchingForServers => IsDiscoverMode && DiscoveredServers.Count == 0;
+```
+
+- [ ] **Step 2: Raise change notifications when the mode changes**
+
+In `OnSettingsConnectionModeChanged` (modified in Task 2), append the two notifications so the method reads:
+
+```csharp
+    partial void OnSettingsConnectionModeChanged(string value)
+    {
+        var configValue = ConnectionModeMapping.ToConfigValue(
+            ConnectionModeMapping.FromDisplayName(value));
+        SaveConnectionModeAsync(configValue).SafeFireAndForget(_logger);
+
+        OnPropertyChanged(nameof(IsDiscoverMode));
+        OnPropertyChanged(nameof(IsSearchingForServers));
+    }
+```
+
+- [ ] **Step 3: Gate the server picker card**
+
+In `src/Sendspin.Windows/MainWindow.xaml`, find the "Section 2: Available Servers" card (around line 241):
+
+```xml
+                    <!-- Section 2: Available Servers -->
+                    <Border Style="{StaticResource WelcomeCardStyle}">
+```
+
+Replace those two lines with:
+
+```xml
+                    <!-- Section 2: Available Servers (client-initiated mode only — in
+                         server-initiated mode the server chooses when to connect) -->
+                    <Border Style="{StaticResource WelcomeCardStyle}"
+                            Visibility="{Binding IsDiscoverMode, Converter={StaticResource BoolToVisibilityConverter}}">
+```
+
+- [ ] **Step 4: Add the waiting card for server-initiated mode**
+
+Immediately after the closing `</Border>` of the "Available Servers" card, add:
+
+```xml
+                    <!-- Server-initiated mode: we advertise and wait. No picker — the server
+                         decides when to connect. Pairing affordances are future work. -->
+                    <Border Style="{StaticResource WelcomeCardStyle}">
+                        <Border.Visibility>
+                            <Binding Path="IsDiscoverMode" Converter="{StaticResource InverseBoolToVisibilityConverter}"/>
+                        </Border.Visibility>
+                        <StackPanel>
+                            <TextBlock Text="Waiting for a Server" Style="{StaticResource WelcomeSectionHeader}"/>
+                            <TextBlock Text="📡" Style="{StaticResource SearchingIcon}"/>
+                            <TextBlock Text="Advertising on your network. Select this player in Music Assistant to connect."
+                                       Style="{StaticResource CaptionText}"
+                                       HorizontalAlignment="Center"
+                                       TextAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       Foreground="{StaticResource TextMutedBrush}"
+                                       Margin="0,8,0,0"/>
+                        </StackPanel>
+                    </Border>
+```
+
+Note on the auto-connect dialog: the spec requires the "connect once / connect always" dialog be
+hidden in server-initiated mode too. No separate change is needed — that dialog is raised only by
+`SelectServer`, which is reachable only through `ServerCard_Click` on cards inside the
+`DiscoveredServers` `ItemsControl` that Step 3 hides. Hiding the card makes the dialog unreachable.
+Do not add a second visibility binding for it; `ShowAutoConnectDialog` can never become true in this
+mode.
+
+- [ ] **Step 5: Verify the inverse converter exists**
+
+Run: `grep -n "InverseBoolToVisibilityConverter" src/Sendspin.Windows/MainWindow.xaml src/Sendspin.Windows/App.xaml src/Sendspin.Windows/Resources/Styles/*.xaml`
+
+If it returns nothing, the converter does not exist. In that case, replace the `<Border.Visibility>` block from Step 4 with a style trigger instead, which needs no converter:
+
+```xml
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource WelcomeCardStyle}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsDiscoverMode}" Value="True">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+```
+
+and delete the `Style="{StaticResource WelcomeCardStyle}"` attribute from that `<Border>` opening tag, since the style now comes from `BasedOn`.
+
+- [ ] **Step 6: Build**
+
+Run: `dotnet build Sendspin.Windows.sln`
+
+Expected: `0 Error(s)`. XAML errors surface at build time, so a clean build confirms the markup parses and every binding target and resource key resolves.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Sendspin.Windows/ViewModels/MainViewModel.cs src/Sendspin.Windows/MainWindow.xaml
+git commit -m "fix: scope the server picker and searching state to discover mode
+
+IsSearchingForServers keyed off IsHosting rather than discovery. That only
+looked right because Auto ran both transports; in server-initiated mode it
+would show a permanent searching state for a mode that never searches.
+
+The server list and auto-connect preference express a choice server-initiated
+mode does not have, so they are hidden there in favour of a waiting state.
+
+Refs #76"
+```
+
+---
+
+### Task 6: Change the shipped default and verify end to end
+
+**Files:**
+- Modify: `src/Sendspin.Windows/appsettings.json`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–5
+- Produces: shipped default `Connection:Mode = "AdvertiseOnly"`
+
+- [ ] **Step 1: Change the shipped default**
+
+In `src/Sendspin.Windows/appsettings.json`, replace:
+
+```json
+  "Connection": {
+    "Mode": "Auto",
+```
+
+with:
+
+```json
+  "Connection": {
+    "Mode": "AdvertiseOnly",
+```
+
+- [ ] **Step 2: Build and run the full suite**
+
+Run: `dotnet build Sendspin.Windows.sln`
+Expected: `0 Error(s)`
+
+Run: `dotnet test tests\Sendspin.Windows.Services.Tests\Sendspin.Windows.Services.Tests.csproj`
+Expected: exactly the two pre-existing failures from Global Constraints.
+
+- [ ] **Step 3: Verify the migration path**
+
+The user config lives at `%LOCALAPPDATA%\Sendspin for Windows\appsettings.json`. Back it up before editing:
+
+```powershell
+$cfg = "$env:LOCALAPPDATA\Sendspin for Windows\appsettings.json"
+Copy-Item $cfg "$cfg.bak" -Force
+```
+
+Set `"Mode": "Auto"` in that file, launch the app, then check the log:
+
+```powershell
+$logs = "$env:LOCALAPPDATA\Sendspin for Windows\logs"
+$f = Get-ChildItem $logs -Filter *.log | Where-Object { $_.Name -notlike "sync-health*" } |
+     Sort-Object LastWriteTime -Descending | Select-Object -First 1
+Get-Content $f.FullName | Select-String -Pattern "Migrating unsupported connection mode|Host service started|Server discovery started"
+```
+
+Expected: a `Migrating unsupported connection mode Auto to AdvertiseOnly` line, a `Host service started` line, and **no** `Server discovery started` line. Restore the backup when finished.
+
+- [ ] **Step 4: Verify each mode starts exactly one transport**
+
+With `"Mode": "AdvertiseOnly"`: log shows `Host service started`, no `Server discovery started`. Welcome screen shows the "Waiting for a Server" card and no server list.
+
+With `"Mode": "DiscoverOnly"`: log shows `Server discovery started`, no `Host service started`. Welcome screen shows "Available Servers" and no waiting card.
+
+- [ ] **Step 5: Verify the #76 regression is fixed**
+
+With two servers on the network and `"Mode": "AdvertiseOnly"`, let one connect and start playback, then have the second server target this player. Confirm in the log:
+
+- an `Arbitration:` line from `SendspinHostService` deciding between them
+- **no** `Rejecting server-initiated connection` line (that code is deleted)
+- **no** `Clock synchronizer reset` followed by `Pipeline state: "Playing" -> "Stopping"` unless arbitration genuinely displaced the current server
+
+- [ ] **Step 6: Verify a runtime mode switch never overlaps transports**
+
+Launch the app, open Settings, and switch the connection mode dropdown from
+`Let servers connect to me` to `I choose a server`, then back. After each switch:
+
+```powershell
+$logs = "$env:LOCALAPPDATA\Sendspin for Windows\logs"
+$f = Get-ChildItem $logs -Filter *.log | Where-Object { $_.Name -notlike "sync-health*" } |
+     Sort-Object LastWriteTime -Descending | Select-Object -First 1
+Get-Content $f.FullName | Select-String -Pattern "Host service started|Host service stopped|Server discovery started|Server discovery stopped"
+```
+
+Expected: every switch produces a *stopped* line before the matching *started* line — for example
+`Host service stopped` then `Server discovery started`. A *started* line appearing before the other
+transport's *stopped* line means the two overlapped and Task 3 Step 2 was not applied correctly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Sendspin.Windows/appsettings.json
+git commit -m "feat: default to server-initiated connections
+
+Server-initiated is the spec-recommended mode: its multi-server admission
+rules are standardized, whereas client-initiated multi-server handling is
+explicitly implementation-defined. Existing configs carrying Auto migrate
+to this value on load.
+
+Closes #76"
+```
+
+---
+
+## Post-implementation
+
+1. Open a PR against `release/2.2.4`.
+2. Forward-port the whole branch to `master`.
+3. Port the `claude.md` connection-mode correction (PR #77, which targets `master`) back to `release/2.2.4`. Note the two branches' `claude.md` files have already diverged — `release/2.2.4` carries newer sync-correction constants that `master` lacks — so reconcile rather than overwrite.
+4. `v2.2.4` is not yet tagged, so this default flip lands before release rather than changing behaviour under existing users.

--- a/docs/superpowers/specs/2026-08-30-spec-compliant-connection-modes-design.md
+++ b/docs/superpowers/specs/2026-08-30-spec-compliant-connection-modes-design.md
@@ -1,0 +1,219 @@
+# Spec-compliant connection modes — design note
+
+Removes the `Auto` connection mode, makes the two transports mutually exclusive, and defaults
+to server-initiated. Tracked as [#76](https://github.com/chrisuthe/windowsSpin/issues/76).
+
+## Symptom
+
+With two Music Assistant servers on the network, a second server connecting server-initiated
+kills the *active* client-initiated session. Playback stops, the clock synchronizer resets, and
+the pipeline goes `Playing → Stopping → Idle`. Observed 2026-08-30 at 12:19:17.
+
+## Spec ground truth
+
+Validated against [sendspin/spec](https://github.com/sendspin/spec) @ `9d8a4dc`, `connection.md`.
+
+> Sendspin has two standard ways to establish connections: Server and Client initiated. **Server
+> Initiated connections are recommended** as they provide standardized multi-server behavior, but
+> require mDNS which may not be available in all environments.
+>
+> Servers must support both methods described below. **Clients MUST use exactly one of the two
+> methods at a time**, advertising or discovering accordingly.
+
+Restated as two prohibitions:
+
+> **Note:** Do not manually connect to servers if you are advertising `_sendspin._tcp`.
+>
+> **Note:** Do not advertise `_sendspin._tcp` if the client plans to initiate the connection.
+
+Multi-server admission is fully specified for server-initiated and explicitly *not* specified for
+client-initiated:
+
+| | Server-initiated | Client-initiated |
+|---|---|---|
+| Multi-server rules | Standardized: one admitted connection, ranked `management` > `playback` > `pairing` (empty lowest); incoming accepted on higher-or-equal priority; provisional until first `server/activate`, dropped at 30s; last-playback-server tiebreak; `another_server` / `concurrent_attempt` goodbyes | "How clients handle multiple discovered servers, server selection, and switching is **implementation-defined**" |
+
+That asymmetry is the reason the spec recommends server-initiated, and the reason we default to it.
+
+## Root cause
+
+`Connection:Mode = "Auto"` — the shipped default — starts **both** transports:
+
+```csharp
+// MainViewModel.InitializeAsync
+if (mode != ConnectionMode.DiscoverOnly)  { await _hostService.StartAsync();     IsHosting = true; }
+if (mode != ConnectionMode.AdvertiseOnly) { await _serverDiscovery.StartAsync(); }
+```
+
+Two independent `if`s, each excluding one mode. `Auto` is excluded by neither, so both run. This is
+the MUST violation, and everything below follows from it.
+
+Three consequences:
+
+1. **Arbitration decides with half the picture.** `SendspinHostService` tracks only host-mode
+   connections, so it logs `Arbitration: Accepting <id> (no existing connection)` while a
+   client-initiated session is playing. It is not wrong — per spec that state cannot occur.
+2. **The app overrides the SDK with a sledgehammer.** `MainViewModel.OnServerConnected` calls
+   `_hostService.DisconnectAllAsync("already_connected")` to reject one unwanted socket.
+   `already_connected` is not a spec reason (`concurrent_attempt` is).
+3. **Shared singletons carry the blast radius.** The two transports are separate
+   `SendspinClientService` instances (`_manualClient` vs the host service's own), but both are
+   constructed against the same injected `IAudioPipeline` and `IClockSynchronizer`. Tearing down
+   one resets state the other is using.
+
+### Evidence
+
+```
+12:19:17.461  SendspinListener:    WebSocket connection opened from 10.0.2.8
+12:19:17.471  Arbitration: Accepting OraobU4... (no existing connection)
+12:19:17.471  MainViewModel: Rejecting server-initiated connection ... already connected via
+                             client-initiated mode
+12:19:17.471  SendspinHostService: Disconnecting server OraobU4...: already_connected
+12:19:17.471  KalmanClockSynchronizer: Clock synchronizer reset
+12:19:17.478  SendspinConnection:  Server closed connection: "NormalClosure"     <- the live one
+12:19:17.503  SendspinClientService: Disconnecting: restart
+12:19:17.503  AudioPipeline: Pipeline state: "Playing" -> "Stopping"
+```
+
+## Design
+
+### 1. Exclusive transports
+
+`InitializeAsync` becomes an if/else:
+
+```csharp
+if (mode == ConnectionMode.AdvertiseOnly)
+{
+    await _hostService.StartAsync();
+    IsHosting = true;
+}
+else
+{
+    await _serverDiscovery.StartAsync();
+}
+```
+
+Exclusivity is then structural — no comment or convention is holding the invariant. The same
+change applies to the runtime mode-switch path (`ApplyConnectionModeAsync`, ~line 2116).
+
+### 2. Mode mapping and migration
+
+`Auto` currently appears in four places, three of them as a `_ =>` fallback:
+
+| Site | Current |
+|---|---|
+| `AvailableConnectionModes` | `{ "Auto", "Advertise Only", "Discover Only" }` |
+| `ParseConnectionMode` | `_ => ConnectionMode.Auto` |
+| `OnSettingsConnectionModeChanged` | `_ => "Auto"` |
+| Settings load (~line 2360) | `_ => "Auto"` |
+
+Every one of those defaults becomes wrong at once, and missing a single one silently resurrects the
+violating mode. This is the part that can fail quietly, so it is the part that gets extracted and
+tested.
+
+Add `ConnectionModeMapping` to `src/Sendspin.Windows.Services/Configuration/` — pure, no WPF
+dependency, unit-testable in the existing `Sendspin.Windows.Services.Tests` project:
+
+- `FromConfigValue(string?) → ConnectionMode` — `"DiscoverOnly"` → `DiscoverOnly`; everything else,
+  including legacy `"Auto"`, `null`, empty, and unrecognized strings → `AdvertiseOnly`.
+- `ToConfigValue(ConnectionMode) → string`
+- `ToDisplayName` / `FromDisplayName` for the settings dropdown.
+
+The SDK's `ConnectionMode` enum is retained as-is for 2.2.x. `Auto` remains *representable* but the
+mapping never produces it. Removing it upstream is
+[sendspin-dotnet#254](https://github.com/Sendspin/sendspin-dotnet/issues/254), targeted at v10.
+
+Migration is silent and one-way: a stored `"Auto"` loads as `AdvertiseOnly` and is rewritten on the
+next settings save. Logged at information level. No prompt — `Auto` was never a valid
+configuration, so there is no user intent to preserve.
+
+### 3. Defer to SDK arbitration
+
+Delete the rejection block in `OnServerConnected` entirely:
+
+```csharp
+// DELETED
+if (_manualClient?.ConnectionState == ConnectionState.Connected)
+{
+    _hostService.DisconnectAllAsync("already_connected").SafeFireAndForget(_logger);
+    return;
+}
+```
+
+With exclusive modes, a client-initiated connection cannot coexist with the host service, so the
+guard is unreachable by construction. `SendspinHostService` already arbitrates correctly in v9.3.0 —
+priority comparison, `LastPlayedServerId` tiebreak, `DisconnectExistingAsync(existing,
+"another_server")` for a displaced connection and `newConnection.DisconnectAsync(...)` for a rejected
+one. Nothing app-side needs to help.
+
+### 4. UI
+
+- **`AdvertiseOnly` (default):** no server picker. Status reads as advertising and waiting for a
+  server. The discovered-servers list, the "connect once / connect always" dialog, and
+  `AutoConnectServerId` are all hidden — they express a choice this mode does not have. Pairing
+  affordances are future work, out of scope here.
+- **`DiscoverOnly`:** current picker behaviour, unchanged.
+- Settings dropdown offers exactly two options. Labels describe what happens rather than naming a
+  transport, and are fixed as:
+
+  | Display name | Config value | `ConnectionMode` |
+  |---|---|---|
+  | `Let servers connect to me` | `AdvertiseOnly` | `AdvertiseOnly` |
+  | `I choose a server` | `DiscoverOnly` | `DiscoverOnly` |
+
+  These strings are the mapping's contract in both directions, so they are pinned here rather than
+  left to implementation choice.
+
+### 5. Config keys
+
+Both keys stay, each scoped to one mode:
+
+- `AutoConnectServerId` — `DiscoverOnly` only. Set by "connect always".
+- `LastPlayedServerId` — `AdvertiseOnly` only. The spec's last-playback server, already passed to
+  `SendspinHostService` at construction and used as the arbitration tiebreak.
+
+## Explicitly not doing
+
+- **No connection coordinator or transport abstraction.** An if/else over two mutually exclusive
+  options is already exclusive by construction; wrapping it in a class would add a type whose tests
+  could only assert against mocks.
+- **Not removing client-initiated.** The spec permits it, and it is the documented fallback for
+  networks where the server cannot discover or reach the client.
+- **Not changing the SDK enum in this work.** Tracked upstream as #254.
+- **No user prompt on migration.**
+
+## Testing
+
+Unit tests (`Sendspin.Windows.Services.Tests`) for `ConnectionModeMapping`:
+
+- legacy `"Auto"` → `AdvertiseOnly`
+- `null` / empty / whitespace / unrecognized → `AdvertiseOnly`
+- `"DiscoverOnly"` → `DiscoverOnly`, `"AdvertiseOnly"` → `AdvertiseOnly`
+- config-value and display-name round trips
+- `FromConfigValue` never returns `ConnectionMode.Auto` for any input, including `"Auto"`
+
+`MainViewModel` has no test project, so the if/else and UI gating are verified manually:
+
+1. Fresh config → advertises, does not discover; server connects and plays.
+2. Config carrying `"Auto"` → loads as `AdvertiseOnly`, migration logged.
+3. `DiscoverOnly` → discovers, does not advertise; picker present.
+4. Two servers, `AdvertiseOnly` → second server arbitrated by the SDK; the playing session is not
+   dropped. This is the #76 regression check.
+5. Mode switch at runtime tears down one transport before starting the other.
+
+## Rollout
+
+Land on `release/2.2.4`, forward-port to `master`. v2.2.4 is not yet tagged, so the default flip
+lands before release rather than changing behaviour under existing users.
+
+`claude.md` guidance was corrected ahead of this work in
+[#77](https://github.com/chrisuthe/windowsSpin/pull/77), which targets `master`; it needs the same
+forward/back-port so both lines describe the spec-correct stance.
+
+## Open risk
+
+Cross-subnet reachability is unverified. `claude.md` previously claimed client-initiated was "more
+reliable for cross-subnet scenarios", but the 12:19:17 trace shows `10.0.2.8` successfully reaching
+this client server-initiated across a subnet boundary, which is evidence against that claim. If
+server-initiated turns out not to work in some network we care about, `DiscoverOnly` remains
+available as an explicit opt-in — that is precisely why it is being kept.

--- a/src/Sendspin.Windows.Services/Configuration/ConnectionModeMapping.cs
+++ b/src/Sendspin.Windows.Services/Configuration/ConnectionModeMapping.cs
@@ -1,0 +1,62 @@
+using Sendspin.SDK.Client;
+
+namespace Sendspin.Windows.Services.Configuration;
+
+/// <summary>
+/// Maps connection mode between its persisted config value, its settings display name, and
+/// <see cref="ConnectionMode"/>.
+/// </summary>
+public static class ConnectionModeMapping
+{
+    /// <summary>Display name for server-initiated mode.</summary>
+    public const string AdvertiseOnlyDisplayName = "Let servers connect to me";
+
+    /// <summary>Display name for client-initiated mode.</summary>
+    public const string DiscoverOnlyDisplayName = "I choose a server";
+
+    private const string AdvertiseOnlyConfigValue = "AdvertiseOnly";
+    private const string DiscoverOnlyConfigValue = "DiscoverOnly";
+
+    /// <summary>Gets the display names offered in the settings dropdown, in order.</summary>
+    public static string[] DisplayNames { get; } =
+    {
+        AdvertiseOnlyDisplayName,
+        DiscoverOnlyDisplayName,
+    };
+
+    /// <summary>Maps a persisted config value to a mode.</summary>
+    /// <param name="configValue">The stored value, which may be legacy or absent.</param>
+    /// <returns>The mode; never <see cref="ConnectionMode.Auto"/>.</returns>
+    /// <remarks>
+    /// Anything unrecognized — including the legacy "Auto", which ran both transports in
+    /// violation of the spec — resolves to <see cref="ConnectionMode.AdvertiseOnly"/>.
+    /// </remarks>
+    public static ConnectionMode FromConfigValue(string? configValue)
+        => configValue == DiscoverOnlyConfigValue
+            ? ConnectionMode.DiscoverOnly
+            : ConnectionMode.AdvertiseOnly;
+
+    /// <summary>Maps a mode to its persisted config value.</summary>
+    /// <param name="mode">The mode to persist.</param>
+    /// <returns>The config value.</returns>
+    public static string ToConfigValue(ConnectionMode mode)
+        => mode == ConnectionMode.DiscoverOnly
+            ? DiscoverOnlyConfigValue
+            : AdvertiseOnlyConfigValue;
+
+    /// <summary>Maps a mode to its settings display name.</summary>
+    /// <param name="mode">The mode to display.</param>
+    /// <returns>The display name.</returns>
+    public static string ToDisplayName(ConnectionMode mode)
+        => mode == ConnectionMode.DiscoverOnly
+            ? DiscoverOnlyDisplayName
+            : AdvertiseOnlyDisplayName;
+
+    /// <summary>Maps a settings display name to a mode.</summary>
+    /// <param name="displayName">The selected display name.</param>
+    /// <returns>The mode; never <see cref="ConnectionMode.Auto"/>.</returns>
+    public static ConnectionMode FromDisplayName(string? displayName)
+        => displayName == DiscoverOnlyDisplayName
+            ? ConnectionMode.DiscoverOnly
+            : ConnectionMode.AdvertiseOnly;
+}

--- a/src/Sendspin.Windows/MainWindow.xaml
+++ b/src/Sendspin.Windows/MainWindow.xaml
@@ -237,8 +237,10 @@
                         </StackPanel>
                     </Border>
 
-                    <!-- Section 2: Available Servers -->
-                    <Border Style="{StaticResource WelcomeCardStyle}">
+                    <!-- Section 2: Available Servers (client-initiated mode only — in
+                         server-initiated mode the server chooses when to connect) -->
+                    <Border Style="{StaticResource WelcomeCardStyle}"
+                            Visibility="{Binding IsDiscoverMode, Converter={StaticResource BoolToVisibilityConverter}}">
                         <StackPanel>
                             <TextBlock Text="Available Servers" Style="{StaticResource WelcomeSectionHeader}"/>
 
@@ -318,6 +320,32 @@
                                            TextWrapping="Wrap"
                                            TextAlignment="Center"/>
                             </StackPanel>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Server-initiated mode: we advertise and wait. No picker — the server
+                         decides when to connect. Pairing affordances are future work. -->
+                    <Border>
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource WelcomeCardStyle}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsDiscoverMode}" Value="True">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="Waiting for a Server" Style="{StaticResource WelcomeSectionHeader}"/>
+                            <TextBlock Text="📡" Style="{StaticResource SearchingIcon}"/>
+                            <TextBlock Text="Advertising on your network. Select this player in Music Assistant to connect."
+                                       Style="{StaticResource CaptionText}"
+                                       HorizontalAlignment="Center"
+                                       TextAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       Foreground="{StaticResource TextMutedBrush}"
+                                       Margin="0,8,0,0"/>
                         </StackPanel>
                     </Border>
 

--- a/src/Sendspin.Windows/MainWindow.xaml
+++ b/src/Sendspin.Windows/MainWindow.xaml
@@ -349,9 +349,19 @@
                         </StackPanel>
                     </Border>
 
-                    <!-- Section 3: Manual Connection (collapsible) -->
-                    <Expander Header="Advanced: Connect by URL"
-                              Style="{StaticResource CollapsibleSectionStyle}">
+                    <!-- Section 3: Manual Connection (collapsible, client-initiated mode only —
+                         connecting out while advertising would run both transports at once) -->
+                    <Expander Header="Advanced: Connect by URL">
+                        <Expander.Style>
+                            <Style TargetType="Expander" BasedOn="{StaticResource CollapsibleSectionStyle}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsDiscoverMode}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Expander.Style>
                         <StackPanel>
                             <TextBlock Text="For cross-subnet connections, enter the server URL directly (e.g. ws://10.0.2.8:8927):"
                                        Style="{StaticResource BodyText}"

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -631,30 +631,25 @@ public partial class MainViewModel : ViewModelBase
 
         try
         {
-            // Start host service (server-initiated mode) unless DiscoverOnly
-            if (mode != ConnectionMode.DiscoverOnly)
+            // Exactly one transport, per spec: a client MUST use exactly one of the two
+            // connection methods at a time. An if/else keeps that structural — the previous
+            // pair of independent ifs let Auto satisfy neither exclusion and start both.
+            if (mode == ConnectionMode.DiscoverOnly)
+            {
+                StatusMessage = "Discovering Sendspin servers...";
+                await _serverDiscovery.StartAsync();
+                _logger.LogInformation("Server discovery started, looking for _sendspin-server._tcp");
+                StatusMessage = "Searching for servers...";
+            }
+            else
             {
                 StatusMessage = "Starting host service...";
                 await _hostService.StartAsync();
                 ClientId = _hostService.ClientId;
                 IsHosting = true;
                 _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
+                StatusMessage = $"Waiting for a server to connect...\nClient ID: {ClientId}";
             }
-
-            // Start server discovery (client-initiated mode) unless AdvertiseOnly
-            if (mode != ConnectionMode.AdvertiseOnly)
-            {
-                StatusMessage = "Discovering Sendspin servers...";
-                await _serverDiscovery.StartAsync();
-                _logger.LogInformation("Server discovery started, looking for _sendspin-server._tcp");
-            }
-
-            StatusMessage = mode switch
-            {
-                ConnectionMode.AdvertiseOnly => $"Advertising as player...\nClient ID: {ClientId}",
-                ConnectionMode.DiscoverOnly => "Searching for servers...",
-                _ => $"Searching for servers...\nClient ID: {ClientId}"
-            };
         }
         catch (Exception ex)
         {
@@ -2086,7 +2081,7 @@ public partial class MainViewModel : ViewModelBase
             _logger.LogInformation("Connection mode saved: {Mode}", mode);
 
             // Apply mode change immediately
-            await ApplyConnectionModeAsync(mode);
+            await ApplyConnectionModeAsync(ConnectionModeMapping.FromConfigValue(mode));
         }
         catch (Exception ex)
         {
@@ -2094,24 +2089,22 @@ public partial class MainViewModel : ViewModelBase
         }
     }
 
-    private async Task ApplyConnectionModeAsync(string mode)
+    private async Task ApplyConnectionModeAsync(ConnectionMode mode)
     {
-        var shouldAdvertise = mode != "DiscoverOnly";
-        var shouldDiscover = mode != "AdvertiseOnly";
+        var shouldAdvertise = mode != ConnectionMode.DiscoverOnly;
 
-        // Start or stop host service (advertising)
-        if (shouldAdvertise && !IsHosting)
+        // Stop the outgoing transport BEFORE starting the incoming one, so the two are never
+        // running together even momentarily.
+        if (shouldAdvertise && _serverDiscovery.IsDiscovering)
         {
             try
             {
-                await _hostService.StartAsync();
-                ClientId = _hostService.ClientId;
-                IsHosting = true;
-                _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
+                await _serverDiscovery.StopAsync();
+                _logger.LogInformation("Server discovery stopped");
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to start host service");
+                _logger.LogWarning(ex, "Failed to stop server discovery");
             }
         }
         else if (!shouldAdvertise && IsHosting)
@@ -2128,8 +2121,21 @@ public partial class MainViewModel : ViewModelBase
             }
         }
 
-        // Start or stop server discovery
-        if (shouldDiscover && !_serverDiscovery.IsDiscovering)
+        if (shouldAdvertise && !IsHosting)
+        {
+            try
+            {
+                await _hostService.StartAsync();
+                ClientId = _hostService.ClientId;
+                IsHosting = true;
+                _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to start host service");
+            }
+        }
+        else if (!shouldAdvertise && !_serverDiscovery.IsDiscovering)
         {
             try
             {
@@ -2141,27 +2147,6 @@ public partial class MainViewModel : ViewModelBase
                 _logger.LogWarning(ex, "Failed to start server discovery");
             }
         }
-        else if (!shouldDiscover && _serverDiscovery.IsDiscovering)
-        {
-            try
-            {
-                await _serverDiscovery.StopAsync();
-                DiscoveredServers.Clear();
-                _logger.LogInformation("Server discovery stopped");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to stop server discovery");
-            }
-        }
-
-        // Update status message
-        StatusMessage = mode switch
-        {
-            "AdvertiseOnly" => $"Advertising as player...\nClient ID: {ClientId}",
-            "DiscoverOnly" => "Searching for servers...",
-            _ => $"Searching for servers...\nClient ID: {ClientId}"
-        };
     }
 
     partial void OnVolumeChanged(int value)

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -2092,6 +2092,7 @@ public partial class MainViewModel : ViewModelBase
     private async Task ApplyConnectionModeAsync(ConnectionMode mode)
     {
         var shouldAdvertise = mode != ConnectionMode.DiscoverOnly;
+        var stopped = true;
 
         // Stop the outgoing transport BEFORE starting the incoming one, so the two are never
         // running together even momentarily.
@@ -2106,6 +2107,7 @@ public partial class MainViewModel : ViewModelBase
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to stop server discovery");
+                stopped = false;
             }
         }
         else if (!shouldAdvertise && IsHosting)
@@ -2119,7 +2121,14 @@ public partial class MainViewModel : ViewModelBase
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to stop host service");
+                stopped = false;
             }
+        }
+
+        if (!stopped)
+        {
+            _logger.LogError("Aborting connection mode switch: the outgoing transport did not stop, so starting the other one would run both at once");
+            return;
         }
 
         if (shouldAdvertise && !IsHosting)

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -1240,16 +1240,11 @@ public partial class MainViewModel : ViewModelBase
     {
         App.Current.Dispatcher.Invoke(() =>
         {
-            // Reject server-initiated connections if we already have a client-initiated connection
-            if (_manualClient?.ConnectionState == ConnectionState.Connected)
-            {
-                _logger.LogInformation(
-                    "Rejecting server-initiated connection from {ServerName} - already connected via client-initiated mode",
-                    server.ServerName);
-                _hostService.DisconnectAllAsync("already_connected").SafeFireAndForget(_logger);
-                return;
-            }
-
+            // No app-side arbitration. SendspinHostService already applies the spec's admission
+            // rules (activity ranking, LastPlayedServerId tiebreak) and disconnects only the
+            // loser. The previous guard here called DisconnectAllAsync to reject a single
+            // unwanted socket, which tore down every connection and reset the shared
+            // IAudioPipeline and IClockSynchronizer that the playing session was using.
             ConnectedServers.Add(server);
             ConnectedServerName = server.ServerName;
             StatusMessage = $"Connected to {server.ServerName}";

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -2089,6 +2089,23 @@ public partial class MainViewModel : ViewModelBase
         var shouldAdvertise = mode != ConnectionMode.DiscoverOnly;
         var stopped = true;
 
+        // Leaving DiscoverOnly ends the client-initiated connection, whether or not discovery
+        // itself happens to be running (e.g. if StartAsync failed earlier and IsDiscovering
+        // never became true, a manual connection could still be live).
+        if (shouldAdvertise && _manualClient?.ConnectionState == ConnectionState.Connected)
+        {
+            try
+            {
+                await _manualClient.DisconnectAsync();
+                _logger.LogInformation("Manual client disconnected");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to disconnect manual client");
+                stopped = false;
+            }
+        }
+
         // Stop the outgoing transport BEFORE starting the incoming one, so the two are never
         // running together even momentarily.
         if (shouldAdvertise && _serverDiscovery.IsDiscovering)
@@ -2103,23 +2120,6 @@ public partial class MainViewModel : ViewModelBase
             {
                 _logger.LogWarning(ex, "Failed to stop server discovery");
                 stopped = false;
-            }
-
-            // A manual (DiscoverOnly) connection is a live use of the same singleton audio
-            // pipeline as the host service would use, so it must be torn down before we
-            // advertise -- otherwise both transports end up live at once.
-            if (_manualClient != null && _manualClient.ConnectionState == ConnectionState.Connected)
-            {
-                try
-                {
-                    await _manualClient.DisconnectAsync();
-                    _logger.LogInformation("Manual client disconnected");
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to disconnect manual client");
-                    stopped = false;
-                }
             }
         }
         else if (!shouldAdvertise && IsHosting)

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -2100,6 +2100,7 @@ public partial class MainViewModel : ViewModelBase
             try
             {
                 await _serverDiscovery.StopAsync();
+                App.Current.Dispatcher.Invoke(() => DiscoveredServers.Clear());
                 _logger.LogInformation("Server discovery stopped");
             }
             catch (Exception ex)
@@ -2147,6 +2148,13 @@ public partial class MainViewModel : ViewModelBase
                 _logger.LogWarning(ex, "Failed to start server discovery");
             }
         }
+
+        // Update status message to reflect the new mode.
+        StatusMessage = mode switch
+        {
+            ConnectionMode.DiscoverOnly => "Searching for servers...",
+            _ => $"Advertising as player...\nClient ID: {ClientId}",
+        };
     }
 
     partial void OnVolumeChanged(int value)

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -361,7 +361,8 @@ public partial class MainViewModel : ViewModelBase
     private string _settingsStreamType = "FLAC (lossless, more bandwidth)";
 
     /// <summary>
-    /// Gets or sets the connection mode (Auto, Advertise Only, Discover Only).
+    /// Gets or sets the connection mode: "Let servers connect to me" (server-initiated) or
+    /// "I choose a server" (client-initiated).
     /// Controls how the client establishes connections with servers.
     /// </summary>
     [ObservableProperty]
@@ -436,9 +437,22 @@ public partial class MainViewModel : ViewModelBase
     private string _autoConnectServerId = string.Empty;
 
     /// <summary>
-    /// Gets whether we're currently searching for servers (no servers found yet).
+    /// Gets whether the client picks its own server (client-initiated mode). The server list and
+    /// the auto-connect preference are meaningful only in this mode; in server-initiated mode the
+    /// server decides when to connect.
     /// </summary>
-    public bool IsSearchingForServers => DiscoveredServers.Count == 0 && IsHosting;
+    public bool IsDiscoverMode
+        => ConnectionModeMapping.FromDisplayName(SettingsConnectionMode) == ConnectionMode.DiscoverOnly;
+
+    /// <summary>
+    /// Gets whether a discovery scan is running and has not yet found anything.
+    /// </summary>
+    /// <remarks>
+    /// Keyed off discovery, not hosting. It previously read <c>IsHosting</c>, which only appeared
+    /// correct because Auto ran both transports; in server-initiated mode that would show a
+    /// permanent "searching" state for a mode that never searches.
+    /// </remarks>
+    public bool IsSearchingForServers => IsDiscoverMode && DiscoveredServers.Count == 0;
 
     /// <summary>
     /// Gets whether the client is connected to any Sendspin server,
@@ -2066,6 +2080,9 @@ public partial class MainViewModel : ViewModelBase
         var configValue = ConnectionModeMapping.ToConfigValue(
             ConnectionModeMapping.FromDisplayName(value));
         SaveConnectionModeAsync(configValue).SafeFireAndForget(_logger);
+
+        OnPropertyChanged(nameof(IsDiscoverMode));
+        OnPropertyChanged(nameof(IsSearchingForServers));
     }
 
     private async Task SaveConnectionModeAsync(string mode)
@@ -2174,7 +2191,7 @@ public partial class MainViewModel : ViewModelBase
         StatusMessage = mode switch
         {
             ConnectionMode.DiscoverOnly => "Searching for servers...",
-            _ => $"Advertising as player...\nClient ID: {ClientId}",
+            _ => $"Waiting for a server to connect...\nClient ID: {ClientId}",
         };
     }
 

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -101,6 +101,27 @@ public partial class MainViewModel : ViewModelBase
     private SendspinClientService? _manualClient;
     private ISendspinConnection? _manualConnection;
     private readonly SemaphoreSlim _cleanupLock = new(1, 1);
+
+    /// <summary>
+    /// Serializes connection mode transitions. Mode changes are started fire-and-forget from the
+    /// property-changed callback, so without this two rapid switches can interleave their
+    /// stop/check/start phases — one stops the host, the next restarts it, then the first starts
+    /// discovery — and leave both transports running.
+    /// </summary>
+    private readonly SemaphoreSlim _connectionModeLock = new(1, 1);
+
+    /// <summary>
+    /// The connection mode whose transport is actually running.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="SettingsConnectionMode"/>, which holds the mode the user
+    /// <em>requested</em> and is already assigned (and persisted) before
+    /// <see cref="ApplyConnectionModeAsync"/> even runs. An aborted switch would otherwise leave
+    /// every mode guard reading a mode that never took effect. Only set once a transport has
+    /// actually started; never on an abort path.
+    /// </remarks>
+    private ConnectionMode _activeConnectionMode = ConnectionMode.AdvertiseOnly;
+
     private string? _lastArtworkUrl;
     private string? _autoConnectedServerId;
     private bool _autoReconnectEnabled = true;
@@ -441,8 +462,12 @@ public partial class MainViewModel : ViewModelBase
     /// the auto-connect preference are meaningful only in this mode; in server-initiated mode the
     /// server decides when to connect.
     /// </summary>
-    public bool IsDiscoverMode
-        => ConnectionModeMapping.FromDisplayName(SettingsConnectionMode) == ConnectionMode.DiscoverOnly;
+    /// <remarks>
+    /// Reads <see cref="_activeConnectionMode"/>, not <see cref="SettingsConnectionMode"/>: the
+    /// requested mode is assigned before the transition runs, so a switch that aborts would
+    /// otherwise expose the manual-connect UI while the host service is still hosting.
+    /// </remarks>
+    public bool IsDiscoverMode => _activeConnectionMode == ConnectionMode.DiscoverOnly;
 
     /// <summary>
     /// Gets whether a discovery scan is running and has not yet found anything.
@@ -450,9 +475,12 @@ public partial class MainViewModel : ViewModelBase
     /// <remarks>
     /// Keyed off discovery, not hosting. It previously read <c>IsHosting</c>, which only appeared
     /// correct because Auto ran both transports; in server-initiated mode that would show a
-    /// permanent "searching" state for a mode that never searches.
+    /// permanent "searching" state for a mode that never searches. It also asks the transport
+    /// whether it is actually discovering — a failed start, or a switch that aborted before
+    /// starting discovery, must not show a "searching" indicator for a scan that is not running.
     /// </remarks>
-    public bool IsSearchingForServers => IsDiscoverMode && DiscoveredServers.Count == 0;
+    public bool IsSearchingForServers
+        => IsDiscoverMode && _serverDiscovery.IsDiscovering && DiscoveredServers.Count == 0;
 
     /// <summary>
     /// Gets whether the client is connected to any Sendspin server,
@@ -652,6 +680,7 @@ public partial class MainViewModel : ViewModelBase
             {
                 StatusMessage = "Discovering Sendspin servers...";
                 await _serverDiscovery.StartAsync();
+                OnPropertyChanged(nameof(IsSearchingForServers));
                 _logger.LogInformation("Server discovery started, looking for _sendspin-server._tcp");
                 StatusMessage = "Searching for servers...";
             }
@@ -664,10 +693,14 @@ public partial class MainViewModel : ViewModelBase
                 _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
                 StatusMessage = $"Waiting for a server to connect...\nClient ID: {ClientId}";
             }
+
+            // Only now is a transport actually running, so only now may the mode guards see it.
+            SetActiveConnectionMode(mode);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to initialize");
+            OnPropertyChanged(nameof(IsSearchingForServers));
 
             if (mode != ConnectionMode.DiscoverOnly)
             {
@@ -690,6 +723,18 @@ public partial class MainViewModel : ViewModelBase
             StatusMessage = $"Failed to start: {ex.Message}";
             SetError($"Failed to initialize: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Records the mode whose transport is actually running and refreshes the UI state derived
+    /// from it. Call only once a transport has started — never on an abort path, where the
+    /// requested mode never took effect.
+    /// </summary>
+    private void SetActiveConnectionMode(ConnectionMode mode)
+    {
+        _activeConnectionMode = mode;
+        OnPropertyChanged(nameof(IsDiscoverMode));
+        OnPropertyChanged(nameof(IsSearchingForServers));
     }
 
     [RelayCommand]
@@ -909,8 +954,9 @@ public partial class MainViewModel : ViewModelBase
     /// This handles creation of the connection, client service, and event subscriptions.
     /// </summary>
     /// <remarks>
-    /// Invariant: every caller must confirm <c>ConnectionModeMapping.FromDisplayName(SettingsConnectionMode)
-    /// == ConnectionMode.DiscoverOnly</c> before calling this. The check cannot live here because
+    /// Invariant: every caller must confirm <c>_activeConnectionMode == ConnectionMode.DiscoverOnly</c>
+    /// before calling this — the mode that actually took effect, not the requested
+    /// <see cref="SettingsConnectionMode"/>. The check cannot live here because
     /// every caller immediately dereferences <c>_manualClient!</c> with null-forgiving right after
     /// calling this method; a guard here that skipped creation would turn a refused connect into a
     /// NullReferenceException instead. Guard at each call site instead.
@@ -943,10 +989,11 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private async Task ConnectToServerAsync()
     {
-        var mode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
-        if (mode != ConnectionMode.DiscoverOnly)
+        // The mode that actually took effect, not the requested one: an aborted switch leaves
+        // SettingsConnectionMode holding a mode whose transport never started.
+        if (_activeConnectionMode != ConnectionMode.DiscoverOnly)
         {
-            _logger.LogWarning("Refusing manual connect: connection mode is {Mode}, not DiscoverOnly", mode);
+            _logger.LogWarning("Refusing manual connect: active connection mode is {Mode}, not DiscoverOnly", _activeConnectionMode);
             return;
         }
 
@@ -1642,10 +1689,11 @@ public partial class MainViewModel : ViewModelBase
 
     private async Task AutoConnectToServerAsync(DiscoveredServer server)
     {
-        var mode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
-        if (mode != ConnectionMode.DiscoverOnly)
+        // The mode that actually took effect, not the requested one: an aborted switch leaves
+        // SettingsConnectionMode holding a mode whose transport never started.
+        if (_activeConnectionMode != ConnectionMode.DiscoverOnly)
         {
-            _logger.LogWarning("Refusing auto-connect to {Name}: connection mode is {Mode}, not DiscoverOnly", server.Name, mode);
+            _logger.LogWarning("Refusing auto-connect to {Name}: active connection mode is {Mode}, not DiscoverOnly", server.Name, _activeConnectionMode);
             return;
         }
 
@@ -2138,15 +2186,53 @@ public partial class MainViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Switches the running transport to match <paramref name="mode"/>: stop the outgoing one,
+    /// verify it stopped, then start the incoming one, so the two never run together.
+    /// </summary>
+    /// <remarks>
+    /// Serialized on <see cref="_connectionModeLock"/>. Callers start this fire-and-forget, and
+    /// two interleaved transitions could otherwise stop the host, restart it, then start
+    /// discovery — both transports at once.
+    /// </remarks>
     private async Task ApplyConnectionModeAsync(ConnectionMode mode)
+    {
+        await _connectionModeLock.WaitAsync();
+        try
+        {
+            // A newer request may have been queued behind this one while it waited on the lock.
+            // The newest request is the one the user meant; running a stale one now would undo it.
+            var requestedMode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
+            if (requestedMode != mode)
+            {
+                _logger.LogInformation(
+                    "Skipping superseded connection mode transition to {Mode}; {RequestedMode} is now requested",
+                    mode, requestedMode);
+                return;
+            }
+
+            await ApplyConnectionModeCoreAsync(mode);
+        }
+        finally
+        {
+            _connectionModeLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// The stop/check/start body of a mode transition. Runs under <see cref="_connectionModeLock"/>.
+    /// </summary>
+    private async Task ApplyConnectionModeCoreAsync(ConnectionMode mode)
     {
         var shouldAdvertise = mode != ConnectionMode.DiscoverOnly;
         var stopped = true;
 
         // Leaving DiscoverOnly ends the client-initiated connection, whether or not discovery
         // itself happens to be running (e.g. if StartAsync failed earlier and IsDiscovering
-        // never became true, a manual connection could still be live).
-        if (shouldAdvertise && _manualClient?.ConnectionState == ConnectionState.Connected)
+        // never became true, a manual connection could still be live). Anything short of
+        // Disconnected counts: a client still in Connecting has a ConnectAsync in flight that
+        // would otherwise complete after the host service started advertising.
+        if (shouldAdvertise && _manualClient is not null && _manualClient.ConnectionState != ConnectionState.Disconnected)
         {
             try
             {
@@ -2175,6 +2261,8 @@ public partial class MainViewModel : ViewModelBase
                 _logger.LogWarning(ex, "Failed to stop server discovery");
                 stopped = false;
             }
+
+            OnPropertyChanged(nameof(IsSearchingForServers));
         }
         else if (!shouldAdvertise)
         {
@@ -2199,6 +2287,8 @@ public partial class MainViewModel : ViewModelBase
 
         if (!stopped)
         {
+            // Deliberately leaves _activeConnectionMode alone: the requested mode never took
+            // effect, and the guards that read it must keep refusing work for it.
             _logger.LogError("Aborting connection mode switch: the outgoing transport did not stop, so starting the other one would run both at once");
             return;
         }
@@ -2215,6 +2305,21 @@ public partial class MainViewModel : ViewModelBase
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to start host service");
+
+                // StartAsync binds the listener before it starts the advertiser, and the
+                // advertiser rethrows, so a throw can leave the listener bound with IsHosting
+                // false. Tear it down here as InitializeAsync does; its own try/catch keeps a
+                // cleanup failure from masking the original exception.
+                try
+                {
+                    await _hostService.StopAsync();
+                }
+                catch (Exception stopEx)
+                {
+                    _logger.LogWarning(stopEx, "Failed to stop partially-started host service");
+                }
+
+                IsHosting = false;
             }
         }
         else if (!shouldAdvertise && !_serverDiscovery.IsDiscovering)
@@ -2228,7 +2333,12 @@ public partial class MainViewModel : ViewModelBase
             {
                 _logger.LogWarning(ex, "Failed to start server discovery");
             }
+
+            OnPropertyChanged(nameof(IsSearchingForServers));
         }
+
+        // The switch completed: record the mode the guards should now honour.
+        SetActiveConnectionMode(mode);
 
         // Update status message to reflect the new mode.
         StatusMessage = mode switch
@@ -2237,7 +2347,6 @@ public partial class MainViewModel : ViewModelBase
             _ => $"Waiting for a server to connect...\nClient ID: {ClientId}",
         };
     }
-
     partial void OnVolumeChanged(int value)
     {
         // Skip if server-initiated update (SDK already applied via server/command)
@@ -2422,6 +2531,14 @@ public partial class MainViewModel : ViewModelBase
                 "Migrating unsupported connection mode {StoredMode} to {NewMode}",
                 modeStr,
                 canonicalValue);
+
+            // Persist through the settings service, not by assigning SettingsConnectionMode: for a
+            // stored "Auto" the canonical mode equals the property's existing default, so the
+            // generated setter short-circuits on equality, OnSettingsConnectionModeChanged never
+            // fires, and the legacy value would stay on disk to be re-migrated every launch.
+            // LoadLoggingSettings is synchronous, hence the fire-and-forget.
+            _settingsService.UpdateSettingAsync("Connection", "Mode", canonicalValue)
+                .SafeFireAndForget(_logger);
         }
 
         SettingsConnectionMode = ConnectionModeMapping.ToDisplayName(loadedMode);
@@ -2704,7 +2821,10 @@ public partial class MainViewModel : ViewModelBase
             // other mode - calling it there would drop the session and claim it reconnected.
             if (playerNameChanged && IsConnected)
             {
-                var connectionMode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
+                // Must match the guard inside ConnectToServerAsync, which reads the mode that
+                // actually took effect; testing the requested mode here could drop the session
+                // and then have the reconnect refused.
+                var connectionMode = _activeConnectionMode;
                 if (connectionMode == ConnectionMode.DiscoverOnly)
                 {
                     StatusMessage = "Reconnecting with new player name...";
@@ -2935,6 +3055,7 @@ public partial class MainViewModel : ViewModelBase
         // Cleanup manual client
         await CleanupManualClientAsync();
         _cleanupLock.Dispose();
+        _connectionModeLock.Dispose();
 
         // Stop host service
         await _hostService.StopAsync();

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -668,6 +668,25 @@ public partial class MainViewModel : ViewModelBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to initialize");
+
+            if (mode != ConnectionMode.DiscoverOnly)
+            {
+                // StartAsync binds the listener before it starts the advertiser, and the
+                // advertiser rethrows. A throw here can therefore leave the listener bound with
+                // IsHosting still false, which a later switch to DiscoverOnly would not clean up.
+                // Tear it down now; StopAsync is idempotent.
+                try
+                {
+                    await _hostService.StopAsync();
+                }
+                catch (Exception stopEx)
+                {
+                    _logger.LogWarning(stopEx, "Failed to stop partially-started host service");
+                }
+
+                IsHosting = false;
+            }
+
             StatusMessage = $"Failed to start: {ex.Message}";
             SetError($"Failed to initialize: {ex.Message}");
         }
@@ -1094,11 +1113,6 @@ public partial class MainViewModel : ViewModelBase
 
                 // Show toast notification for connection
                 _notificationService.ShowConnected(ConnectedServerName);
-
-                // Disconnect any server-initiated connections and stop advertising
-                // to ensure only one connection uses the audio pipeline at a time
-                _hostService.DisconnectAllAsync().SafeFireAndForget(_logger);
-                _hostService.StopAdvertisingAsync().SafeFireAndForget(_logger);
             }
             else if (e.NewState == ConnectionState.Disconnected)
             {
@@ -1123,8 +1137,10 @@ public partial class MainViewModel : ViewModelBase
 
                 OnPropertyChanged(nameof(IsConnected));
 
-                // Resume advertising so servers can discover us again
-                _hostService.StartAdvertisingAsync().SafeFireAndForget(_logger);
+                // Deliberately no StartAdvertisingAsync here: a manual client only exists in
+                // DiscoverOnly, and the spec forbids advertising _sendspin._tcp while the client
+                // initiates connections. Advertising lifecycle belongs to InitializeAsync and
+                // ApplyConnectionModeAsync alone.
 
                 // Cleanup in background to avoid blocking UI
                 CleanupManualClientAsync().SafeFireAndForget(_logger);
@@ -2160,8 +2176,14 @@ public partial class MainViewModel : ViewModelBase
                 stopped = false;
             }
         }
-        else if (!shouldAdvertise && IsHosting)
+        else if (!shouldAdvertise)
         {
+            // Unconditional, NOT gated on IsHosting. SendspinHostService.StartAsync starts the
+            // listener first and the advertiser second, so a failed advertise (port 5353
+            // contention, no usable NIC) leaves the listener bound while IsHosting stays false.
+            // Gating the stop on IsHosting would skip it there and leave the listener running
+            // alongside discovery - both transports at once. Both StopAsync calls are
+            // idempotent, so stopping a host that never started is a harmless no-op.
             try
             {
                 await _hostService.StopAsync();
@@ -2676,28 +2698,47 @@ public partial class MainViewModel : ViewModelBase
             // Close settings panel first
             IsSettingsOpen = false;
 
-            // If player name changed and we're connected, reconnect to apply the new name
+            // If player name changed and we're connected, the session has to be re-handshaked
+            // for the new name to reach the server. How depends on who owns the connection:
+            // only DiscoverOnly may dial back out, because ConnectToServerAsync refuses in any
+            // other mode - calling it there would drop the session and claim it reconnected.
             if (playerNameChanged && IsConnected)
             {
-                StatusMessage = "Reconnecting with new player name...";
-                _logger.LogInformation("Reconnecting to apply new player name");
-
-                // Store the current server URL for reconnection
-                var currentServerUrl = ManualServerUrl;
-
-                // Disconnect
-                await DisconnectFromServerAsync();
-
-                // Small delay to ensure clean disconnection
-                await Task.Delay(ReconnectDelayMs);
-
-                // Reconnect
-                if (!string.IsNullOrEmpty(currentServerUrl))
+                var connectionMode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
+                if (connectionMode == ConnectionMode.DiscoverOnly)
                 {
-                    await ConnectToServerAsync();
-                }
+                    StatusMessage = "Reconnecting with new player name...";
+                    _logger.LogInformation("Reconnecting to apply new player name");
 
-                StatusMessage = "Settings saved. Reconnected with new player name.";
+                    // Store the current server URL for reconnection
+                    var currentServerUrl = ManualServerUrl;
+
+                    // Disconnect
+                    await DisconnectFromServerAsync();
+
+                    // Small delay to ensure clean disconnection
+                    await Task.Delay(ReconnectDelayMs);
+
+                    // Reconnect
+                    if (!string.IsNullOrEmpty(currentServerUrl))
+                    {
+                        await ConnectToServerAsync();
+                    }
+
+                    StatusMessage = "Settings saved. Reconnected with new player name.";
+                }
+                else
+                {
+                    // The server dialled us, so only the server can re-establish the session.
+                    // Drop it and keep advertising; the server reconnects and re-handshakes with
+                    // the new name.
+                    StatusMessage = "Disconnecting to apply new player name...";
+                    _logger.LogInformation("Disconnecting so the server re-handshakes with the new player name");
+
+                    await DisconnectFromServerAsync();
+
+                    StatusMessage = "Settings saved. Waiting for the server to reconnect with the new player name.";
+                }
             }
             else
             {

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -889,6 +889,13 @@ public partial class MainViewModel : ViewModelBase
     /// Creates and configures the manual client for connecting to a server.
     /// This handles creation of the connection, client service, and event subscriptions.
     /// </summary>
+    /// <remarks>
+    /// Invariant: every caller must confirm <c>ConnectionModeMapping.FromDisplayName(SettingsConnectionMode)
+    /// == ConnectionMode.DiscoverOnly</c> before calling this. The check cannot live here because
+    /// every caller immediately dereferences <c>_manualClient!</c> with null-forgiving right after
+    /// calling this method; a guard here that skipped creation would turn a refused connect into a
+    /// NullReferenceException instead. Guard at each call site instead.
+    /// </remarks>
     private void CreateAndConfigureManualClient()
     {
         _manualConnection = new SendspinConnection(
@@ -1619,6 +1626,13 @@ public partial class MainViewModel : ViewModelBase
 
     private async Task AutoConnectToServerAsync(DiscoveredServer server)
     {
+        var mode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
+        if (mode != ConnectionMode.DiscoverOnly)
+        {
+            _logger.LogWarning("Refusing auto-connect to {Name}: connection mode is {Mode}, not DiscoverOnly", server.Name, mode);
+            return;
+        }
+
         // Clear any previous error when starting a new connection attempt
         ClearError();
 

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -917,6 +917,13 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private async Task ConnectToServerAsync()
     {
+        var mode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
+        if (mode != ConnectionMode.DiscoverOnly)
+        {
+            _logger.LogWarning("Refusing manual connect: connection mode is {Mode}, not DiscoverOnly", mode);
+            return;
+        }
+
         // Clear any previous error when starting a new connection attempt
         ClearError();
 

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -468,11 +468,10 @@ public partial class MainViewModel : ViewModelBase
     /// server decides when to connect.
     /// </summary>
     /// <remarks>
-    /// Reads <see cref="_activeConnectionMode"/>, not <see cref="SettingsConnectionMode"/>: the
-    /// requested mode is assigned before the transition runs, so a switch that aborts would
-    /// otherwise expose the manual-connect UI while the host service is still hosting.
+    /// The same conjunction the connect guards use, so the manual-connect UI disappears the moment
+    /// a switch away from DiscoverOnly is requested rather than when it finishes.
     /// </remarks>
-    public bool IsDiscoverMode => _activeConnectionMode == ConnectionMode.DiscoverOnly;
+    public bool IsDiscoverMode => CanInitiateOutboundConnection;
 
     /// <summary>
     /// Gets whether a discovery scan is running and has not yet found anything.
@@ -542,6 +541,28 @@ public partial class MainViewModel : ViewModelBase
     /// unbounded stream, where the bar is hidden and the value is unused.
     /// </summary>
     public double ProgressPercent => HasKnownDuration ? (Position / Duration) * 100 : 0;
+
+    /// <summary>
+    /// Gets whether the client may dial out right now: client-initiated mode is both the mode the
+    /// user has requested and the mode whose transport is actually running.
+    /// </summary>
+    /// <remarks>
+    /// Both terms are load-bearing, and neither is sufficient on its own:
+    /// <para><see cref="_activeConnectionMode"/> alone would permit a connect for the whole
+    /// duration of a switch AWAY from DiscoverOnly. ApplyConnectionModeCoreAsync runs on the UI
+    /// thread and yields at DisconnectAsync/StopAsync/StartAsync, and the active mode stays
+    /// DiscoverOnly until the new transport is up — so during those yields a queued
+    /// OnDiscoveredServerFound, or a Connect click, could land an outbound client while the host
+    /// listener is starting. Both transports live.</para>
+    /// <para><see cref="SettingsConnectionMode"/> alone would permit a connect after a switch TO
+    /// DiscoverOnly aborted: the requested mode is assigned and persisted before the transition
+    /// even runs, so it reads DiscoverOnly while the host service is still hosting.</para>
+    /// The conjunction refuses in both directions. Keep the two guards on this one member so they
+    /// cannot drift apart.
+    /// </remarks>
+    private bool CanInitiateOutboundConnection
+        => _activeConnectionMode == ConnectionMode.DiscoverOnly
+            && ConnectionModeMapping.FromDisplayName(SettingsConnectionMode) == ConnectionMode.DiscoverOnly;
 
     /// <summary>
     /// Formats seconds as a time string (M:SS or H:MM:SS for long tracks).
@@ -772,6 +793,7 @@ public partial class MainViewModel : ViewModelBase
             SetError($"Failed to initialize: {ex.Message}");
         }
     }
+
     /// <summary>
     /// Records the mode whose transport is actually running and refreshes the UI state derived
     /// from it. Call only once a transport has started — never on an abort path, where the
@@ -1001,9 +1023,8 @@ public partial class MainViewModel : ViewModelBase
     /// This handles creation of the connection, client service, and event subscriptions.
     /// </summary>
     /// <remarks>
-    /// Invariant: every caller must confirm <c>_activeConnectionMode == ConnectionMode.DiscoverOnly</c>
-    /// before calling this — the mode that actually took effect, not the requested
-    /// <see cref="SettingsConnectionMode"/>. The check cannot live here because
+    /// Invariant: every caller must confirm <see cref="CanInitiateOutboundConnection"/> before
+    /// calling this. The check cannot live here because
     /// every caller immediately dereferences <c>_manualClient!</c> with null-forgiving right after
     /// calling this method; a guard here that skipped creation would turn a refused connect into a
     /// NullReferenceException instead. Guard at each call site instead.
@@ -1036,11 +1057,12 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private async Task ConnectToServerAsync()
     {
-        // The mode that actually took effect, not the requested one: an aborted switch leaves
-        // SettingsConnectionMode holding a mode whose transport never started.
-        if (_activeConnectionMode != ConnectionMode.DiscoverOnly)
+        if (!CanInitiateOutboundConnection)
         {
-            _logger.LogWarning("Refusing manual connect: active connection mode is {Mode}, not DiscoverOnly", _activeConnectionMode);
+            _logger.LogWarning(
+                "Refusing manual connect: active mode is {ActiveMode} and requested mode is {RequestedMode}; both must be DiscoverOnly",
+                _activeConnectionMode,
+                ConnectionModeMapping.FromDisplayName(SettingsConnectionMode));
             return;
         }
 
@@ -1736,11 +1758,13 @@ public partial class MainViewModel : ViewModelBase
 
     private async Task AutoConnectToServerAsync(DiscoveredServer server)
     {
-        // The mode that actually took effect, not the requested one: an aborted switch leaves
-        // SettingsConnectionMode holding a mode whose transport never started.
-        if (_activeConnectionMode != ConnectionMode.DiscoverOnly)
+        if (!CanInitiateOutboundConnection)
         {
-            _logger.LogWarning("Refusing auto-connect to {Name}: active connection mode is {Mode}, not DiscoverOnly", server.Name, _activeConnectionMode);
+            _logger.LogWarning(
+                "Refusing auto-connect to {Name}: active mode is {ActiveMode} and requested mode is {RequestedMode}; both must be DiscoverOnly",
+                server.Name,
+                _activeConnectionMode,
+                ConnectionModeMapping.FromDisplayName(SettingsConnectionMode));
             return;
         }
 
@@ -2213,8 +2237,10 @@ public partial class MainViewModel : ViewModelBase
             ConnectionModeMapping.FromDisplayName(value));
         SaveConnectionModeAsync(configValue).SafeFireAndForget(_logger);
 
-        // Not IsDiscoverMode: it reads _activeConnectionMode, which only changes once the new
-        // transport is actually running, and ApplyConnectionModeAsync raises it there.
+        // Both are live: IsDiscoverMode is the requested/active conjunction, so it flips here the
+        // moment a switch away from DiscoverOnly is requested — which is what hides the
+        // manual-connect UI for the duration of the transition rather than after it.
+        OnPropertyChanged(nameof(IsDiscoverMode));
         OnPropertyChanged(nameof(IsSearchingForServers));
     }
 
@@ -2891,11 +2917,9 @@ public partial class MainViewModel : ViewModelBase
             // other mode - calling it there would drop the session and claim it reconnected.
             if (playerNameChanged && IsConnected)
             {
-                // Must match the guard inside ConnectToServerAsync, which reads the mode that
-                // actually took effect; testing the requested mode here could drop the session
-                // and then have the reconnect refused.
-                var connectionMode = _activeConnectionMode;
-                if (connectionMode == ConnectionMode.DiscoverOnly)
+                // The same guard ConnectToServerAsync applies: testing anything weaker here could
+                // drop the session and then have the reconnect refused.
+                if (CanInitiateOutboundConnection)
                 {
                     StatusMessage = "Reconnecting with new player name...";
                     _logger.LogInformation("Reconnecting to apply new player name");

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -2104,6 +2104,23 @@ public partial class MainViewModel : ViewModelBase
                 _logger.LogWarning(ex, "Failed to stop server discovery");
                 stopped = false;
             }
+
+            // A manual (DiscoverOnly) connection is a live use of the same singleton audio
+            // pipeline as the host service would use, so it must be torn down before we
+            // advertise -- otherwise both transports end up live at once.
+            if (_manualClient != null && _manualClient.ConnectionState == ConnectionState.Connected)
+            {
+                try
+                {
+                    await _manualClient.DisconnectAsync();
+                    _logger.LogInformation("Manual client disconnected");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to disconnect manual client");
+                    stopped = false;
+                }
+            }
         }
         else if (!shouldAdvertise && IsHosting)
         {

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -103,22 +103,27 @@ public partial class MainViewModel : ViewModelBase
     private readonly SemaphoreSlim _cleanupLock = new(1, 1);
 
     /// <summary>
-    /// Serializes connection mode transitions. Mode changes are started fire-and-forget from the
+    /// Serializes every transport start/stop: the initial one in <see cref="InitializeAsync"/>
+    /// and each runtime mode transition. Mode changes are started fire-and-forget from the
     /// property-changed callback, so without this two rapid switches can interleave their
     /// stop/check/start phases — one stops the host, the next restarts it, then the first starts
-    /// discovery — and leave both transports running.
+    /// discovery — and leave both transports running. Initialization takes the same lock because
+    /// it too is started unawaited and can otherwise finish starting a transport after a switch
+    /// has already moved to the other one.
     /// </summary>
     private readonly SemaphoreSlim _connectionModeLock = new(1, 1);
 
     /// <summary>
-    /// The connection mode whose transport is actually running.
+    /// The mode of the transport that last started successfully — the one actually running.
     /// </summary>
     /// <remarks>
     /// Distinct from <see cref="SettingsConnectionMode"/>, which holds the mode the user
     /// <em>requested</em> and is already assigned (and persisted) before
     /// <see cref="ApplyConnectionModeAsync"/> even runs. An aborted switch would otherwise leave
-    /// every mode guard reading a mode that never took effect. Only set once a transport has
-    /// actually started; never on an abort path.
+    /// every mode guard reading a mode that never took effect. Set only after a transport has
+    /// actually started, so it is left unchanged both when the stop phase aborts a switch and
+    /// when the new transport fails to start; in the latter case nothing is running and it names
+    /// the previous mode, which is the conservative reading for the guards.
     /// </remarks>
     private ConnectionMode _activeConnectionMode = ConnectionMode.AdvertiseOnly;
 
@@ -664,10 +669,40 @@ public partial class MainViewModel : ViewModelBase
         Position = _progressTracker.PositionSeconds;
     }
 
+    /// <summary>
+    /// Starts the transport for the configured connection mode.
+    /// </summary>
+    /// <remarks>
+    /// Holds <see cref="_connectionModeLock"/>, the same semaphore a runtime mode switch takes.
+    /// App.xaml.cs shows the window and then starts this unawaited, and the constructor's
+    /// settings load can already have queued a transition, so without the lock the initial
+    /// StartAsync could complete AFTER a switch had moved to the other transport - leaving both
+    /// running with <see cref="_activeConnectionMode"/> naming the wrong one and nothing to
+    /// repair it. No reentrancy risk: ApplyConnectionModeAsync has a single caller and nothing
+    /// inside a transition assigns SettingsConnectionMode.
+    /// </remarks>
     public async Task InitializeAsync()
     {
         _logger.LogInformation("Initializing MainViewModel");
 
+        await _connectionModeLock.WaitAsync();
+        try
+        {
+            await StartInitialTransportAsync();
+        }
+        finally
+        {
+            _connectionModeLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// The transport-starting body of initialization. Runs under <see cref="_connectionModeLock"/>.
+    /// </summary>
+    private async Task StartInitialTransportAsync()
+    {
+        // Read the mode under the lock: a transition queued from the constructor's settings load
+        // may already have run and changed which transport belongs to this session.
         var mode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
         _logger.LogInformation("Connection mode: {Mode}", mode);
 
@@ -676,21 +711,32 @@ public partial class MainViewModel : ViewModelBase
             // Exactly one transport, per spec: a client MUST use exactly one of the two
             // connection methods at a time. An if/else keeps that structural — the previous
             // pair of independent ifs let Auto satisfy neither exclusion and start both.
+            // The already-running checks match the runtime path: a transition that ran ahead of
+            // this may have started the very transport we want, and starting it twice is not a
+            // documented no-op.
             if (mode == ConnectionMode.DiscoverOnly)
             {
-                StatusMessage = "Discovering Sendspin servers...";
-                await _serverDiscovery.StartAsync();
-                OnPropertyChanged(nameof(IsSearchingForServers));
-                _logger.LogInformation("Server discovery started, looking for _sendspin-server._tcp");
+                if (!_serverDiscovery.IsDiscovering)
+                {
+                    StatusMessage = "Discovering Sendspin servers...";
+                    await _serverDiscovery.StartAsync();
+                    OnPropertyChanged(nameof(IsSearchingForServers));
+                    _logger.LogInformation("Server discovery started, looking for _sendspin-server._tcp");
+                }
+
                 StatusMessage = "Searching for servers...";
             }
             else
             {
-                StatusMessage = "Starting host service...";
-                await _hostService.StartAsync();
-                ClientId = _hostService.ClientId;
-                IsHosting = true;
-                _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
+                if (!IsHosting)
+                {
+                    StatusMessage = "Starting host service...";
+                    await _hostService.StartAsync();
+                    ClientId = _hostService.ClientId;
+                    IsHosting = true;
+                    _logger.LogInformation("Host service started, advertising as {ClientId}", ClientId);
+                }
+
                 StatusMessage = $"Waiting for a server to connect...\nClient ID: {ClientId}";
             }
 
@@ -720,11 +766,12 @@ public partial class MainViewModel : ViewModelBase
                 IsHosting = false;
             }
 
+            // _activeConnectionMode is deliberately left alone: no transport started, so the
+            // mode guards must keep refusing work for this mode.
             StatusMessage = $"Failed to start: {ex.Message}";
             SetError($"Failed to initialize: {ex.Message}");
         }
     }
-
     /// <summary>
     /// Records the mode whose transport is actually running and refreshes the UI state derived
     /// from it. Call only once a transport has started — never on an abort path, where the
@@ -2166,7 +2213,8 @@ public partial class MainViewModel : ViewModelBase
             ConnectionModeMapping.FromDisplayName(value));
         SaveConnectionModeAsync(configValue).SafeFireAndForget(_logger);
 
-        OnPropertyChanged(nameof(IsDiscoverMode));
+        // Not IsDiscoverMode: it reads _activeConnectionMode, which only changes once the new
+        // transport is actually running, and ApplyConnectionModeAsync raises it there.
         OnPropertyChanged(nameof(IsSearchingForServers));
     }
 
@@ -2202,6 +2250,9 @@ public partial class MainViewModel : ViewModelBase
         {
             // A newer request may have been queued behind this one while it waited on the lock.
             // The newest request is the one the user meant; running a stale one now would undo it.
+            // Depends on the CommunityToolkit generator assigning the backing field BEFORE it
+            // invokes OnSettingsConnectionModeChanged — otherwise this reads the previous value
+            // and every transition looks stale.
             var requestedMode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
             if (requestedMode != mode)
             {
@@ -2293,6 +2344,10 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
+        // Whether the transport this mode needs is now running: either it was already up, or it
+        // started here. A failed start must not be recorded as a completed switch.
+        var started = true;
+
         if (shouldAdvertise && !IsHosting)
         {
             try
@@ -2320,6 +2375,7 @@ public partial class MainViewModel : ViewModelBase
                 }
 
                 IsHosting = false;
+                started = false;
             }
         }
         else if (!shouldAdvertise && !_serverDiscovery.IsDiscovering)
@@ -2332,9 +2388,23 @@ public partial class MainViewModel : ViewModelBase
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to start server discovery");
+                started = false;
             }
 
             OnPropertyChanged(nameof(IsSearchingForServers));
+        }
+
+        if (!started)
+        {
+            // Leave _activeConnectionMode at the mode whose transport last started successfully.
+            // Both transports are down at this point: the old one was stopped above and the new
+            // one failed, so claiming the new mode would let its guards admit work with nothing
+            // running to carry it.
+            _logger.LogError(
+                "Connection mode switch to {Mode} left no transport running: the new transport failed to start (still reporting {ActiveMode})",
+                mode, _activeConnectionMode);
+            StatusMessage = "Failed to start the connection. Check the logs and try again.";
+            return;
         }
 
         // The switch completed: record the mode the guards should now honour.

--- a/src/Sendspin.Windows/ViewModels/MainViewModel.cs
+++ b/src/Sendspin.Windows/ViewModels/MainViewModel.cs
@@ -20,6 +20,7 @@ using Sendspin.SDK.Extensions;
 using Sendspin.SDK.Models;
 using Sendspin.SDK.Protocol.Messages;
 using Sendspin.SDK.Synchronization;
+using Sendspin.Windows.Services.Configuration;
 using Sendspin.Windows.Services.Diagnostics;
 using Sendspin.Windows.Services.Discord;
 using Sendspin.Windows.Services.MediaControls;
@@ -364,17 +365,12 @@ public partial class MainViewModel : ViewModelBase
     /// Controls how the client establishes connections with servers.
     /// </summary>
     [ObservableProperty]
-    private string _settingsConnectionMode = "Auto";
+    private string _settingsConnectionMode = ConnectionModeMapping.AdvertiseOnlyDisplayName;
 
     /// <summary>
     /// Gets the available connection mode options for the settings dropdown.
     /// </summary>
-    public string[] AvailableConnectionModes { get; } = new[]
-    {
-        "Auto",
-        "Advertise Only",
-        "Discover Only"
-    };
+    public string[] AvailableConnectionModes { get; } = ConnectionModeMapping.DisplayNames;
 
     /// <summary>
     /// Gets the available audio output devices.
@@ -630,7 +626,7 @@ public partial class MainViewModel : ViewModelBase
     {
         _logger.LogInformation("Initializing MainViewModel");
 
-        var mode = ParseConnectionMode(SettingsConnectionMode);
+        var mode = ConnectionModeMapping.FromDisplayName(SettingsConnectionMode);
         _logger.LogInformation("Connection mode: {Mode}", mode);
 
         try
@@ -666,16 +662,6 @@ public partial class MainViewModel : ViewModelBase
             StatusMessage = $"Failed to start: {ex.Message}";
             SetError($"Failed to initialize: {ex.Message}");
         }
-    }
-
-    private static ConnectionMode ParseConnectionMode(string displayName)
-    {
-        return displayName switch
-        {
-            "Advertise Only" => ConnectionMode.AdvertiseOnly,
-            "Discover Only" => ConnectionMode.DiscoverOnly,
-            _ => ConnectionMode.Auto
-        };
     }
 
     [RelayCommand]
@@ -2087,13 +2073,8 @@ public partial class MainViewModel : ViewModelBase
 
     partial void OnSettingsConnectionModeChanged(string value)
     {
-        // Convert display name to config value
-        var configValue = value switch
-        {
-            "Advertise Only" => "AdvertiseOnly",
-            "Discover Only" => "DiscoverOnly",
-            _ => "Auto"
-        };
+        var configValue = ConnectionModeMapping.ToConfigValue(
+            ConnectionModeMapping.FromDisplayName(value));
         SaveConnectionModeAsync(configValue).SafeFireAndForget(_logger);
     }
 
@@ -2356,14 +2337,20 @@ public partial class MainViewModel : ViewModelBase
         // Load auto-connect server preference
         AutoConnectServerId = _configuration.GetValue<string>("Connection:AutoConnectServerId", string.Empty) ?? string.Empty;
 
-        // Load connection mode
-        var modeStr = _configuration.GetValue<string>("Connection:Mode", "Auto") ?? "Auto";
-        SettingsConnectionMode = modeStr switch
+        // Load connection mode. Anything we do not recognize — including the legacy "Auto",
+        // which ran both transports in violation of the spec — resolves to AdvertiseOnly.
+        var modeStr = _configuration.GetValue<string>("Connection:Mode", string.Empty) ?? string.Empty;
+        var loadedMode = ConnectionModeMapping.FromConfigValue(modeStr);
+        var canonicalValue = ConnectionModeMapping.ToConfigValue(loadedMode);
+        if (!string.IsNullOrEmpty(modeStr) && modeStr != canonicalValue)
         {
-            "AdvertiseOnly" => "Advertise Only",
-            "DiscoverOnly" => "Discover Only",
-            _ => "Auto"
-        };
+            _logger.LogInformation(
+                "Migrating unsupported connection mode {StoredMode} to {NewMode}",
+                modeStr,
+                canonicalValue);
+        }
+
+        SettingsConnectionMode = ConnectionModeMapping.ToDisplayName(loadedMode);
 
         // Enumerate audio devices
         EnumerateAudioDevices();

--- a/src/Sendspin.Windows/appsettings.json
+++ b/src/Sendspin.Windows/appsettings.json
@@ -33,7 +33,7 @@
     }
   },
   "Connection": {
-    "Mode": "Auto",
+    "Mode": "AdvertiseOnly",
     "AutoConnectServerId": "",
     "LastPlayedServerId": ""
   },

--- a/tests/Sendspin.Windows.Services.Tests/Configuration/ConnectionModeMappingTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Configuration/ConnectionModeMappingTests.cs
@@ -1,0 +1,116 @@
+using Sendspin.SDK.Client;
+using Sendspin.Windows.Services.Configuration;
+using Xunit;
+
+namespace Sendspin.Windows.Services.Tests.Configuration;
+
+public class ConnectionModeMappingTests
+{
+    [Theory]
+    [InlineData("AdvertiseOnly")]
+    [InlineData("DiscoverOnly")]
+    public void FromConfigValue_RoundTripsKnownValues(string configValue)
+    {
+        var mode = ConnectionModeMapping.FromConfigValue(configValue);
+        Assert.Equal(configValue, ConnectionModeMapping.ToConfigValue(mode));
+    }
+
+    [Fact]
+    public void FromConfigValue_DiscoverOnly_ReturnsDiscoverOnly()
+    {
+        Assert.Equal(ConnectionMode.DiscoverOnly, ConnectionModeMapping.FromConfigValue("DiscoverOnly"));
+    }
+
+    [Fact]
+    public void FromConfigValue_AdvertiseOnly_ReturnsAdvertiseOnly()
+    {
+        Assert.Equal(ConnectionMode.AdvertiseOnly, ConnectionModeMapping.FromConfigValue("AdvertiseOnly"));
+    }
+
+    [Fact]
+    public void FromConfigValue_LegacyAuto_MigratesToAdvertiseOnly()
+    {
+        Assert.Equal(ConnectionMode.AdvertiseOnly, ConnectionModeMapping.FromConfigValue("Auto"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Nonsense")]
+    [InlineData("advertiseonly")]
+    public void FromConfigValue_UnrecognizedInput_DefaultsToAdvertiseOnly(string? configValue)
+    {
+        Assert.Equal(ConnectionMode.AdvertiseOnly, ConnectionModeMapping.FromConfigValue(configValue));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Auto")]
+    [InlineData("Nonsense")]
+    [InlineData("AdvertiseOnly")]
+    [InlineData("DiscoverOnly")]
+    public void FromConfigValue_NeverReturnsAuto(string? configValue)
+    {
+        Assert.NotEqual(ConnectionMode.Auto, ConnectionModeMapping.FromConfigValue(configValue));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Auto")]
+    [InlineData("Advertise Only")]
+    [InlineData("Let servers connect to me")]
+    [InlineData("I choose a server")]
+    public void FromDisplayName_NeverReturnsAuto(string? displayName)
+    {
+        Assert.NotEqual(ConnectionMode.Auto, ConnectionModeMapping.FromDisplayName(displayName));
+    }
+
+    [Fact]
+    public void FromDisplayName_DiscoverOnlyLabel_ReturnsDiscoverOnly()
+    {
+        Assert.Equal(
+            ConnectionMode.DiscoverOnly,
+            ConnectionModeMapping.FromDisplayName(ConnectionModeMapping.DiscoverOnlyDisplayName));
+    }
+
+    [Fact]
+    public void FromDisplayName_UnrecognizedLabel_DefaultsToAdvertiseOnly()
+    {
+        Assert.Equal(ConnectionMode.AdvertiseOnly, ConnectionModeMapping.FromDisplayName("Advertise Only"));
+    }
+
+    [Theory]
+    [InlineData(ConnectionMode.AdvertiseOnly)]
+    [InlineData(ConnectionMode.DiscoverOnly)]
+    public void ToDisplayName_RoundTrips(ConnectionMode mode)
+    {
+        Assert.Equal(mode, ConnectionModeMapping.FromDisplayName(ConnectionModeMapping.ToDisplayName(mode)));
+    }
+
+    [Fact]
+    public void ToConfigValue_Auto_CoercedToAdvertiseOnly()
+    {
+        // Auto is unreachable through our own mapping, but the SDK enum still allows it.
+        // Coerce rather than emit a value we would refuse to read back.
+        Assert.Equal("AdvertiseOnly", ConnectionModeMapping.ToConfigValue(ConnectionMode.Auto));
+    }
+
+    [Fact]
+    public void ToDisplayName_Auto_CoercedToAdvertiseOnlyLabel()
+    {
+        Assert.Equal(
+            ConnectionModeMapping.AdvertiseOnlyDisplayName,
+            ConnectionModeMapping.ToDisplayName(ConnectionMode.Auto));
+    }
+
+    [Fact]
+    public void DisplayNames_ContainsExactlyTheTwoSupportedModes()
+    {
+        Assert.Equal(
+            new[] { ConnectionModeMapping.AdvertiseOnlyDisplayName, ConnectionModeMapping.DiscoverOnlyDisplayName },
+            ConnectionModeMapping.DisplayNames);
+    }
+}


### PR DESCRIPTION
Forward-port of #78 to `master`. Same work, same commits, one conflict resolved. Closes #76 on the mainline.

See **#78** for the full analysis — the spec violation, the five separate paths that ran both transports, and the per-task review history. This description covers only what differs about the port.

## Why a separate PR

`master` and `release/2.2.4` have diverged: 6 commits on `master` are not on the release line, 22 the other way, and the two reference different SDK versions (`master` 9.1.0, `release/2.2.4` 9.3.0). All four files this work touches differ between the lines, so this could not be a fast-forward.

## What the port involved

13 of the 14 commits cherry-picked cleanly. One conflict, in `claude.md`, because #77 had already landed on `master` — so both sides carried an independent rewrite of the same `## Connection Modes` section.

I resolved it as a genuine merge rather than taking a side, keeping the strongest parts of each:

- From #77: the full spec quote with both prohibitions; the complete arbitration ruleset (activity ranking `management` > `playback` > `pairing`, provisional-until-`server/activate` with a 30s drop, last-playback tiebreak, `another_server` / `concurrent_attempt` goodbye reasons); and the explicit warning against overriding SDK arbitration with `DisconnectAllAsync`.
- From this branch: that the mode is chosen by `Connection.Mode` and switched via `ApplyConnectionModeAsync`, which stops the outgoing transport before starting the incoming one and aborts if the stop fails; that `DiscoverOnly` also covers manual URL connection (`ConnectToServerAsync` refuses to run in any other mode); and that the host service is fully stopped in `DiscoverOnly`.
- Corrected on the merge: `LastPlayedServerId` is **written in both modes** (`SetLastPlayedServerId`) and **consumed only in `AdvertiseOnly`**. #77's text said "server-initiated only", which was wrong about the write side.

## Verification on this branch specifically

The port was built and tested against **SDK 9.1.0**, not the 9.3.0 that `release/2.2.4` uses — that was the main risk and it is clear:

- `dotnet build Sendspin.Windows.sln` — **0 errors**
- Suite: **184 passed, 2 failed** — `DynamicResamplerSampleProviderTests.RateCorrection_ConcealsShortfalls_WithoutSilenceGaps` and `MultiRoomSyncAlignmentTests.StartupPrefill_Uncompensated_DriftsOffSchedule`, both pre-existing on `master` before this branch and unrelated.

## Runtime scenarios still unverified

Same list as #78 — these need a human with two servers on the network. Scenarios 1 (fresh config advertises, does not discover) and 2 (a config carrying `"Auto"` migrates and logs it) have since been confirmed on the `release/2.2.4` build. Still open:

3. `DiscoverOnly` discovers and does not advertise; picker and the URL panel appear.
4. **Two servers in `AdvertiseOnly`: the second is arbitrated by the SDK and the playing session is not dropped.** The #76 regression check.
5. A runtime mode switch stops one transport before starting the other.

## Merge ordering

#78 targets `release/2.2.4` and this targets `master`; they do not conflict with each other. Merge them in either order. Note that #77's `claude.md` content is now subsumed by the resolution here.
