### PR TITLE
chore: bump Sendspin.SDK to 9.3.2 for the mDNS announce fix

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -95,8 +95,16 @@ starting the incoming one and aborts the switch if the stop failed.
 ### 1. Server-Initiated Mode — `AdvertiseOnly` (Primary, default)
 We advertise via mDNS and servers connect to us.
 - `SendspinHostService` runs a WebSocket server on a random port
-- Advertises as `_sendspin._tcp.local`
+- Advertises as `_sendspin._tcp.local`, with a `path` TXT record (REQUIRED by the spec) and a
+  `name` TXT record carrying the friendly player name
 - Music Assistant servers discover and connect to us
+- **Advertising must announce, not just answer.** SDK 9.3.2 sends unsolicited mDNS
+  announcements when the interface set changes — which `MulticastService` raises inside
+  `Start()`, and again when a NIC appears (Wi-Fi associating, resume from sleep). Before
+  9.3.2 the SDK only registered a passive query responder, so a server whose browser had
+  finished its startup queries never asked again and never found us: python-zeroconf drops
+  to refresh-only scheduling after four. If discovery ever regresses, check that an
+  announcement is actually leaving the machine before suspecting the record's contents.
 - Server admission (which server wins when several connect) is arbitrated inside the SDK's
   `SendspinHostService` — the app does no arbitration of its own, and must not reimplement or
   override it
@@ -104,7 +112,7 @@ We advertise via mDNS and servers connect to us.
   - **Spec:** admission is ranked by connection *activity* — `management` > `playback` >
     `pairing` — with a new connection held provisional until the server sends
     `server/activate`, and dropped after 30s if it never does.
-  - **SDK 9.3.1 (the version this branch builds against):** arbitration is still the earlier
+  - **SDK 9.3.2 (the version this branch builds against):** arbitration is still the earlier
     `connection_reason` comparison — `"playback"` beats `"discovery"` — with
     `LastPlayedServerId` breaking ordinary ties. Activity-based arbitration arrives with the
     v10 SDK; until then, do not write app code that assumes it.

--- a/src/Sendspin.Windows.Services/Sendspin.Windows.Services.csproj
+++ b/src/Sendspin.Windows.Services/Sendspin.Windows.Services.csproj
@@ -23,7 +23,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.3.1" />
+    <PackageReference Include="Sendspin.SDK" Version="9.3.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />

--- a/src/Sendspin.Windows/Sendspin.Windows.csproj
+++ b/src/Sendspin.Windows/Sendspin.Windows.csproj
@@ -63,7 +63,7 @@
     SDK's dev branch). Unset property => NuGet path, so normal builds are unaffected.
   -->
   <ItemGroup Condition="'$(UseSdkSource)' != 'true'">
-    <PackageReference Include="Sendspin.SDK" Version="9.3.1" />
+    <PackageReference Include="Sendspin.SDK" Version="9.3.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseSdkSource)' == 'true'">
     <ProjectReference Include="$(SdkSourcePath)\src\Sendspin.SDK\Sendspin.SDK.csproj" />


### PR DESCRIPTION
> **Stacked on #80.** Base is `chore/bump-sdk-9.3.1` so the diff shows only 9.3.1 → 9.3.2. GitHub will retarget this to `release/2.2.5` automatically once #80 merges. Merge #80 first.

Fixes the player not being discovered by servers.

## The bug

`MdnsServiceAdvertiser` called `ServiceDiscovery.Advertise()` and never `Announce()`. Makaretu's own documentation draws the distinction exactly:

> **`Advertise`** — "Any queries for the service or service instance **will be answered** with information from the profile."
>
> **`Announce`** — "Sends an **unsolicited** MDNS response describing the service profile… two unsolicited responses are sent one second apart."

So the client was purely passive: it answered a `_sendspin._tcp.local` PTR query correctly, but never announced itself. It also called `Advertise()` *before* `_mdns.Start()`, so nothing could have left the machine regardless.

That made discovery depend entirely on a server happening to browse at the right moment — and **python-zeroconf drops to refresh-only scheduling after four startup queries**, so a server already running when the player started never asked again and never found it. RFC 6762 §8.3 requires the unsolicited responses, and the spec's discovery section opens with *"Clients announce their presence via mDNS"*.

It also explains a symptom that otherwise looks random: a server started *after* the player finds it, while one started *before* doesn't.

## The fix

Upstream hangs `Announce()` off `MulticastService`'s interface-discovered event rather than just reordering the calls. One hook covers two cases: the event fires synchronously inside `Start()` once the send sockets exist — the earliest an announcement can actually leave the machine — and again when an interface appears later, such as Wi-Fi associating after boot or resuming from sleep, which needs a fresh announcement because the one sent at start never reached it.

`Announce` blocks for the RFC-mandated second between its two sends, so it is dispatched off-thread under a lock to avoid stalling `Start()` and to stop overlapping triggers interleaving packets.

## Impact on this repo: none beyond the version

The fix is entirely inside `MdnsServiceAdvertiser`, which this app doesn't touch, and its only new member is `internal`.

- `dotnet build Sendspin.Windows.sln -t:Rebuild` — **0 errors**, **570 warnings**, identical to 9.3.1.
- Tests: **184 passed, 2 failed** — the same two pre-existing audio failures.
- Confirmed the restore actually resolved 9.3.2 (`project.assets.json`), not a cached 9.3.1.

`claude.md` records what changed and why, so a future discovery regression starts by checking whether an announcement is leaving the machine rather than by suspecting the record's contents.

## Still to verify at runtime

The thing this fixes is precisely the thing automated tests can't reach: start Music Assistant **first**, then start the player in `AdvertiseOnly`, and confirm the player appears without restarting the server. That ordering is what failed before.