### PR TITLE
chore: bump Sendspin.SDK to 9.3.1 (2.2.5)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -104,10 +104,15 @@ We advertise via mDNS and servers connect to us.
   - **Spec:** admission is ranked by connection *activity* — `management` > `playback` >
     `pairing` — with a new connection held provisional until the server sends
     `server/activate`, and dropped after 30s if it never does.
-  - **SDK 9.3.0 (the version this branch builds against):** arbitration is the earlier
+  - **SDK 9.3.1 (the version this branch builds against):** arbitration is still the earlier
     `connection_reason` comparison — `"playback"` beats `"discovery"` — with
     `LastPlayedServerId` breaking ordinary ties. Activity-based arbitration arrives with the
     v10 SDK; until then, do not write app code that assumes it.
+  - 9.3.1 also adds `SendspinHostService.AdoptClientInitiated` / `ReleaseClientInitiated`, which
+    let an embedder register a client-initiated connection so host arbitration will not tear it
+    down. **We do not use them, and should not:** they exist for clients that run both
+    transports, which this app deliberately no longer does. If you find yourself reaching for
+    them, the real problem is that something started two transports.
 - Discovery of `_sendspin-server._tcp` is NOT running in this mode
 
 ### 2. Client-Initiated Mode — `DiscoverOnly` (Opt-in)
@@ -196,6 +201,17 @@ The buffer handles:
 The frame drop/insert band (`ResamplingThresholdMicroseconds`, now 100ms) sits above the
 hard-sync tier by default, so it is only reached when that tier is disabled or the
 resampling threshold is lowered below 5ms.
+
+**Hard-sync stall detection (SDK 9.3.1+):** the one-shot tier stands itself down when snapping
+stops closing the error, letting the capped continuous tier correct instead
+([sendspin-dotnet#252](https://github.com/Sendspin/sendspin-dotnet/issues/252)). Before this,
+a *constant* offset — as opposed to accumulating drift — made the tier re-fire on every
+callback: observed here as ~870 corrections per second, each inserting ~90ms of silence that
+left the error unchanged, ballooning the buffer from 9s to 30s and reducing output to
+stutter. The trigger was a 48kHz stream against a 192kHz output device, where the resampler
+runs at a ratio other than 1.0 and the reported output latency is wrong. If you see
+`HardSyncStalled`, the residual error is real and the usual cause is host-side output latency
+being misreported — not a threshold that needs raising.
 
 **Resampling Sync Correction** (v2.2.0+):
 - `ITimedAudioBuffer.TargetPlaybackRate` exposes the desired rate (1.0 = normal)

--- a/src/Sendspin.Windows.Services/Sendspin.Windows.Services.csproj
+++ b/src/Sendspin.Windows.Services/Sendspin.Windows.Services.csproj
@@ -23,7 +23,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.3.0" />
+    <PackageReference Include="Sendspin.SDK" Version="9.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />

--- a/src/Sendspin.Windows/Sendspin.Windows.csproj
+++ b/src/Sendspin.Windows/Sendspin.Windows.csproj
@@ -10,7 +10,7 @@
     <ApplicationIcon>Resources\Icons\sendspinTray.ico</ApplicationIcon>
 
     <!-- Version info - set via -p:Version= during CI builds -->
-    <Version>2.2.4</Version>
+    <Version>2.2.5</Version>
     <!--
       AssemblyVersion/FileVersion must be purely numeric (major.minor.build.revision).
       For prerelease versions like "0.0.0-dev.xxx", we need separate numeric versions.
@@ -63,7 +63,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.3.0" />
+    <PackageReference Include="Sendspin.SDK" Version="9.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />

--- a/tests/Sendspin.Windows.Services.Tests/Configuration/ConnectionModeMappingTests.cs
+++ b/tests/Sendspin.Windows.Services.Tests/Configuration/ConnectionModeMappingTests.cs
@@ -4,6 +4,15 @@ using Xunit;
 
 namespace Sendspin.Windows.Services.Tests.Configuration;
 
+// SDK 9.3.1 marks ConnectionMode.Auto [Obsolete] because it describes a spec violation, and
+// removes it in 10.0.0. These tests name it deliberately: their whole point is proving the
+// mapping NEVER returns it and coerces it away on the rare path that can still supply it
+// (it remains the enum's zero value on this release line, so default(ConnectionMode) is Auto).
+// Silencing the warning by deleting them would discard the property most worth guarding.
+// When the SDK drops to 10.0.0 these tests stop compiling, which is the correct prompt to
+// revisit them rather than a regression.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public class ConnectionModeMappingTests
 {
     [Theory]
@@ -114,3 +123,5 @@ public class ConnectionModeMappingTests
             ConnectionModeMapping.DisplayNames);
     }
 }
+
+#pragma warning restore CS0618


### PR DESCRIPTION
Bumps `Sendspin.SDK` 9.3.0 → 9.3.1 and the app version to 2.2.5. Nothing else.

## What 9.3.1 fixes

All three are issues filed from this project during the 2.2.4 work:

| SDK PR | Fixes | Issue |
|---|---|---|
| Sendspin/sendspin-dotnet#257 | Hard-sync tier looping on an error it cannot close | [#252](https://github.com/Sendspin/sendspin-dotnet/issues/252) |
| Sendspin/sendspin-dotnet#259 | A rejected server connection tearing down the live session | [#253](https://github.com/Sendspin/sendspin-dotnet/issues/253) |
| Sendspin/sendspin-dotnet#256 | `ConnectionMode.Auto` deprecated, enum docs corrected | [#254](https://github.com/Sendspin/sendspin-dotnet/issues/254) |

**#252 is the one that matters to users here.** A *constant* sync offset — as opposed to accumulating drift — made the one-shot hard-sync tier re-fire on every callback: roughly 870 corrections per second, each inserting ~90ms of silence that left the error exactly where it was. The buffer ballooned from 9s to 30s and output became stutter. Reproduced here with a 48 kHz stream against a 192 kHz output device, where the resampler runs at a ratio other than 1.0. 9.3.1 stands the tier down when snapping stops closing the error and lets the capped continuous tier correct instead.

## No source changes were needed

I probed the bump in a throwaway worktree before writing anything. Two changes look breaking and are not:

- `ITimedAudioBuffer` gained `HardSyncStalled`, but it is **`internal`** — and we consume that interface rather than implementing it.
- `SyncCorrectionPolicy.Decide` gained a `suppressHardSync` parameter, but with a default, so it stays source-compatible.

Build: **0 errors**. Warning count is **570, identical to 9.3.0** — the bump introduced exactly four CS0618s and the suppression below absorbs exactly those four, nothing more. Tests: **184 passed, 2 failed**, the same two pre-existing audio failures.

## Why CS0618 is suppressed rather than the tests deleted

`ConnectionMode.Auto` is now `[Obsolete]`, and four tests in `ConnectionModeMappingTests` name it. Deleting them would silence the warning and discard the property most worth guarding — that the mapping **never returns** `Auto` and coerces it away on the one path that can still supply it. `Auto` remains the enum's zero value on this release line, so `default(ConnectionMode)` is still `Auto`; that is precisely why the coercion tests exist.

The suppression is file-scoped with a comment explaining it. At SDK 10.0.0 `Auto` is removed and these tests stop compiling, which is the correct prompt to revisit them rather than a silent regression.

## Deliberately not adopted

9.3.1 adds public `SendspinHostService.AdoptClientInitiated` / `ReleaseClientInitiated`, letting an embedder register a client-initiated connection so host arbitration will not tear it down. **We do not use them and should not** — they exist for clients that run both transports, which #76 removed from this app. Recorded in `claude.md` so nobody reaches for them later; if they ever seem necessary, the real problem is that something started two transports.

## Arbitration is unchanged

9.3.1 does **not** add the spec's activity ranking — still the `connection_reason` comparison with a `LastPlayedServerId` tiebreak, with activity-based arbitration arriving in v10. `claude.md` moves only the version number, and the 2.2.4 release note's known-limitation section remains accurate.

## Still to verify

The #252 fix wants a runtime check that automated tests cannot give: set the output device to 192 kHz, connect to a server that negotiates 48 kHz, and confirm the hard-sync runaway is gone. On 2.2.4 that produced a log full of `Hard sync #N: inserting silence for ~90ms` with the error never moving.
