### PR TITLE
feat: replace the rotating emoji with a green progress spinner

### DIFF
--- a/src/Sendspin.Windows/MainWindow.xaml
+++ b/src/Sendspin.Windows/MainWindow.xaml
@@ -285,7 +285,7 @@
                             <!-- Searching state (no servers found yet, but discovery is running) -->
                             <StackPanel Visibility="{Binding IsSearchingForServers, Converter={StaticResource BoolToVisibilityConverter}}"
                                         Margin="0,8,0,0">
-                                <TextBlock Text="🔍" Style="{StaticResource SearchingIcon}"/>
+                                <Control Style="{StaticResource ProgressSpinner}"/>
                                 <TextBlock Text="Searching for servers..."
                                            Style="{StaticResource CaptionText}"
                                            HorizontalAlignment="Center"
@@ -338,7 +338,7 @@
                         </Border.Style>
                         <StackPanel>
                             <TextBlock Text="Waiting for a Server" Style="{StaticResource WelcomeSectionHeader}"/>
-                            <TextBlock Text="📡" Style="{StaticResource SearchingIcon}"/>
+                            <Control Style="{StaticResource ProgressSpinner}"/>
                             <TextBlock Text="Advertising on your network. Select this player in Music Assistant to connect."
                                        Style="{StaticResource CaptionText}"
                                        HorizontalAlignment="Center"

--- a/src/Sendspin.Windows/Resources/Styles/WelcomeStyles.xaml
+++ b/src/Sendspin.Windows/Resources/Styles/WelcomeStyles.xaml
@@ -31,7 +31,12 @@
         </Style.Triggers>
     </Style>
 
-    <!-- Broadcasting Indicator Animation -->
+    <!-- Broadcasting Indicator Animation.
+         Gated on IsVisible for the same reason as ProgressSpinner below: an EventTrigger on
+         Loaded fires once and never again, so a RepeatBehavior="Forever" storyboard begun
+         there pulses for the life of the process, including while the window is hidden to the
+         tray. This dot shows whenever we are advertising, which is the app's default resting
+         state — so it was the longest-running instance of the three. -->
     <Style x:Key="BroadcastingIndicator" TargetType="Ellipse">
         <Setter Property="Width" Value="8"/>
         <Setter Property="Height" Value="8"/>
@@ -39,15 +44,20 @@
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="Margin" Value="0,0,8,0"/>
         <Style.Triggers>
-            <EventTrigger RoutedEvent="Loaded">
-                <BeginStoryboard>
-                    <Storyboard RepeatBehavior="Forever">
-                        <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                       From="1.0" To="0.3" Duration="0:0:1.5"
-                                       AutoReverse="True"/>
-                    </Storyboard>
-                </BeginStoryboard>
-            </EventTrigger>
+            <Trigger Property="IsVisible" Value="True">
+                <Trigger.EnterActions>
+                    <BeginStoryboard x:Name="PulseStoryboard">
+                        <Storyboard RepeatBehavior="Forever">
+                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                           From="1.0" To="0.3" Duration="0:0:1.5"
+                                           AutoReverse="True"/>
+                        </Storyboard>
+                    </BeginStoryboard>
+                </Trigger.EnterActions>
+                <Trigger.ExitActions>
+                    <StopStoryboard BeginStoryboardName="PulseStoryboard"/>
+                </Trigger.ExitActions>
+            </Trigger>
         </Style.Triggers>
     </Style>
 

--- a/src/Sendspin.Windows/Resources/Styles/WelcomeStyles.xaml
+++ b/src/Sendspin.Windows/Resources/Styles/WelcomeStyles.xaml
@@ -51,27 +51,65 @@
         </Style.Triggers>
     </Style>
 
-    <!-- Searching Animation for Icon -->
-    <Style x:Key="SearchingIcon" TargetType="TextBlock">
-        <Setter Property="FontSize" Value="32"/>
-        <Setter Property="Opacity" Value="0.5"/>
+    <!-- Indeterminate progress spinner: a brand-green arc sweeping a faint track.
+         Used wherever the client is waiting on the network (waiting for a server to
+         connect to us, or searching for servers to connect to).
+
+         The animation is gated on IsVisible, NOT on Loaded. Loaded fires once and never
+         again, so a RepeatBehavior="Forever" storyboard started there keeps running for the
+         life of the process — including while the window is hidden to the tray, because WPF
+         storyboard clocks do not stop for a hidden window. That matters here specifically:
+         these spinners appear only while DISCONNECTED, which is exactly the state someone
+         is likely to leave sitting in the tray. IsVisible is false when this control is
+         collapsed OR any ancestor is hidden, so one trigger covers both. -->
+    <Style x:Key="ProgressSpinner" TargetType="Control">
+        <Setter Property="Width" Value="28"/>
+        <Setter Property="Height" Value="28"/>
         <Setter Property="HorizontalAlignment" Value="Center"/>
-        <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
-        <Setter Property="RenderTransform">
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="IsTabStop" Value="False"/>
+        <Setter Property="Template">
             <Setter.Value>
-                <RotateTransform/>
+                <ControlTemplate TargetType="Control">
+                    <Grid>
+                        <Ellipse Stroke="{StaticResource SurfaceLightBrush}"
+                                 StrokeThickness="3"
+                                 Margin="1.5"/>
+                        <!-- StrokeDashArray is expressed in multiples of StrokeThickness.
+                             A 25px path circle at 3px stroke is ~26 units around, so
+                             6.5 on / 19.5 off draws a quarter-turn arc. -->
+                        <Ellipse x:Name="Arc"
+                                 Stroke="{StaticResource PrimaryLightBrush}"
+                                 StrokeThickness="3"
+                                 StrokeStartLineCap="Round"
+                                 StrokeEndLineCap="Round"
+                                 StrokeDashArray="6.5 19.5"
+                                 Margin="1.5"
+                                 RenderTransformOrigin="0.5,0.5">
+                            <Ellipse.RenderTransform>
+                                <RotateTransform/>
+                            </Ellipse.RenderTransform>
+                        </Ellipse>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsVisible" Value="True">
+                            <Trigger.EnterActions>
+                                <BeginStoryboard x:Name="SpinStoryboard">
+                                    <Storyboard RepeatBehavior="Forever">
+                                        <DoubleAnimation Storyboard.TargetName="Arc"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
+                                                         From="0" To="360" Duration="0:0:1.1"/>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <StopStoryboard BeginStoryboardName="SpinStoryboard"/>
+                            </Trigger.ExitActions>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Style.Triggers>
-            <EventTrigger RoutedEvent="Loaded">
-                <BeginStoryboard>
-                    <Storyboard RepeatBehavior="Forever">
-                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)"
-                                       From="0" To="360" Duration="0:0:2"/>
-                    </Storyboard>
-                </BeginStoryboard>
-            </EventTrigger>
-        </Style.Triggers>
     </Style>
 
     <!-- Dialog Overlay Background -->


### PR DESCRIPTION
Both waiting states — **"Waiting for a Server"** (server-initiated) and **"Searching for servers"** (client-initiated) — spun an emoji at 50% opacity: 🔍 and 📡, rotated 0→360° over two seconds. That reads as decoration rather than progress, and 50% opacity on `SurfaceBrush` is low contrast.

## What it is now

One shared `ProgressSpinner` style: an indeterminate ring — a quarter-turn arc in `PrimaryLightBrush` (`#5BE58A`, the brand green's light stop, the same colour as the "Broadcasting — visible to servers" status dot) sweeping a faint `SurfaceLightBrush` track. 28px, 3px stroke, rounded caps, full opacity, 1.1s per revolution.

Both sites use the same style, so the two states can't drift apart.

I picked `PrimaryLightBrush` over `PlayerAccentBrush` (`#4ADE80`) deliberately — the two greens are nearly identical, but `PlayerAccent` already means "active transport toggle" and overloading it would blur that.

## It also fixes a render-loop leak

The style being replaced started its `RepeatBehavior="Forever"` storyboard from an `EventTrigger` on `Loaded`:

```xml
<EventTrigger RoutedEvent="Loaded">
    <BeginStoryboard>
        <Storyboard RepeatBehavior="Forever">
```

`Loaded` fires once and never again, so the animation ran for the life of the process — including while the window was hidden to the tray, because WPF storyboard clocks don't stop for a hidden window. This is the same defect class as the `CompositionTarget.Rendering` loops removed in 2.2.4, expressed in XAML instead of code-behind.

It's reachable in a very ordinary way: these spinners appear **only while disconnected**, which is exactly the state someone leaves sitting in the tray when a server isn't reachable.

The new style triggers on `IsVisible` with `EnterActions`/`ExitActions` instead. `IsVisible` is false when the control is collapsed *or* any ancestor is hidden, so one trigger covers both the mode-gated card and the tray case, and the animation stops with the card rather than outliving it.

## Verification

- `dotnet build Sendspin.Windows.sln` — 0 errors. XAML resolves at build time, so a clean build confirms the template, both binding targets and every resource key.
- No dangling `SearchingIcon` references anywhere.
- Launched and captured the running window in `AdvertiseOnly`: the arc renders correctly on the "Waiting for a Server" card. The `DiscoverOnly` state uses the identical style.

Not verified: whether the storyboard actually stops on hide. That needs a GPU measurement in the tray while disconnected, the same way 2.2.4's render-loop fix was checked — worth doing before release, since it's the half of this change that isn't visual.